### PR TITLE
Implemented pointAt. Used GLM as reference

### DIFF
--- a/lime/geometry/Matrix3D.hx
+++ b/lime/geometry/Matrix3D.hx
@@ -292,7 +292,7 @@ class Matrix3D
       return invertable;
    }
 
-   inline public function pointAt(pos : Vector3D, ?at : Vector3D, ?up : Vector3D) : Matrix3D {
+   inline public function pointAt(pos : Vector3D, at : Vector3D, up : Vector3D) : Matrix3D {
       var zaxis = at.subtract(pos);
       zaxis.normalize();
       var xaxis = zaxis.crossProduct(up);


### PR DESCRIPTION
Sure thing.

Use Case:
In 3D programming you generally need model, view, and projection matrices. pointAt() creates a view matrix which can be thought of as a camera. This matrix basically replaces gluLookAt from the old fixed-function versions of OpenGL.

I uploaded a modified version of the SimpleOpenGL sample to [pastebin](http://pastebin.com/Epyn1kuT) that uses the pointAt function to simulate a Camera moving around an object.
