### PR TITLE
Update extension template Build.xml

### DIFF
--- a/templates/extension/project/Build.xml
+++ b/templates/extension/project/Build.xml
@@ -20,7 +20,7 @@
 	<target id="NDLL" output="${LIBPREFIX}::extensionLowerCase::${MSVC_LIB_VERSION}${DEBUGEXTRA}${LIBEXTRA}" tool="linker" toolid="${STD_MODULE_LINK}">
 		
 		<outdir name="../ndll/${BINDIR}"/>
-		<ext value=".ndll" if="windows || mac || linux"/>
+		<ext value=".ndll" if="windows || mac || macos || linux"/>
 		<files id="common"/>
 		
 	</target>


### PR DESCRIPTION
Previous to this commit the extension template project does not puts the correct extension to generated file (.dylib instead of .ndll).
I left the previous "mac" in order not to break something that maybe was working with previous versions of Hxcpp (Im using Hxcpp git).