### PR TITLE
High-resolution window chrome on Mac apps

### DIFF
--- a/templates/mac/Info.plist
+++ b/templates/mac/Info.plist
@@ -26,5 +26,7 @@
 	<string>NO</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
 </dict>
 </plist>


### PR DESCRIPTION
This sets the correct Info.plist setting to allow for high-resolution window chrome.

See [High Resolution Guidelines for OS X](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html#//apple_ref/doc/uid/TP40012302-CH4-SW11) for more info.
