### PR TITLE
Fix HTML5 CopyPixels

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -252,6 +252,7 @@ class Image {
 			
 			case CANVAS:
 				
+				ImageCanvasUtil.convertToCanvas (this);
 				ImageCanvasUtil.copyPixels (this, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
 			
 			case DATA:


### PR DESCRIPTION
Using copyPixels were resulting in 

Uncaught TypeError: Cannot read property 'clearRect' of null ImageCanvasUtil.hx:102

Adding this line fix the problem
