### PR TITLE
Make iOS Linker Flags an Array

### DIFF
--- a/templates/iphone/PROJ.xcodeproj/project.pbxproj
+++ b/templates/iphone/PROJ.xcodeproj/project.pbxproj
@@ -401,7 +401,7 @@
 					::foreach linkedLibraries:: "-l::__current__::",
 					::end::
 					"-lApplicationMain",
-					::foreach IOS_LINKER_FLAGS:: "-l::__current__::",
+					::foreach IOS_LINKER_FLAGS:: "::__current__::",
 					::end::
 				);
 			};
@@ -434,7 +434,7 @@
 					::foreach linkedLibraries:: "-l::__current__::",
 					::end::
 					"-lApplicationMain",
-					::foreach IOS_LINKER_FLAGS:: "-l::__current__::",
+					::foreach IOS_LINKER_FLAGS:: "::__current__::",
 					::end::
 				);
 			};


### PR DESCRIPTION
This pull request converts iOS linker flags to an array.  It is currently being used to support the changes in the PR to force_load all 3rd party iOS dependencies, openfl/lime-tools#81.
- Even though @jgranick and I talked about ios linker flags going away, I think we can benefit from using this array internally and can just remove the public facing aspects.
