### PR TITLE
Fixing mouse wheel in html5 (lime:next)

### DIFF
--- a/lime/ui/MouseEventManager.hx
+++ b/lime/ui/MouseEventManager.hx
@@ -78,8 +78,9 @@ class MouseEventManager {
 			
 		} else {
 			
-			eventInfo.x = event.deltaX;
-			eventInfo.y = event.deltaY;
+			var wheelEvent = cast(event, js.html.WheelEvent);
+			eventInfo.x = wheelEvent.wheelDeltaX;
+			eventInfo.y = wheelEvent.wheelDeltaY;
 			
 		}
 		


### PR DESCRIPTION
event.deltaX/Y doesn't seem to exist in js.html.MouseEvent.
