### PR TITLE
Make the ProjectXMLParser to receive the configs on the constructor.

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1157,7 +1157,7 @@ class CommandLineTools {
 			
 			if (Path.extension (projectFile) == "lime" || Path.extension (projectFile) == "nmml" || Path.extension (projectFile) == "xml") {
 				
-				project = new ProjectXMLParser (Path.withoutDirectory (projectFile), userDefines, includePaths);
+				project = new ProjectXMLParser (Path.withoutDirectory (projectFile), userDefines, includePaths, config);
 				
 			} else if (Path.extension (projectFile) == "hxp") {
 				
@@ -1169,6 +1169,7 @@ class CommandLineTools {
 					project.debug = debug;
 					project.target = target;
 					project.targetFlags = targetFlags;
+					project.merge (config);
 					
 				} else {
 					
@@ -1187,8 +1188,6 @@ class CommandLineTools {
 			return null;
 			
 		}
-		
-		project.merge (config);
 		
 		project.haxedefs.set ("tools", version);
 		

--- a/tools/project/ProjectXMLParser.hx
+++ b/tools/project/ProjectXMLParser.hx
@@ -25,7 +25,7 @@ class ProjectXMLParser extends HXProject {
 	private static var varMatch = new EReg("\\${(.*?)}", "");
 	
 	
-	public function new (path:String = "", defines:Map <String, Dynamic> = null, includePaths:Array <String> = null, useExtensionPath:Bool = false) {
+	public function new (path:String = "", defines:Map <String, Dynamic> = null, includePaths:Array <String> = null, useExtensionPath:Bool = false, includeProject:HXProject = null) {
 		
 		super ();
 		
@@ -43,6 +43,12 @@ class ProjectXMLParser extends HXProject {
 			
 			this.includePaths = new Array <String> ();
 			
+		}
+
+		if (includeProject != null) {
+
+			merge(includeProject);
+
 		}
 		
 		initialize ();


### PR DESCRIPTION
This is made so that ProjectXMLParser can merge configs before parsing the XML and call the substitute function (otherwise, you need to set ANDROID_SDK on your console environment to be able to use ${ANDROID_SDK} on your project.xml).
