### PR TITLE
Reference assets from the project directory

### DIFF
--- a/tools/project/ProjectXMLParser.hx
+++ b/tools/project/ProjectXMLParser.hx
@@ -399,6 +399,12 @@ class ProjectXMLParser extends HXProject {
 		var glyphs = null;
 		var type = null;
 		
+		if (element.has.useRoot && (substitute (element.att.useRoot) == "true")) {
+			
+			basePath = Sys.getCwd();
+			
+		}
+		
 		if (element.has.path) {
 			
 			path = PathHelper.combine (basePath, substitute (element.att.path));


### PR DESCRIPTION
When creating multiple projects I found myself using the same hierarchy for assets, this allow those projects to share this information in an external include.xml

```
<assets path="assets/data/images/backgrounds_compressed" useRoot="true" if="release" />
```