### PR TITLE
Add support for android immsersive mode

### DIFF
--- a/templates/android/template/src/org/haxe/lime/GameActivity.java
+++ b/templates/android/template/src/org/haxe/lime/GameActivity.java
@@ -100,7 +100,10 @@ public class GameActivity extends Activity implements SensorEventListener {
 		
 		requestWindowFeature (Window.FEATURE_NO_TITLE);
 		::if WIN_FULLSCREEN::
-		getWindow ().addFlags (WindowManager.LayoutParams.FLAG_FULLSCREEN | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+			::if (ANDROID_TARGET_SDK_VERSION < 19)::
+				getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN
+					| WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+			::end::
 		::end::
 		
 		metrics = new DisplayMetrics ();
@@ -161,45 +164,18 @@ public class GameActivity extends Activity implements SensorEventListener {
 		
 	}
 	
+	// IMMERSIVE MODE SUPPORT
 	::if (ANDROID_TARGET_SDK_VERSION >= 19)::
-	
-	private final int HIDE_DELAY = 100;
-	
-	@Override
-	protected void onPostCreate(Bundle savedInstanceState) {
-		super.onPostCreate(savedInstanceState);
-		
-		this.delayedHide(HIDE_DELAY);
-	}
 	
 	@Override
 	public void onWindowFocusChanged(boolean hasFocus) {
 		super.onWindowFocusChanged(hasFocus);
 		
-		// when the window lost focus cancel all pending hide actions
-		// when the window gains focus, hide the system ui.
 		if(hasFocus) {
-			this.delayedHide(HIDE_DELAY);
-		} else {
-			hideSystemUiHandler.removeMessages(0);
-		}
-	}
-	
-	// declare handler
-	protected Handler hideSystemUiHandler = new Handler() {
-		
-		@Override
-		public void handleMessage(Message message) {
 			hideSystemUi();
 		}
-	};
-	
-	// hide system ui after delay
-	private void delayedHide(int delayInMilliseconds) {
-		this.hideSystemUiHandler.removeMessages(0);
-		this.hideSystemUiHandler.sendEmptyMessageDelayed(0, delayInMilliseconds);
 	}
-	
+
 	private void hideSystemUi() {
 		View decorView = this.getWindow().getDecorView();
 		
@@ -209,18 +185,8 @@ public class GameActivity extends Activity implements SensorEventListener {
 			| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
 			| View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
 			| View.SYSTEM_UI_FLAG_FULLSCREEN
-			| View.SYSTEM_UI_FLAG_IMMERSIVE);
+			| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
 	}
-	
-	private void showSystemUi() {
-		View decorView = this.getWindow().getDecorView();
-		
-		decorView.setSystemUiVisibility(
-			View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-			| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-			| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-	}
-	
 	
 	::end::
 	


### PR DESCRIPTION
Google introduced the "immersive mode" in Android API 19 which hides the navigation and notification bar (and frees up some space).

[For more information about the immersive mode read this](https://developer.android.com/training/system-ui/immersive.html)

![immersive mode](https://developer.android.com/images/training/imm-states.png)

This change is currently only available when you add the following line to your lime-project file:

```
<android target-sdk-version="19" />
```

**Note:** That this change only affects devices using API level 19+, older Android versions will ~~obviously~~ should still work.

There is a related pull request in openfl-native: https://github.com/openfl/openfl-native/pull/175
