### PR TITLE
Fixed ByteArray.readUTFBytes() to not crash with an empty array.

### DIFF
--- a/lime/utils/ByteArray.hx
+++ b/lime/utils/ByteArray.hx
@@ -554,7 +554,12 @@ class ByteArray #if !js extends Bytes implements ArrayAccess<Int> implements IDa
 		position += len;
 		
 		#if neko
-		return new String (untyped __dollar__ssub (b, p, len));
+		if (b == null || len == 0) {
+			return new String("");
+		}
+		else {
+			return new String (untyped __dollar__ssub (b, p, len));
+		}
 		#elseif cpp
 		var result = "";
 		if (b != null && len > 0) {


### PR DESCRIPTION
Without this, readUTFBytes() and toString() crash when used on a newly created but empty ByteArray. This can happen, for instance, with a call to `Assert.isNull(<non-null ByteArray>);`.
