### PR TITLE
Make substitute replace ${VARS} with environment values.

### DIFF
--- a/tools/project/ProjectXMLParser.hx
+++ b/tools/project/ProjectXMLParser.hx
@@ -1668,7 +1668,17 @@ class ProjectXMLParser extends HXProject {
 			
 			if (substring == null) {
 				
-				substring = "";
+                                substring = varMatch.matched (1);
+					
+                        	if(environment != null && environment.exists(substring)){
+					
+                                        substring = environment.get(substring);
+					
+                                } else {
+					
+                                        substring = "";
+					
+                                }
 				
 			}
 			


### PR DESCRIPTION
Make substitute replace ${VARS} with environment values IF they have no value set in defines.
This allows the use of ${ANDROID_SDK} inside extensions XML files.
