### PR TITLE
Removed double dispatch of mouse event for html5 target

### DIFF
--- a/lime/ui/TouchEventManager.hx
+++ b/lime/ui/TouchEventManager.hx
@@ -74,22 +74,6 @@ import flash.Lib;
 			
 		}
 		
-		switch (eventInfo.type) {
-			
-			case TOUCH_START:
-				
-				onTouchStart.dispatch (eventInfo.x, eventInfo.y, eventInfo.id);
-			
-			case TOUCH_END:
-				
-				onTouchEnd.dispatch (eventInfo.x, eventInfo.y, eventInfo.id);
-			
-			case TOUCH_MOVE:
-				
-				onTouchMove.dispatch (eventInfo.x, eventInfo.y, eventInfo.id);
-			
-		}
-		
 		#elseif flash
 		
 		//touchEvent.id = event.touchPointID;


### PR DESCRIPTION
The html5 branch was repeating the same switch that every target would execute at the end of the method, so touch events would dispatch mouse events twice when building html5 projects.
