### PR TITLE
Issue #304: Prevent crash when creating a new BitmapData.

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -74,7 +74,7 @@ class Image {
 		
 		if (type == null) {
 			
-			if (Application.__instance != null && Application.__instance.windows != null && Application.__instance.window.currentRenderer != null) {
+			if (Application.__instance != null && Application.__instance.window != null && Application.__instance.window.currentRenderer != null) {
 				
 				this.type = switch (Application.__instance.window.currentRenderer.context) {
 					


### PR DESCRIPTION
Tiny typo caused creation of a BitmapData to always crash.
