### PR TITLE
[html5] Honour the requested width and height

### DIFF
--- a/lime/system/System.hx
+++ b/lime/system/System.hx
@@ -74,6 +74,8 @@ class System {
 		#if tools
 		ApplicationMain.config.background = color;
 		ApplicationMain.config.element = element;
+		ApplicationMain.config.width = width;
+		ApplicationMain.config.height = height;
 		ApplicationMain.create ();
 		#end
 		


### PR DESCRIPTION
The html5 target would always create an app as big as the browser window when the <window/> tag is not specified in the project file.
I'm trying to allow for some extra freedom by honouring the size requested while embedding the application.
