### PR TITLE
Fix ByteArray resizing for js target

### DIFF
--- a/lime/utils/ByteArray.hx
+++ b/lime/utils/ByteArray.hx
@@ -1131,7 +1131,7 @@ class ByteArray #if !js extends Bytes implements ArrayAccess<Int> implements IDa
 		#if js
 		if (allocated < value)
 			___resizeBuffer (allocated = Std.int (Math.max (value, allocated * 2)));
-		else if (allocated > value)
+		else if (allocated > value * 2)
 			___resizeBuffer (allocated = value);
 		length = value;
 		#end


### PR DESCRIPTION
Originally, I encountered this problem when I was playing with luxeengine - https://github.com/underscorediscovery/snow/pull/68

Since ByteArray in show was based on ByteArray from lime, I checked lime's version, and found the same bug.

I don't know exact lime roadmap (will lime still use it own implementation of ByteArray or will use typedarrays like snow), but maybe this pull-request will be useful.

---

Prehistory: let's have an empty ByteArray, and then do writeByte in a loop.

value | allocated | action
--- | --- | ---
- | 0 | initial
1 | 1 | up resize
2 | 2 | up resize
3 | 4 | up resize
4 | 4 | -
5 | 8 | up resize
6 | 6 | down resize
7 | 12 | up resize
8 | 8 | down resize
9 | 16 | up resize
10 | 10 | down resize
... | ... | ... etc ...
