### PR TITLE
Compilation errors in JNI.hx

### DIFF
--- a/lime/utils/JNI.hx
+++ b/lime/utils/JNI.hx
@@ -1,7 +1,7 @@
 package lime.utils;
 #if (android)
 
-import lime.core.Libs;
+import lime.utils.Libs;
 
 import cpp.zip.Uncompress;
 import haxe.crypto.BaseCode;
@@ -19,7 +19,7 @@ class JNI {
         if (!initialized) {
             
             initialized = true;
-            var method = Lib.load ("lime", "lime_jni_init_callback", 1);
+            var method = Libs.load ("lime", "lime_jni_init_callback", 1);
             method (onCallback);
             
         }
@@ -70,7 +70,7 @@ class JNI {
     
     
     
-    private static var lime_jni_create_method = Lib.load ("lime", "lime_jni_create_method", 4);
+    private static var lime_jni_create_method = Libs.load ("lime", "lime_jni_create_method", 4);
     
     
 }


### PR DESCRIPTION
I tried to use the JNI.hx file in lime, and I got some compilation errors which were easily fixed.

lime.core.Libs is lime.utils.Libs and Lib.load is Libs.load.
