### PR TITLE
Support custom prefix (root) for resources URLs in html5.

### DIFF
--- a/lime/app/Config.hx
+++ b/lime/app/Config.hx
@@ -9,6 +9,7 @@ typedef Config = {
 	@:optional var depthBuffer:Bool;
 	#if (js && html5)
 	@:optional var element:js.html.HtmlElement;
+	@:optional var assetsPrefix:String;
 	#end
 	@:optional var fps:Int;
 	@:optional var fullscreen:Bool;

--- a/lime/system/System.hx
+++ b/lime/system/System.hx
@@ -29,7 +29,7 @@ class System {
 	
 	#if (js && html5)
 	@:keep @:expose("lime.embed")
-	public static function embed (element:Dynamic, width:Null<Int> = null, height:Null<Int> = null, background:String = null) {
+	public static function embed (element:Dynamic, width:Null<Int> = null, height:Null<Int> = null, background:String = null, assetsPrefix:String = null) {
 		
 		var htmlElement:HtmlElement = null;
 		
@@ -82,6 +82,7 @@ class System {
 		ApplicationMain.config.element = htmlElement;
 		ApplicationMain.config.width = width;
 		ApplicationMain.config.height = height;
+		ApplicationMain.config.assetsPrefix = assetsPrefix;
 		ApplicationMain.create ();
 		#end
 		

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -32,6 +32,8 @@ class ApplicationMain {
 		::else::types.push (null);::end::
 		::end::::end::
 		
+		urls = [for (url in urls) Assets.getPath(url)];
+		
 		preloader.load (urls, types);
 		#end
 		

--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -57,6 +57,13 @@ class DefaultAssetLibrary extends AssetLibrary {
 		type.set (id, AssetType.$$upper(::type::));
 		::end::::end::
 		
+		var assetsPrefix = ApplicationMain.config.assetsPrefix;
+		if (assetsPrefix != null) {
+			for (k in path.keys()) {
+				path.set(k, assetsPrefix + path[k]);
+			}
+		}
+		
 		#else
 		
 		#if openfl


### PR DESCRIPTION
Allow users to specify custom resources root in lime.embed.

This PR resumes the discussion at http://community.openfl.org/t/set-root-url-for-resources-on-html5-backend/580/3

I've added an extra `assetsPrefix` argument to `lime.embed`, which can be used to specify custom prefix for assets location (such as `/static/app/resources/` or `https://static.my.magic.domain/app-resources/`).

>A part of me considers doing it as another argument, but another part of me wonders if we'll have another things we want to do to customize it, and we keep (perpetually) adding arguments when (at some point) we should have done some kind of "options" object.

I decided to make it as an another argument, because it's less disruptive. Making some kind of "options" object is definitely great idea, but it's out of scope of this change. My opinion is that all these options should be properties of `lime.app.Config`, and `embed` should throw exception on unknown parameters to make it more strict.

Use case for this particular change is not multiple projects in the same page, but rather something like A/B testing for a single project, when a page can dynamically load different versions/builds/whatever of the same thing.

I'm somewhat unhappy with changes in `templates/haxe/ApplicationMain.hx`, because this part of assets preloading is basically duplicated in the same file in openfl repo, so I had to make this change in openfl repo as well (PR will follow shortly). On the other hand, I don't see a better way to do it without some refactoring, and I'm hesitant to do it cause I'm not the code owner...