### PR TITLE
Multithread was not properly detached

### DIFF
--- a/project/src/platform/android/AndroidCommon.cpp
+++ b/project/src/platform/android/AndroidCommon.cpp
@@ -2,13 +2,20 @@
 #include <android/log.h>
 #include <string>
 #include <map>
-#include <stdint.h> 
+#include <stdint.h>
+#include <pthread.h>
 
 #undef LOGE
 #define LOGE(msg,args...) __android_log_print(ANDROID_LOG_ERROR, "lime::System", msg, ## args)
 
 JavaVM *_vm;
 std::map<std::string, jclass> jClassCache;
+static pthread_key_t s_thread_key;
+
+static void ThreadDataDestroy (void *env)
+{
+  _vm->DetachCurrentThread();
+}
 
 JNIEnv *GetEnv()
 {
@@ -19,6 +26,7 @@ JNIEnv *GetEnv()
         if (_vm->AttachCurrentThread(&env, 0) != 0) {
             LOGE("Failed to attach");
         }
+        pthread_setspecific (s_thread_key, &env);
     }
     return env;
 }
@@ -46,6 +54,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 {
     _vm = vm;
     jClassCache = std::map<std::string, jclass>();
+    pthread_key_create(&s_thread_key, ThreadDataDestroy);
     return  JNI_VERSION_1_4;                    // the required JNI version
     
 }


### PR DESCRIPTION
..causing crash in some cases returning 'native thread exited without detaching' error message.
