### PR TITLE
Fix font preloading for Safari on OsX

### DIFF
--- a/lime/app/Preloader.hx
+++ b/lime/app/Preloader.hx
@@ -142,7 +142,7 @@ class Preloader #if flash extends Sprite #end {
 		Browser.document.body.appendChild (node);
 		
 		var width = node.offsetWidth;
-		style.fontFamily = "'" + font + "'";
+		style.fontFamily = "'" + font + "', sans-serif";
 		
 		var interval:Null<Int> = null;
 		var found = false;


### PR DESCRIPTION
Safari on OsX reports some strange offsetWidth immediately after changing fontFamily, but before font actually loaded, and if you want to pre-cache font metrics on application start, you will get wrong values.

Specifying correct css font family stack seems to fix this issue.
