### PR TITLE
fixed commented parameternames

### DIFF
--- a/project/src/renderer/opengl/OGLExport.cpp
+++ b/project/src/renderer/opengl/OGLExport.cpp
@@ -314,17 +314,13 @@ GL_IS(program,Program)
 //GL_IS(renderbuffer,Renderbuffer)
 
 value lime_gl_is_framebuffer(value val) { 
-	#ifndef HX_LINUX
 	if (&glIsFramebuffer) return alloc_bool(glIsFramebuffer(val_int(val)));
-	#endif
 	return alloc_bool(false);
 }
 DEFINE_PRIM(lime_gl_is_framebuffer,1);
 
 value lime_gl_is_renderbuffer(value val) { 
-	#ifndef HX_LINUX
 	if (&glIsRenderbuffer) return alloc_bool(glIsRenderbuffer(val_int(val)));
-	#endif
 	return alloc_bool(false);
 }
 DEFINE_PRIM(lime_gl_is_renderbuffer,1);
@@ -406,9 +402,7 @@ DEFINE_PRIM(lime_gl_blend_equation,1);
 
 value lime_gl_blend_equation_separate(value rgb, value a)
 {
-   #ifndef HX_LINUX
    glBlendEquationSeparate(val_int(rgb), val_int(a));
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_blend_equation_separate,2);
@@ -424,9 +418,7 @@ DEFINE_PRIM(lime_gl_blend_func,2);
 
 value lime_gl_blend_func_separate(value srgb, value drgb, value sa, value da)
 {
-   #ifndef HX_LINUX   
    glBlendFuncSeparate(val_int(srgb), val_int(drgb), val_int(sa), val_int(da) );
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_blend_func_separate,4);
@@ -1257,18 +1249,14 @@ DEFINE_PRIM(lime_gl_get_buffer_parameter,2);
 
 value lime_gl_bind_framebuffer(value target, value framebuffer)
 {
-   #ifndef HX_LINUX
    if (&glBindFramebuffer) glBindFramebuffer(val_int(target), val_int(framebuffer) );
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_bind_framebuffer,2);
 
 value lime_gl_bind_renderbuffer(value target, value renderbuffer)
 {
-   #ifndef HX_LINUX
    if (&glBindRenderbuffer) glBindRenderbuffer(val_int(target),val_int(renderbuffer));
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_bind_renderbuffer,2);
@@ -1276,19 +1264,15 @@ DEFINE_PRIM(lime_gl_bind_renderbuffer,2);
 value lime_gl_create_framebuffer( )
 {
    GLuint id = 0;
-   #ifndef HX_LINUX
    if (&glGenFramebuffers) glGenFramebuffers(1,&id);
-   #endif
    return alloc_int(id);
 }
 DEFINE_PRIM(lime_gl_create_framebuffer,0);
 
 value lime_gl_delete_framebuffer(value target)
 {
-   #ifndef HX_LINUX
    GLuint id = val_int(target);
    if (&glDeleteFramebuffers) glDeleteFramebuffers(1, &id);
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_delete_framebuffer,1);
@@ -1296,55 +1280,43 @@ DEFINE_PRIM(lime_gl_delete_framebuffer,1);
 value lime_gl_create_render_buffer( )
 {
    GLuint id = 0;
-   #ifndef HX_LINUX
    if (&glGenRenderbuffers) glGenRenderbuffers(1,&id);
-   #endif
    return alloc_int(id);
 }
 DEFINE_PRIM(lime_gl_create_render_buffer,0);
 
 value lime_gl_delete_render_buffer(value target)
 {
-   #ifndef HX_LINUX
    GLuint id = val_int(target);
    if (&glDeleteRenderbuffers) glDeleteRenderbuffers(1, &id);
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_delete_render_buffer,1);
 
 value lime_gl_framebuffer_renderbuffer(value target, value attachment, value renderbuffertarget, value renderbuffer)
 {
-   #ifndef HX_LINUX
    if (&glFramebufferRenderbuffer) glFramebufferRenderbuffer(val_int(target), val_int(attachment), val_int(renderbuffertarget), val_int(renderbuffer) );
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_framebuffer_renderbuffer,4);
 
 value lime_gl_framebuffer_texture2D(value target, value attachment, value textarget, value texture, value level)
 {
-   #ifndef HX_LINUX
    if (&glFramebufferTexture2D) glFramebufferTexture2D( val_int(target), val_int(attachment), val_int(textarget), val_int(texture), val_int(level) );
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_framebuffer_texture2D,5);
 
 value lime_gl_renderbuffer_storage(value target, value internalFormat, value width, value height)
 {
-   #ifndef HX_LINUX
    if (&glRenderbufferStorage) glRenderbufferStorage( val_int(target), val_int(internalFormat), val_int(width), val_int(height) );
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_renderbuffer_storage,4);
 
 value lime_gl_check_framebuffer_status(value inTarget)
 {
-   #ifndef HX_LINUX
    if (&glCheckFramebufferStatus) return alloc_int( glCheckFramebufferStatus(val_int(inTarget)));
-   #endif
    return alloc_int(0);
 }
 DEFINE_PRIM(lime_gl_check_framebuffer_status,1);
@@ -1352,9 +1324,7 @@ DEFINE_PRIM(lime_gl_check_framebuffer_status,1);
 value lime_gl_get_framebuffer_attachment_parameter(value target, value attachment, value pname)
 {
    GLint result = 0;
-   #ifndef HX_LINUX
    if (&glGetFramebufferAttachmentParameteriv) glGetFramebufferAttachmentParameteriv( val_int(target), val_int(attachment), val_int(pname), &result);
-   #endif
    return alloc_int(result);
 }
 DEFINE_PRIM(lime_gl_get_framebuffer_attachment_parameter,3);
@@ -1362,9 +1332,7 @@ DEFINE_PRIM(lime_gl_get_framebuffer_attachment_parameter,3);
 value lime_gl_get_render_buffer_parameter(value target, value pname)
 {
    int result = 0;
-   #ifndef HX_LINUX
    if (&glGetRenderbufferParameteriv) glGetRenderbufferParameteriv(val_int(target), val_int(pname), &result);
-   #endif
    return alloc_int(result);
 }
 DEFINE_PRIM(lime_gl_get_render_buffer_parameter,2);
@@ -1723,9 +1691,7 @@ DEFINE_PRIM_MULT(lime_gl_copy_tex_sub_image_2d);
 
 value lime_gl_generate_mipmap(value inTarget)
 {
-   #ifndef HX_LINUX
    if (&glGenerateMipmap) glGenerateMipmap(val_int(inTarget));
-   #endif
    return alloc_null();
 }
 DEFINE_PRIM(lime_gl_generate_mipmap,1);


### PR DESCRIPTION
When working with FBOs I noticed that on iOS there is an issue concerning framebuffer ids where the default id is not 0(should be according to gl-spec). So I need GL_FRAMEBUFFER_BINDING to determine the default renderbuffer at startup. Not sure why these were left out so far.

A lot functions in the ogl-exports have a strange #ifndef HX_LINUX that obviously gets in the way when compiling for Linux. I removed them and my demos compiled out of the box.
