### PR TITLE
TextField::setTextColor: fix textColor not updating after setting it

### DIFF
--- a/project/src/common/TextField.cpp
+++ b/project/src/common/TextField.cpp
@@ -298,6 +298,7 @@ void TextField::setTextColor(int inCol)
    {
       defaultTextFormat = defaultTextFormat->COW();
       defaultTextFormat->color = inCol;
+      setText(getText());
    }
 }
 


### PR DESCRIPTION
This fixes https://github.com/openfl/openfl-native/issues/41

I realize that this is probably an inrecidbly hacky / inefficient fix, but it works... and I couldn't get the "obvious solution" (or at least what seemed obvious to me) to work, that is, setting one of the different dirty flags:

``` cpp
mLinesDirty = true;
mFontsDirty = true;
mGfxDirty = true;

dirtyCache();
```
