### PR TITLE
Remove 512 size limit on CURL header

### DIFF
--- a/project/src/common/CURL.cpp
+++ b/project/src/common/CURL.cpp
@@ -146,7 +146,7 @@ public:
       {
         URLRequestHeader h = r.headers[i];
         std::vector<char> buffer;
-        buffer.resize(512);
+        buffer.resize(strlen(h.name) + strlen(h.value) + 3); // 1 for terminating char, 2 for ': '
         snprintf(&buffer[0], buffer.size(), "%s: %s", h.name, h.value);
         headerlist = curl_slist_append(headerlist, &buffer[0]);
       }


### PR DESCRIPTION
This updates the buffer for each header to be sized according to the header being added. 

This fixes an issue where we had a long authentication token header which was being chopped by the 512 limit.
