### PR TITLE
Merge consecutive arguments that don't start with - 

### DIFF
--- a/tools/platforms/FlashPlatform.hx
+++ b/tools/platforms/FlashPlatform.hx
@@ -78,7 +78,7 @@ class FlashPlatform extends PlatformTarget {
 				
 			}
 			
-			var index = 2;
+			var index = 1;
 			
 			while (index < args.length) {
 				


### PR DESCRIPTION
Otherwise, if the app title or output file contained a space, the title/filename would be split into separate arguments.
