### PR TITLE
Fixed BitmapData.getPixels() to not change the image to turn it blue.

### DIFF
--- a/legacy/project/src/common/Surface.cpp
+++ b/legacy/project/src/common/Surface.cpp
@@ -1145,15 +1145,6 @@ void SimpleSurface::getPixels(const Rect &inRect,uint32 *outPixels,bool inIgnore
             src+=4;
          }
          outPixels += r.w;
-
-         if (!(mPixelFormat & pfHasAlpha))
-         {
-            for(int x=0;x<r.w;x++)
-            {
-               *a = 255;
-               a+=4;
-            }
-         }
       }
    }
 }


### PR DESCRIPTION
This only happens when the BitmapData does not have an alpha component, such as from a loaded JPG.

As far as I can tell, this code should never have been here as it causes getPixels() to modify the BitmapData its getting the pixels from. It looks like either:

1. Someone was using it for testing to visually verify it was grabbing pixels from where they expected.
2. It was trying to get the alpha value in the returned pixels to 0xFF, but doing it wrong. And, that's not even necessary because without this, it already returns an alpha of 0xFF.

I also have a bunch of unit tests to go along with this change, but I can't submit those yet because they don't work on -next as that appears to use RGBA instead of ARGB like legacy does.