### PR TITLE
Fixed bug where certain characters weren't showing up in text input fields on ios + android.

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -310,6 +310,7 @@
 		<file name="src/common/CURL.cpp" unless="nocurl"/>
 		<file name="src/common/Lzma.cpp"/>
 		<file name="src/common/Thread.cpp"/>
+        <file name="src/common/KeyCodes.cpp"/>
 		<file name="src/common/Audio.cpp" if="openal"/>
 		<file name="src/common/video/TheoraVideo.cpp" if="theora" />
 		<file name="src/common/empty/Video.cpp" unless="theora" />

--- a/project/include/KeyCodes.h
+++ b/project/include/KeyCodes.h
@@ -4,6 +4,8 @@
 namespace lime
 {
 
+int TranslateASCIICodeToKeyCode(int asciiCode);
+
 enum KeyCode
 {
 

--- a/project/src/common/KeyCodes.cpp
+++ b/project/src/common/KeyCodes.cpp
@@ -1,0 +1,63 @@
+#include <KeyCodes.h>
+
+
+namespace lime
+{
+
+int TranslateASCIICodeToKeyCode(int asciiCode)
+{
+   // Map lowercase letters to uppercase equivalent
+   // ASCII codes for uppercase letters match their keycodes
+   if (asciiCode >= 97 && asciiCode <= 122)
+   {
+      asciiCode -= 32;
+   }
+   
+   switch (asciiCode)
+   {
+      /* 0-31 are control codes */
+      case 10:   return keyENTER;
+      case 13:   return keyENTER;
+      /* 32 is a space, maps to self */
+      case 33:   return keyNUMBER_1;
+      case 34:   return keyQUOTE;
+      case 35:   return keyNUMBER_3;
+      case 36:   return keyNUMBER_4;
+      case 37:   return keyNUMBER_5;
+      case 38:   return keyNUMBER_7;
+      case 39:   return keyQUOTE;
+      case 40:   return keyNUMBER_9;
+      case 41:   return keyNUMBER_0;
+      case 42:   return keyNUMBER_2;
+      case 43:   return keyEQUAL;
+      case 44:   return keyCOMMA;   
+      case 45:   return keyMINUS;   
+      case 46:   return keyPERIOD;
+      case 47:   return keySLASH;
+      /* 48-57 are digits, map to self */
+      case 58:   return keySEMICOLON;
+      case 59:   return keySEMICOLON;
+      case 60:   return keyCOMMA;
+      case 61:   return keyEQUAL;
+      case 62:   return keyPERIOD;
+      case 63:   return keySLASH;
+      case 64:   return keyNUMBER_2;
+      /* 65-90 are uppercase letters, map to self */      
+      case 91:   return keyLEFTBRACKET;
+      case 92:   return keyBACKSLASH;
+      case 93:   return keyRIGHTBRACKET;
+      case 94:   return keyNUMBER_6;
+      case 95:   return keyMINUS;
+      case 96:   return keyBACKQUOTE;
+      /* 97-122 are lowercase letters, handled above */
+      case 123:  return keyLEFTBRACKET;
+      case 124:  return keyBACKSLASH;
+      case 125:  return keyRIGHTBRACKET;
+      case 126:  return keyBACKQUOTE;
+      default:   return asciiCode;
+   }
+}
+
+}
+
+

--- a/project/src/platform/android/AndroidFrame.cpp
+++ b/project/src/platform/android/AndroidFrame.cpp
@@ -123,7 +123,7 @@ public:
       //__android_log_print(ANDROID_LOG_INFO, "lime", "OnKey %d %d", inCode, inDown);
       Event key( inDown ? etKeyDown : etKeyUp );
       key.code = inCode;
-      key.value = inCode;
+      key.value = TranslateASCIICodeToKeyCode(inCode);
       HandleEvent(key);
    }
 

--- a/project/src/platform/ios/UIStageView.mm
+++ b/project/src/platform/ios/UIStageView.mm
@@ -1028,15 +1028,16 @@ public:
       for(int i=0; i<[string length]; i++)
       {
          unichar c = [string characterAtIndex: i];
+         unichar v = TranslateASCIICodeToKeyCode(c);
 
          Event key_down(etKeyDown);
          key_down.code = c;
-         key_down.value = c;
+         key_down.value = v;
          mStage->OnEvent(key_down);
          
          Event key_up(etKeyUp);
          key_up.code = c;
-         key_up.value = c;
+         key_up.value = v;
          mStage->OnEvent(key_up);
       }
    }


### PR DESCRIPTION
Bug is due to mobile devices reporting only the ASCII character codes and not the keyboard scan codes like desktop + flash. Treating the ASCII codes as scan codes causes conflicts (eg. periods being treated as DELETE).

Added a translation function to convert ASCII codes on mobile to their keyboard scan code equivalents.

Note this change was developed and tested against openfl-native version 1.1.4. I wasn't able to test it against the latest Git repos as my projects kept crashing (on file reading and HTTP operations - complaining about missing class org/haxe/nme/GameActivity even though i couldn't find any references to it in my code or in lime code).
