### PR TITLE
Preventing duplicate objects error in ByteArray.h (lime:next)

### DIFF
--- a/project/include/utils/ByteArray.h
+++ b/project/include/utils/ByteArray.h
@@ -67,28 +67,7 @@ namespace lime {
 	extern int gFixedOrientation;
 
 	#elif defined(HX_MACOS)
-	#include <CoreFoundation/CoreFoundation.h>
-	FILE *OpenRead(const char *inName)
-	{
-		FILE *result = fopen(inName,"rb");
-		if (!result) {
-			CFStringRef str = CFStringCreateWithCString(NULL, inName, kCFStringEncodingUTF8);
-			CFURLRef path = CFBundleCopyResourceURL(CFBundleGetMainBundle(), str, NULL, NULL);
-			CFRelease(str);
-			if (path) {
-				str = CFURLCopyPath(path);
-				CFIndex maxSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(str),kCFStringEncodingUTF8);
-				char *buffer = (char *)malloc(maxSize);
-				if (CFStringGetCString(str, buffer, maxSize, kCFStringEncodingUTF8)) {
-					result = fopen(buffer,"rb");
-					free(buffer);
-				}
-				CFRelease(str);
-				CFRelease(path);
-			}
-		}
-		return result;
-	}
+	FILE *OpenRead(const char *inName);
 	#define OpenOverwrite(x) fopen(x,"wb")
 	#else
 	#ifdef TIZEN

--- a/project/src/backend/sdl/SDLRenderer.cpp
+++ b/project/src/backend/sdl/SDLRenderer.cpp
@@ -1,6 +1,6 @@
 #include "SDLWindow.h"
 #include "SDLRenderer.h"
-#include "../../graphics/opengl/OpenGLBindings.h"
+#include "../../graphics/OpenGLBindings.h"
 
 
 namespace lime {

--- a/project/src/utils/ByteArray.cpp
+++ b/project/src/utils/ByteArray.cpp
@@ -113,22 +113,7 @@ namespace lime {
     } DEFINE_PRIM(lime_byte_array_get_native_pointer,1);
     
     
-    #ifdef HX_WINDOWS
-typedef wchar_t OSChar;
-#define val_os_string val_wstring
-#define OpenRead(x) _wfopen(x,L"rb")
-#define OpenOverwrite(x) _wfopen(x,L"wb") // [ddc]
-
-#else
-typedef char OSChar;
-#define val_os_string val_string
-
-#if defined(IPHONE)
-FILE *OpenRead(const char *inName);
-FILE *OpenOverwrite(const char *inName); // [ddc]
-extern int gFixedOrientation;
-
-#elif defined(HX_MACOS)
+#if defined(HX_MACOS)
 #include <CoreFoundation/CoreFoundation.h>
 FILE *OpenRead(const char *inName)
 {
@@ -151,14 +136,6 @@ FILE *OpenRead(const char *inName)
 	}
 	return result;
 }
-#define OpenOverwrite(x) fopen(x,"wb")
-#else
-#ifdef TIZEN
-extern int gFixedOrientation;
-#endif
-#define OpenRead(x) fopen(x,"rb")
-#define OpenOverwrite(x) fopen(x,"wb") // [ddc]
-#endif
 #endif
     
     


### PR DESCRIPTION
Compiling on OSX creates duplicate versions of OpenRead.
