### PR TITLE
Copy defined variables into userDefines.

### DIFF
--- a/tools/project/HXProject.hx
+++ b/tools/project/HXProject.hx
@@ -425,6 +425,8 @@ class HXProject {
 		
 		if (project != null) {
 			
+			StringMapHelper.copyKeys (project.defines, userDefines);
+			
 			processHaxelibs (project, userDefines);
 			
 		}


### PR DESCRIPTION
Required in order for included Haxe libraries (like OpenFL) to access defines (like "-Dnext"). This affects only HXP projects.
