### PR TITLE
Incorrect parameter number on lime_bitmap_data_get_transparent

### DIFF
--- a/project/src/common/ExternalInterface.cpp
+++ b/project/src/common/ExternalInterface.cpp
@@ -3183,7 +3183,7 @@ value lime_bitmap_data_get_transparent(value inHandle,value inRGB)
       return alloc_bool( surface->GetAllowTrans() );
    return alloc_null();
 }
-DEFINE_PRIM(lime_bitmap_data_get_transparent,1);
+DEFINE_PRIM(lime_bitmap_data_get_transparent,2);
 
 value lime_bitmap_data_set_flags(value inHandle,value inFlags)
 {


### PR DESCRIPTION
Hello,

The incorrect parameter number was causing this error when trying to build lime-tools from source:
HaxeFoundation/haxe#2831

I have also fixed it on the openfl-native side https://github.com/openfl/openfl-native/pull/207

o/
