### PR TITLE
`cvs` removed from built-in exclude filter

### DIFF
--- a/lime/project/HXProject.hx
+++ b/lime/project/HXProject.hx
@@ -556,7 +556,7 @@ class HXProject {
 			
 		}
 		
-		exclude = exclude.concat ([ ".*", "cvs", "thumbs.db", "desktop.ini", "*.hash" ]);
+		exclude = exclude.concat ([ ".*", "thumbs.db", "desktop.ini", "*.hash" ]);
 			
 		if (path == "") {
 			

--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -483,7 +483,7 @@ class ProjectXMLParser extends HXProject {
 				
 			} else {
 				
-				var exclude = ".*|cvs|thumbs.db|desktop.ini|*.hash";
+				var exclude = ".*|thumbs.db|desktop.ini|*.hash";
 				var include = "";
 				
 				if (element.has.exclude) {


### PR DESCRIPTION
I have a lot of files with `cvs` sequence inside file name. For example `docvslayer.png`, abbreviation `dcvs_click.mp3`, `cvsync.atlas`, `cvs_log.json`, etc. Now these files is ignored and not copying into build folders, I maintain these specific situations by gradle task now, but this is just workaround solution.

So I propose to remove CVS exclude filter from build-in exclude list. I think it would be much better to set `cvs` exclude filter only by hands in xml project file.