### PR TITLE
[legacy] Add finger touch events to SDL2Stage

### DIFF
--- a/legacy/project/src/sdl2/SDL2Stage.cpp
+++ b/legacy/project/src/sdl2/SDL2Stage.cpp
@@ -268,7 +268,7 @@ public:
       }
       mPrimarySurface->IncRef();
      
-      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX) || defined(HX_WINDOWS)
       mMultiTouch = true;
       #else
       mMultiTouch = false;
@@ -535,7 +535,7 @@ public:
       }
       #endif
 
-      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX) || defined(HX_WINDOWS)
       if (inEvent.type == etMouseMove || inEvent.type == etMouseDown || inEvent.type == etMouseUp)
       {
          if (mSingleTouchID == NO_TOUCH || inEvent.value == mSingleTouchID || !mMultiTouch)
@@ -683,7 +683,7 @@ public:
    
    bool getMultitouchSupported()
    {
-      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX) || defined(HX_WINDOWS)
       return true;
       #else
       return false;
@@ -696,7 +696,7 @@ public:
    
    bool getMultitouchActive()
    {
-      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX) || defined(HX_WINDOWS)
       return mMultiTouch;
       #else
       return false;
@@ -1210,7 +1210,7 @@ void ProcessEvent(SDL_Event &inEvent)
 
             //int inValue=0, int inID=0, int inFlags=0, float inScaleX=1,float inScaleY=1, int inDeltaX=0,int inDeltaY=0
          Event mouse(etMouseMove, inEvent.motion.x, inEvent.motion.y, 0, 0, 0, 1.0f, 1.0f, deltaX, deltaY);
-         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
+         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX) || defined(HX_WINDOWS) 
          mouse.value = inEvent.motion.which;
          mouse.flags |= efLeftDown;
          #else
@@ -1222,7 +1222,7 @@ void ProcessEvent(SDL_Event &inEvent)
       case SDL_MOUSEBUTTONDOWN:
       {
          Event mouse(etMouseDown, inEvent.button.x, inEvent.button.y, inEvent.button.button - 1);
-         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
+         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX) || defined(HX_WINDOWS)
          mouse.value = inEvent.motion.which;
          mouse.flags |= efLeftDown;
          #else
@@ -1234,7 +1234,7 @@ void ProcessEvent(SDL_Event &inEvent)
       case SDL_MOUSEBUTTONUP:
       {
          Event mouse(etMouseUp, inEvent.button.x, inEvent.button.y, inEvent.button.button - 1);
-         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
+         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX) || defined(HX_WINDOWS)
          mouse.value = inEvent.motion.which;
          #else
          AddModStates(mouse.flags);

--- a/legacy/project/src/sdl2/SDL2Stage.cpp
+++ b/legacy/project/src/sdl2/SDL2Stage.cpp
@@ -268,7 +268,7 @@ public:
       }
       mPrimarySurface->IncRef();
      
-      #if defined(WEBOS) || defined(BLACKBERRY)
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
       mMultiTouch = true;
       #else
       mMultiTouch = false;
@@ -534,8 +534,8 @@ public:
          inEvent.type = etQuit;
       }
       #endif
-      
-      #if defined(WEBOS) || defined(BLACKBERRY)
+
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
       if (inEvent.type == etMouseMove || inEvent.type == etMouseDown || inEvent.type == etMouseUp)
       {
          if (mSingleTouchID == NO_TOUCH || inEvent.value == mSingleTouchID || !mMultiTouch)
@@ -682,8 +682,8 @@ public:
    
    
    bool getMultitouchSupported()
-   { 
-      #if defined(WEBOS) || defined(BLACKBERRY)
+   {
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
       return true;
       #else
       return false;
@@ -696,7 +696,7 @@ public:
    
    bool getMultitouchActive()
    {
-      #if defined(WEBOS) || defined(BLACKBERRY)
+      #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
       return mMultiTouch;
       #else
       return false;
@@ -1210,7 +1210,7 @@ void ProcessEvent(SDL_Event &inEvent)
 
             //int inValue=0, int inID=0, int inFlags=0, float inScaleX=1,float inScaleY=1, int inDeltaX=0,int inDeltaY=0
          Event mouse(etMouseMove, inEvent.motion.x, inEvent.motion.y, 0, 0, 0, 1.0f, 1.0f, deltaX, deltaY);
-         #if defined(WEBOS) || defined(BLACKBERRY)
+         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
          mouse.value = inEvent.motion.which;
          mouse.flags |= efLeftDown;
          #else
@@ -1222,7 +1222,7 @@ void ProcessEvent(SDL_Event &inEvent)
       case SDL_MOUSEBUTTONDOWN:
       {
          Event mouse(etMouseDown, inEvent.button.x, inEvent.button.y, inEvent.button.button - 1);
-         #if defined(WEBOS) || defined(BLACKBERRY)
+         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
          mouse.value = inEvent.motion.which;
          mouse.flags |= efLeftDown;
          #else
@@ -1234,7 +1234,7 @@ void ProcessEvent(SDL_Event &inEvent)
       case SDL_MOUSEBUTTONUP:
       {
          Event mouse(etMouseUp, inEvent.button.x, inEvent.button.y, inEvent.button.button - 1);
-         #if defined(WEBOS) || defined(BLACKBERRY)
+         #if defined(WEBOS) || defined(BLACKBERRY) || defined(HX_LINUX)
          mouse.value = inEvent.motion.which;
          #else
          AddModStates(mouse.flags);
@@ -1257,6 +1257,30 @@ void ProcessEvent(SDL_Event &inEvent)
          AddModStates(mouse.flags);
             //and done.
          sgSDLFrame->ProcessEvent(mouse);
+         break;
+      }
+      case SDL_FINGERMOTION:
+      {
+         SDL_TouchFingerEvent inFingerEvent = inEvent.tfinger;
+         Event finger(etTouchMove, inFingerEvent.x, inFingerEvent.y, 0, 0, 0, 1.0f, 1.0f, inFingerEvent.dx, inFingerEvent.dy);
+         finger.value = inFingerEvent.fingerId;
+         sgSDLFrame->ProcessEvent(finger);
+         break;
+      }
+      case SDL_FINGERDOWN:
+      {
+         SDL_TouchFingerEvent inFingerEvent = inEvent.tfinger;
+         Event finger(etTouchBegin, inFingerEvent.x, inFingerEvent.y);
+         finger.value = inFingerEvent.fingerId;
+         sgSDLFrame->ProcessEvent(finger);
+         break;
+      }
+      case SDL_FINGERUP:
+      {
+         SDL_TouchFingerEvent inFingerEvent = inEvent.tfinger;
+         Event finger(etTouchEnd, inFingerEvent.x, inFingerEvent.y);
+         finger.value = inFingerEvent.fingerId;
+         sgSDLFrame->ProcessEvent(finger);
          break;
       }
       case SDL_KEYDOWN:


### PR DESCRIPTION
Fix for https://github.com/openfl/lime/issues/360

Tested on a Dell XPS 13 with touchscreen on Linux with XInput2 driver.

Please note that this also requires changing SDL_Config in "project/lib/sdl" to enable XInput2, as follows:
```
diff --git a/include/configs/linux/SDL_config.h b/include/configs/linux/SDL_config.h
index 99b06c2..ba75343 100644
--- a/include/configs/linux/SDL_config.h
+++ b/include/configs/linux/SDL_config.h
@@ -274,14 +274,14 @@
 #define SDL_VIDEO_DRIVER_X11_DYNAMIC_XEXT "libXext.so.6"
 /* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XCURSOR */
 /* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XINERAMA */
-/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2 */
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2 "libXi.so.6"
 /* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XRANDR */
 /* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XSS */
 /* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XVIDMODE */
 /* #undef SDL_VIDEO_DRIVER_X11_XCURSOR */
 /* #undef SDL_VIDEO_DRIVER_X11_XINERAMA */
-/* #undef SDL_VIDEO_DRIVER_X11_XINPUT2 */
-/* #undef SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH */
+#define SDL_VIDEO_DRIVER_X11_XINPUT2 1
+#define SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH 1
 /* #undef SDL_VIDEO_DRIVER_X11_XRANDR */
 /* #undef SDL_VIDEO_DRIVER_X11_XSCRNSAVER */
 #define SDL_VIDEO_DRIVER_X11_XSHAPE 1
```

As I'm just beginning with lime/openfl I'm not sure whether this patch would have side effects on regular single pointer apps/games.

Also it would be cool if someone could try this on a Windows machine with touchscreen (might need to add more "defines" and also add `if defined(HX_WINDOWS)` in SDL2Scene). :smile: 