### PR TITLE
isLocal always true with Sound [Flash]

### DIFF
--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -387,11 +387,11 @@ class DefaultAssetLibrary extends AssetLibrary {
 		
 		#if flash
 		
-		if (requestedType != AssetType.MUSIC && requestedType != AssetType.SOUND) {
+		//if (requestedType != AssetType.MUSIC && requestedType != AssetType.SOUND) {
 			
 			return className.exists (id);
 			
-		}
+		//}
 		
 		#end
 		


### PR DESCRIPTION
Fix isLocal function always true with test Sound on Flash.
When embed sound is set on false, isLocal can't by pass exist test.
In the original case, exist test is by passed with Flash compilation and true is return.