### PR TITLE
Disabled mipmaps since they will not be used anyway

### DIFF
--- a/project/src/renderer/opengl/OpenGLTexture.cpp
+++ b/project/src/renderer/opengl/OpenGLTexture.cpp
@@ -184,6 +184,7 @@ namespace lime {
 		mSmooth = true;
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 		
 		// TODO: Need replacement call for GLES2?
 		#ifdef GPH


### PR DESCRIPTION
I ran a few OpenGL analysis tools on my game to try and chase down a nasty bug and it was very upset about the filtering of textures. I added this line on recommendation by @jgranick, and it seemed to make it happy again.
