### PR TITLE
[legacy] Decomposing and recomposing of Matrix like AS3

### DIFF
--- a/legacy/project/include/Display.h
+++ b/legacy/project/include/Display.h
@@ -243,6 +243,10 @@ protected:
    double scaleX;
    double scaleY;
    double rotation;
+   double skew00;
+   double skew01;
+   double skew10;
+   double skew11;
 };
 
 

--- a/legacy/project/src/common/Display.cpp
+++ b/legacy/project/src/common/Display.cpp
@@ -382,8 +382,8 @@ void DisplayObject::UpdateDecomp()
       scaleX = sqrt(mLocalMatrix.m00 * mLocalMatrix.m00 + mLocalMatrix.m10 * mLocalMatrix.m10);
       scaleY = sqrt(mLocalMatrix.m01 * mLocalMatrix.m01 + mLocalMatrix.m11 * mLocalMatrix.m11);
       if ((mLocalMatrix.m00 * mLocalMatrix.m11 - mLocalMatrix.m10 * mLocalMatrix.m01) < 0.0)
-          scaleY = -scaleY;
-      double angle = atan2(mLocalMatrix.m10, mLocalMatrix.m00);
+          (mLocalMatrix.m10 == 0.0 && mLocalMatrix.m01 == 0.0 && mLocalMatrix.m11 == 1.0) ? scaleX = -scaleX : scaleY = -scaleY;
+      double angle = atan2(mLocalMatrix.m10, scaleX < 0.0 ? -mLocalMatrix.m00 : mLocalMatrix.m00);
       rotation = angle * 180.0 / M_PI;
       double s = sin(-angle);
       double c = cos(-angle);


### PR DESCRIPTION
I have a project https://github.com/dimanux/MatrixTest for testing matrix decomposition and recomposition on old lime version and this new version. Results:

Main.hx:61: Decompose test passed old(14%) new(100%)
Main.hx:62: Recompose test passed old(4%) new(100%)
Main.hx:63: Recompose test after 'scaleX = 1.0' passed old(4%) new(72%)
Main.hx:64: Recompose test after 'scaleY = 1.0' passed old(5%) new(94%)
Main.hx:65: Recompose test after 'rotation = 0.0' passed old(10%) new(94%)
Main.hx:66: Recompose test after 'x = 0.0' passed old(10%) new(94%)
Main.hx:67: Recompose test after 'y = 0.0' passed old(10%) new(94%)

So, I think that decomposing of Matrix is 100% AS3 accurate. But for recomposing there are some troubles then set scaleX or scaleY from 0.0 to any number - AS3 changes skew matrices somehow. It's for future investigations.