### PR TITLE
Corrected parameters on lime_bitmap_data_get_transparent

### DIFF
--- a/project/src/common/ExternalInterface.cpp
+++ b/project/src/common/ExternalInterface.cpp
@@ -3175,7 +3175,7 @@ value lime_bitmap_data_clear(value inHandle,value inRGB)
 }
 DEFINE_PRIM(lime_bitmap_data_clear,2);
 
-value lime_bitmap_data_get_transparent(value inHandle,value inRGB)
+value lime_bitmap_data_get_transparent(value inHandle)
 {
    Surface *surface;
    if (AbstractToObject(inHandle,surface))


### PR DESCRIPTION
Hello,

As noted on #124 , the problem was the parameters and not the number of parameters, so I have corrected that on this pull request, and closed the others.

The incorrect parameters was causing this error when trying to build lime-tools from source:
HaxeFoundation/haxe#2831

o/
