### PR TITLE
Security fix

### DIFF
--- a/lime/tools/helpers/FlashHelper.hx
+++ b/lime/tools/helpers/FlashHelper.hx
@@ -828,7 +828,7 @@ class FlashHelper {
 		
 		if (assets.length > 0) {
 			
-			project.haxeflags.push ("-swf-lib " + project.app.path + "/flash/obj/assets.swf");
+			project.haxeflags.push ("-swf-lib " + PathHelper.tryFullPath(project.app.path) + "/flash/obj/assets.swf");
 			project.haxedefs.set ("flash-use-stage", "");
 			
 			return true;


### PR DESCRIPTION
This fix is very important and avoid a very vicious situation we encountered...

We have an architecture where an openfl application is composed by multiples clients which are individual openfl projects themselves.

So each of these individual proejcts had their own bin directory, and now the bin/obj/assets.swf file !
That lead us to the main project compilation, templates were copied perffectly and the generation is good. BUT the wrong assets.swf file was used by haxe  !  As several classpath lead to the same file, things where mixed up and very hard to catch. (since not all the ressources where common).

Anyway, the idea is to clarify which assets.swf file must be linked to our final flash file!
For that, I'm proposing an easy but not elegant way here using  full path.

But you can also, for example, imagine to add the -cp bin/flash/obj  and do a -swf-lib assets.swf  so that there's no more confusion possible.

Thomas