### PR TITLE
DrawTiles optimization

### DIFF
--- a/project/src/common/ExternalInterface.cpp
+++ b/project/src/common/ExternalInterface.cpp
@@ -2343,7 +2343,7 @@ value lime_gfx_draw_datum(value inGfx,value inDatum)
 }
 DEFINE_PRIM(lime_gfx_draw_datum,2);
 
-value lime_gfx_draw_tiles(value inGfx,value inSheet, value inXYIDs,value inFlags)
+value lime_gfx_draw_tiles(value inGfx,value inSheet, value inXYIDs,value inFlags,value inDataSize)
 {
    Graphics *gfx;
    Tilesheet *sheet;
@@ -2402,7 +2402,9 @@ value lime_gfx_draw_tiles(value inGfx,value inSheet, value inXYIDs,value inFlags
       if (flags & TILE_ALPHA)
          components++;
 
-      int n = val_array_size(inXYIDs)/components;
+      int n = val_int(inDataSize);
+      if (n < 0) n = val_array_size(inXYIDs);
+      n /= components;
       double *vals = val_array_double(inXYIDs);
       float *fvals = val_array_float(inXYIDs);
       int max = sheet->Tiles();
@@ -2523,7 +2525,7 @@ value lime_gfx_draw_tiles(value inGfx,value inSheet, value inXYIDs,value inFlags
    }
    return alloc_null();
 }
-DEFINE_PRIM(lime_gfx_draw_tiles,4);
+DEFINE_PRIM(lime_gfx_draw_tiles,5);
 
 
 static bool sNekoLutInit = false;


### PR DESCRIPTION
This is a memory/performance optimization for engines that call drawTiles to render each frame.

HaxePunk and HaxeFlixel keep an array of data to pass to drawTiles each frame. The arrays is recycled on the next frame, and if the size of data to be rendered is greater than the previous frame, the array will expand, or if it's smaller, shrink (HaxePunk uses splice() to remove the extra elements in the array, while HaxeFlixel uses "untyped array.length = n").

I've added a parameter to drawTiles, dataSize, which specifies the amount of the XYIDs array that actually contains information that should be rendered - so instead of shrinking the array, the entire array could be passed to drawTiles along with the last position which was written to this frame. This avoids the overhead of having to shrink the array - it can simply grow to the largest size that's needed, and continually overwrite that same block of allocated memory.

On the openfl-native end, the dataSize parameter will default to -1, which will imply that the entire array should be used, ensuring that this change won't break any existing code.

This is my first contribution to lime, so I'm not sure what the correct procedure is, but I have additional pull requests ready to update the API on openfl-native and openfl also if this one is merged.
