### PR TITLE
html5 target now supports dependencies

### DIFF
--- a/templates/html5/template/index.html
+++ b/templates/html5/template/index.html
@@ -23,6 +23,11 @@
         <script type="text/javascript" src="./lib/soundmanager/soundmanager2-nodebug-jsmin.js"></script>        
         <script type="text/javascript" src="./lib/modernizr.js"></script>
 
+        ::if (JAVASCRIPT_LIBRARIES)::
+            ::foreach (JAVASCRIPT_LIBRARIES)::
+                <script type="text/javascript" src="./::PATH::"></script>   
+            ::end::
+        ::end::
     </head>
 
     <body style="padding: 0; margin: 0; background-color: #FFFFFF;">


### PR DESCRIPTION
Hello,

It is now possible to include a javascript files, through an haxelib.
The way to do it similar to how the dependencies work in Android and iOS. You basically specify a path to the js file in the dependency tag

For example:

SomeHTML5Haxelib/dependencies/JSLib/jslib.js

```
    <JS CODE>
```

SomeHTML5Haxelib/include.xml

```
    <extension>

         <dependency path="dependencies/jslib.js" if="html5" />

    </extension>
```

The resulting template execution on index.html will inject the contents of include.htm via the:

```
     ::if (JAVASCRIPT_LIBRARIES)::
          ::foreach (JAVASCRIPT_LIBRARIES)::
                  <script type="text/javascript" src="./::PATH::"></script>   
          ::end::
    ::end::
```

So the final index.html will successfully load the javascript file and it will be available for use in Haxe code through the usual "extern" or "untyped **js**".

Its a pretty simple feature, but helps a lot with bringing even more autonomy to haxelibs.

This pull request is connected to another one in lime-tools. https://github.com/openfl/lime-tools/pull/73

Thanks!
Rui.
