### PR TITLE
Added fallback to filename when font name couldn't be parsed

### DIFF
--- a/lime/tools/helpers/FlashHelper.hx
+++ b/lime/tools/helpers/FlashHelper.hx
@@ -300,11 +300,12 @@ class FlashHelper {
 			// More code ripped off from "samhaxe"
 			
 			var src = path;
-			//var font_name = Path.withoutExtension (name);
-			
 			var face = Font.fromFile (src);
 			var font = face.decompose ();
 			var font_name = font.family_name;
+			//fallback for font name is case no one could be found..
+			if ( font_name == null || font_name.length == 0 )
+				font_name = Path.withoutExtension(name).split("/").pop().split("\\").pop();
 			
 			var glyphs = new Array <Font2GlyphData> ();
 			var glyph_layout = new Array <FontLayoutGlyphData> ();


### PR DESCRIPTION
Just added a simple fallback in case the font name could not be parsed properly (we have such font here, homemade).
Haven't been able to debug the lime code directly, so meanwhile I though that fallback could be helpful