### PR TITLE
[legacy] Set TextField's caret color to match textColor.

### DIFF
--- a/legacy/project/include/TextField.h
+++ b/legacy/project/include/TextField.h
@@ -44,7 +44,9 @@ public:
    void modifyLocalMatrix(Matrix &ioMatrix);
 
 
-   int   getCaretIndex() { return caretIndex; }
+   int   getCaretIndex() { return caretIndex; };
+   void  setCaretIndex(int newIndex);
+   
    int   getMaxScrollH() { Layout(); return maxScrollH; }
    int   getMaxScrollV() { Layout(); return maxScrollV; }
    int   getBottomScrollV();

--- a/legacy/project/src/ExternalInterface.cpp
+++ b/legacy/project/src/ExternalInterface.cpp
@@ -303,6 +303,7 @@ DEFINE_LIME_PROP(text_field,auto_size);
 DEFINE_LIME_PROP(text_field,scroll_h);
 DEFINE_LIME_PROP(text_field,scroll_v);
 DEFINE_LIME_PROP(text_field,max_chars);
+DEFINE_LIME_PROP(text_field,caret_index);
 DEFINE_LIME_PROP_READ(text_field,text_width);
 DEFINE_LIME_PROP_READ(text_field,text_height);
 DEFINE_LIME_PROP_READ(text_field,max_scroll_h);

--- a/legacy/project/src/common/ExternalInterface.cpp
+++ b/legacy/project/src/common/ExternalInterface.cpp
@@ -3499,6 +3499,7 @@ TEXT_PROP(max_chars,MaxChars,alloc_int,val_int);
 TEXT_PROP_GET_IDX(line_text,LineText,alloc_wstring);
 TEXT_PROP_GET_IDX(line_offset,LineOffset,alloc_int);
 
+TEXT_PROP(caret_index, CaretIndex, alloc_int, val_int);
 
 value nme_bitmap_data_create(value* arg, int nargs)
 {

--- a/legacy/project/src/common/TextField.cpp
+++ b/legacy/project/src/common/TextField.cpp
@@ -1512,7 +1512,7 @@ void TextField::Render( const RenderTarget &inTarget, const RenderState &inState
             double height = mLines[line].mMetrics.height;
             if (pos.y+height <= fieldHeight-GAP+1)
             {
-               mCaretGfx->lineStyle(1, 0x000000 ,1.0, false, ssmOpenGL  );
+               mCaretGfx->lineStyle(1, textColor ,1.0, false, ssmOpenGL  );
                mCaretGfx->moveTo(pos.x,pos.y);
                mCaretGfx->lineTo(pos.x,pos.y+height);
             }

--- a/legacy/project/src/common/TextField.cpp
+++ b/legacy/project/src/common/TextField.cpp
@@ -92,6 +92,11 @@ TextField::~TextField()
    mCharGroups.DeleteAll();
 }
 
+void TextField::setCaretIndex(int nextIndex)
+{
+   caretIndex = nextIndex;
+}
+
 double TextField::getWidth()
 {
    if (mLinesDirty)
@@ -1512,6 +1517,10 @@ void TextField::Render( const RenderTarget &inTarget, const RenderState &inState
             double height = mLines[line].mMetrics.height;
             if (pos.y+height <= fieldHeight-GAP+1)
             {
+				if(caretIndex == 0 && (mCharGroups.empty() || (mCharGroups.size() == 1 && mCharGroups[0]->Chars() == 0)) && getTextFormat()->align == tfaCenter)
+				{
+					pos.x = fieldWidth/2;
+				}
                mCaretGfx->lineStyle(1, textColor ,1.0, false, ssmOpenGL  );
                mCaretGfx->moveTo(pos.x,pos.y);
                mCaretGfx->lineTo(pos.x,pos.y+height);


### PR DESCRIPTION
Input text with a dark background and light text color should be more readable now.

The "text cursor" that appears when hovering over selectable text needs to reflect this next (the cursor currently becomes black).

This is in the Windows build.