### PR TITLE
Fixes for data classes in neko/flash (lime:next)

### DIFF
--- a/lime/utils/ArrayBufferView.hx
+++ b/lime/utils/ArrayBufferView.hx
@@ -34,7 +34,7 @@ class ArrayBufferView implements IMemoryRange {
 			buffer = new ArrayBuffer (#if !flash byteLength #end);
 			
 			#if flash
-			while (byteLength > 0) { buffer.writeByte (0); }
+			for (i in 0...byteLength) { buffer.writeByte (0); }
 			buffer.position = 0;
 			#end
 			
@@ -74,7 +74,9 @@ class ArrayBufferView implements IMemoryRange {
 			
 		}
 		
-		#if !flash
+		#if flash
+		buffer.endian = flash.utils.Endian.LITTLE_ENDIAN;
+		#else
 		buffer.bigEndian = false;
 		#end
 		

--- a/lime/utils/Int16Array.hx
+++ b/lime/utils/Int16Array.hx
@@ -7,7 +7,7 @@ typedef Int16Array = js.html.Int16Array;
 class Int16Array extends ArrayBufferView implements ArrayAccess<Int> {
 	
 	
-	public static inline var BYTES_PER_ELEMENT (default, null) = 2;
+	public static inline var BYTES_PER_ELEMENT = 2;
 	
 	public var length (default, null):Int;
 	


### PR DESCRIPTION
I fixed ArrayBufferView so it doesn't hang in Flash and is now little endian like the other targets. Int16Array would not compile for neko due to the additional (default, null) on a static variable.
