### PR TITLE
Adding mouse functionality for locking/warping in native

### DIFF
--- a/lime/_backend/flash/FlashMouse.hx
+++ b/lime/_backend/flash/FlashMouse.hx
@@ -38,6 +38,10 @@ class FlashMouse {
 		
 	}
 	
+	public static function setRelative (value:Bool):Int{
+
+		return -1;
+	}
 	
 	
 	

--- a/lime/_backend/flash/FlashMouse.hx
+++ b/lime/_backend/flash/FlashMouse.hx
@@ -38,16 +38,27 @@ class FlashMouse {
 		
 	}
 	
-	public static function setRelative (value:Bool):Int{
-
-		return -1;
+	public static function warpGlobal (x:Int,y:Int):Void {
+		
 	}
 	
 	
 	
 	// Get & Set Methods
+
 	
+
+
+	public static function get_lock ():Bool {
+
+		return false;
+	}
+
 	
+	public static function set_lock (value:Bool):Bool {
+
+		return value;
+	}
 	
 	
 	public static function get_cursor ():MouseCursor {

--- a/lime/_backend/flash/FlashWindow.hx
+++ b/lime/_backend/flash/FlashWindow.hx
@@ -71,5 +71,12 @@ class FlashWindow {
 		
 	}
 	
+
+	public function warpMouse (x:Int, y:Int):Void {
+		
+		
+		
+	}
+	
 	
 }

--- a/lime/_backend/html5/HTML5Mouse.hx
+++ b/lime/_backend/html5/HTML5Mouse.hx
@@ -52,9 +52,27 @@ class HTML5Mouse {
 	}
 	
 	
+	public static function warpGlobal (x:Int,y:Int):Void {
+		
+	}
+	
 	
 	
 	// Get & Set Methods
+	
+	
+
+	
+	public static function get_lock ():Bool {
+
+		return false;
+	}
+
+	
+	public static function set_lock (value:Bool):Bool {
+
+		return value;
+	}
 	
 	
 	

--- a/lime/_backend/html5/HTML5Mouse.hx
+++ b/lime/_backend/html5/HTML5Mouse.hx
@@ -30,6 +30,11 @@ class HTML5Mouse {
 		}
 		
 	}
+
+	public static function setRelative (value:Bool):Int{
+
+		return -1;
+	}
 	
 	
 	public static function show ():Void {

--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -392,5 +392,11 @@ class HTML5Window {
 		
 	}
 	
+
+	public function warpMouse (x:Int, y:Int):Void {
+		
+		
+		
+	}
 	
 }

--- a/lime/_backend/native/NativeMouse.hx
+++ b/lime/_backend/native/NativeMouse.hx
@@ -81,7 +81,7 @@ class NativeMouse {
 					
 				}
 				
-				lime_mouse_set_cursor (value);
+				lime_mouse_set_cursor (type);
 				
 			}
 			

--- a/lime/_backend/native/NativeMouse.hx
+++ b/lime/_backend/native/NativeMouse.hx
@@ -38,6 +38,11 @@ class NativeMouse {
 	}
 	
 	
+	public static function setRelative (value:Bool):Int {
+		
+		return lime_mouse_set_relative (value);
+		
+	}
 	
 	
 	// Get & Set Methods
@@ -76,7 +81,7 @@ class NativeMouse {
 					
 				}
 				
-				lime_mouse_set_cursor (type);
+				lime_mouse_set_cursor (value);
 				
 			}
 			
@@ -96,6 +101,7 @@ class NativeMouse {
 	
 	
 	
+	private static var lime_mouse_set_relative = System.load ("lime", "lime_mouse_set_relative", 1);
 	private static var lime_mouse_hide = System.load ("lime", "lime_mouse_hide", 0);
 	private static var lime_mouse_set_cursor = System.load ("lime", "lime_mouse_set_cursor", 1);
 	private static var lime_mouse_show = System.load ("lime", "lime_mouse_show", 0);

--- a/lime/_backend/native/NativeMouse.hx
+++ b/lime/_backend/native/NativeMouse.hx
@@ -41,7 +41,7 @@ class NativeMouse {
 	
 	public static function warpGlobal (x:Int,y:Int):Void {
 		
-		return lime_mouse_warp_global (x,y);
+		lime_mouse_warp_global (x,y);
 		
 	}
 	

--- a/lime/_backend/native/NativeMouse.hx
+++ b/lime/_backend/native/NativeMouse.hx
@@ -38,6 +38,13 @@ class NativeMouse {
 	}
 	
 	
+	public static function warpGlobal (x:Int,y:Int):Void {
+		
+		return lime_mouse_warp_global (x,y);
+		
+	}
+	
+	
 	public static function setRelative (value:Bool):Int {
 		
 		return lime_mouse_set_relative (value);
@@ -101,6 +108,7 @@ class NativeMouse {
 	
 	
 	
+	private static var lime_mouse_warp_global = System.load ("lime", "lime_mouse_warp_global", 2);
 	private static var lime_mouse_set_relative = System.load ("lime", "lime_mouse_set_relative", 1);
 	private static var lime_mouse_hide = System.load ("lime", "lime_mouse_hide", 0);
 	private static var lime_mouse_set_cursor = System.load ("lime", "lime_mouse_set_cursor", 1);

--- a/lime/_backend/native/NativeMouse.hx
+++ b/lime/_backend/native/NativeMouse.hx
@@ -10,7 +10,8 @@ class NativeMouse {
 	
 	private static var __cursor:MouseCursor;
 	private static var __hidden:Bool;
-	
+	private static var __lock:Bool;
+
 	
 	public static function hide ():Void {
 		
@@ -45,16 +46,30 @@ class NativeMouse {
 	}
 	
 	
-	public static function setRelative (value:Bool):Int {
+	// Get & Set Methods
+	
+	
+	
+
+	public static function get_lock ():Bool {
 		
-		return lime_mouse_set_relative (value);
+		return __lock;
 		
 	}
 	
 	
-	// Get & Set Methods
-	
-	
+	public static function set_lock (value:Bool):Bool {
+		
+		if (__lock != value) {
+
+			lime_mouse_set_lock (value);
+			__lock = value;
+
+		}
+
+		return __lock;
+
+	}
 	
 	
 	public static function get_cursor ():MouseCursor {
@@ -109,7 +124,7 @@ class NativeMouse {
 	
 	
 	private static var lime_mouse_warp_global = System.load ("lime", "lime_mouse_warp_global", 2);
-	private static var lime_mouse_set_relative = System.load ("lime", "lime_mouse_set_relative", 1);
+	private static var lime_mouse_set_lock = System.load ("lime", "lime_mouse_set_lock", 1);
 	private static var lime_mouse_hide = System.load ("lime", "lime_mouse_hide", 0);
 	private static var lime_mouse_set_cursor = System.load ("lime", "lime_mouse_set_cursor", 1);
 	private static var lime_mouse_show = System.load ("lime", "lime_mouse_show", 0);

--- a/lime/_backend/native/NativeWindow.hx
+++ b/lime/_backend/native/NativeWindow.hx
@@ -142,6 +142,17 @@ class NativeWindow {
 	}
 	
 	
+	public function warpMouse (x:Int, y:Int):Void {
+		
+		if (handle != null) {
+			
+			lime_window_warp_mouse (handle, x, y);
+			
+		}
+		
+	}
+	
+	
 	private static var lime_window_close = System.load ("lime", "lime_window_close", 1);
 	private static var lime_window_create = System.load ("lime", "lime_window_create", 5);
 	private static var lime_window_move = System.load ("lime", "lime_window_move", 3);
@@ -149,6 +160,7 @@ class NativeWindow {
 	private static var lime_window_set_fullscreen = System.load ("lime", "lime_window_set_fullscreen", 2);
 	private static var lime_window_set_icon = System.load ("lime", "lime_window_set_icon", 2);
 	private static var lime_window_set_minimized = System.load ("lime", "lime_window_set_minimized", 2);
+	private static var lime_window_warp_mouse = System.load ("lime", "lime_window_warp_mouse", 3);
 	
 	
 }

--- a/lime/ui/Mouse.hx
+++ b/lime/ui/Mouse.hx
@@ -4,6 +4,7 @@ package lime.ui;
 class Mouse {
 	
 	
+	public static var lock (get, set):Bool;
 	public static var cursor (get, set):MouseCursor;
 	
 	
@@ -24,12 +25,6 @@ class Mouse {
 
 		MouseBackend.warpGlobal(x,y);
 	}
-	
-	public static function setRelative(value:Bool):Int {
-
-		return MouseBackend.setRelative(value);
-	}
-
 
 
 
@@ -37,6 +32,19 @@ class Mouse {
 	
 
 	
+
+	private static function get_lock ():Bool {
+		
+		return MouseBackend.get_lock ();
+		
+	}
+	
+	
+	private static function set_lock (value:Bool):Bool {
+		
+		return MouseBackend.set_lock (value);
+		
+	}
 
 	private static function get_cursor ():MouseCursor {
 		

--- a/lime/ui/Mouse.hx
+++ b/lime/ui/Mouse.hx
@@ -5,6 +5,8 @@ class Mouse {
 	
 	
 	public static var cursor (get, set):MouseCursor;
+
+	// public static var relative (default, set):Bool = false;
 	
 	
 	public static function hide ():Void {
@@ -20,13 +22,14 @@ class Mouse {
 		
 	}
 	
-	
-	
-	
+	public static function setRelative(value:Bool):Int {
+
+		return MouseBackend.setRelative(value);
+	}
+
 	// Get & Set Methods
 	
-	
-	
+
 	
 	private static function get_cursor ():MouseCursor {
 		

--- a/lime/ui/Mouse.hx
+++ b/lime/ui/Mouse.hx
@@ -20,6 +20,11 @@ class Mouse {
 		
 	}
 	
+	public static function warpGlobal(x:Int,y:Int):Void {
+
+		MouseBackend.warpGlobal(x,y);
+	}
+	
 	public static function setRelative(value:Bool):Int {
 
 		return MouseBackend.setRelative(value);
@@ -32,7 +37,7 @@ class Mouse {
 	
 
 	
-	
+
 	private static function get_cursor ():MouseCursor {
 		
 		return MouseBackend.get_cursor ();

--- a/lime/ui/Mouse.hx
+++ b/lime/ui/Mouse.hx
@@ -5,8 +5,6 @@ class Mouse {
 	
 	
 	public static var cursor (get, set):MouseCursor;
-
-	// public static var relative (default, set):Bool = false;
 	
 	
 	public static function hide ():Void {
@@ -27,9 +25,13 @@ class Mouse {
 		return MouseBackend.setRelative(value);
 	}
 
+
+
+
 	// Get & Set Methods
 	
 
+	
 	
 	private static function get_cursor ():MouseCursor {
 		

--- a/lime/ui/Window.hx
+++ b/lime/ui/Window.hx
@@ -129,6 +129,11 @@ class Window {
 		backend.setIcon (image);
 		
 	}
+
+	public function warpMouse(x:Int, y:Int){
+
+		backend.warpMouse(x,y);
+	}
 	
 	
 	

--- a/project/include/ui/Mouse.h
+++ b/project/include/ui/Mouse.h
@@ -14,6 +14,7 @@ namespace lime {
 			
 			static MouseCursor currentCursor;
 			
+			static void WarpGlobal (int x, int y);
 			static int SetRelative (bool value);
 			static void Hide ();
 			static void SetCursor (MouseCursor cursor);

--- a/project/include/ui/Mouse.h
+++ b/project/include/ui/Mouse.h
@@ -14,6 +14,7 @@ namespace lime {
 			
 			static MouseCursor currentCursor;
 			
+			static int SetRelative (bool value);
 			static void Hide ();
 			static void SetCursor (MouseCursor cursor);
 			static void Show ();

--- a/project/include/ui/Mouse.h
+++ b/project/include/ui/Mouse.h
@@ -15,7 +15,7 @@ namespace lime {
 			static MouseCursor currentCursor;
 			
 			static void WarpGlobal (int x, int y);
-			static int SetRelative (bool value);
+			static void SetLock (bool value);
 			static void Hide ();
 			static void SetCursor (MouseCursor cursor);
 			static void Show ();

--- a/project/include/ui/Window.h
+++ b/project/include/ui/Window.h
@@ -24,6 +24,7 @@ namespace lime {
 			virtual bool SetFullscreen (bool fullscreen) = 0;
 			virtual void SetIcon (ImageBuffer *imageBuffer) = 0;
 			virtual bool SetMinimized (bool minimized) = 0;
+			virtual void WarpMouse (int x, int y) = 0;
 			
 			Application* currentApplication;
 			int flags;

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -524,9 +524,9 @@ namespace lime {
 	}
 	
 	
-	value lime_mouse_set_relative (value input_value) {
+	value lime_mouse_set_lock (value input_value) {
 		
-		Mouse::SetRelative (input_value);
+		Mouse::SetLock (input_value);
 		return alloc_null ();
 		
 	}
@@ -811,7 +811,7 @@ namespace lime {
 	DEFINE_PRIM (lime_lzma_encode, 1);
 	DEFINE_PRIM (lime_lzma_decode, 1);
 	DEFINE_PRIM (lime_mouse_warp_global, 2);
-	DEFINE_PRIM (lime_mouse_set_relative, 1);
+	DEFINE_PRIM (lime_mouse_set_lock, 1);
 	DEFINE_PRIM (lime_mouse_hide, 0);
 	DEFINE_PRIM (lime_mouse_set_cursor, 1);
 	DEFINE_PRIM (lime_mouse_show, 0);

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -516,6 +516,14 @@ namespace lime {
 	}
 	
 	
+	value lime_mouse_set_relative (value input_value) {
+		
+		Mouse::SetRelative (input_value);
+		return alloc_null ();
+		
+	}
+	
+	
 	value lime_mouse_set_cursor (value cursor) {
 		
 		Mouse::SetCursor ((MouseCursor)val_int (cursor));
@@ -785,6 +793,7 @@ namespace lime {
 	DEFINE_PRIM (lime_key_event_manager_register, 2);
 	DEFINE_PRIM (lime_lzma_encode, 1);
 	DEFINE_PRIM (lime_lzma_decode, 1);
+	DEFINE_PRIM (lime_mouse_set_relative, 1);
 	DEFINE_PRIM (lime_mouse_hide, 0);
 	DEFINE_PRIM (lime_mouse_set_cursor, 1);
 	DEFINE_PRIM (lime_mouse_show, 0);

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -516,6 +516,14 @@ namespace lime {
 	}
 	
 	
+	value lime_mouse_warp_global (value x, value y) {
+		
+		Mouse::WarpGlobal (val_int(x),val_int(y));
+		return alloc_null ();
+		
+	}
+	
+	
 	value lime_mouse_set_relative (value input_value) {
 		
 		Mouse::SetRelative (input_value);
@@ -761,6 +769,15 @@ namespace lime {
 	}
 	
 	
+	value lime_window_warp_mouse (value window, value x, value y) {
+		
+		Window* targetWindow = (Window*)(intptr_t)val_float (window);
+		targetWindow->WarpMouse (val_int (x), val_int (y));
+		return alloc_null ();
+		
+	}
+	
+	
 	DEFINE_PRIM (lime_application_create, 1);
 	DEFINE_PRIM (lime_application_exec, 1);
 	DEFINE_PRIM (lime_application_init, 1);
@@ -793,6 +810,7 @@ namespace lime {
 	DEFINE_PRIM (lime_key_event_manager_register, 2);
 	DEFINE_PRIM (lime_lzma_encode, 1);
 	DEFINE_PRIM (lime_lzma_decode, 1);
+	DEFINE_PRIM (lime_mouse_warp_global, 2);
 	DEFINE_PRIM (lime_mouse_set_relative, 1);
 	DEFINE_PRIM (lime_mouse_hide, 0);
 	DEFINE_PRIM (lime_mouse_set_cursor, 1);
@@ -819,6 +837,7 @@ namespace lime {
 	DEFINE_PRIM (lime_window_set_fullscreen, 2);
 	DEFINE_PRIM (lime_window_set_icon, 2);
 	DEFINE_PRIM (lime_window_set_minimized, 2);
+	DEFINE_PRIM (lime_window_warp_mouse, 3);
 	
 	
 }

--- a/project/src/backend/sdl/SDLMouse.cpp
+++ b/project/src/backend/sdl/SDLMouse.cpp
@@ -18,6 +18,11 @@ namespace lime {
 	SDL_Cursor* SDLMouse::waitCursor = 0;
 	SDL_Cursor* SDLMouse::waitArrowCursor = 0;
 
+	void Mouse::WarpGlobal(int x, int y){
+
+		SDL_WarpMouseGlobal(x,y);
+	}
+
 
 	int Mouse::SetRelative (bool value) {
 		if(value)

--- a/project/src/backend/sdl/SDLMouse.cpp
+++ b/project/src/backend/sdl/SDLMouse.cpp
@@ -24,14 +24,15 @@ namespace lime {
 	}
 
 
-	int Mouse::SetRelative (bool value) {
+	void Mouse::SetLock (bool value) {
+
 		if(value)
 		{
-			return SDL_SetRelativeMouseMode(SDL_TRUE);
+			SDL_SetRelativeMouseMode(SDL_TRUE);
 		}
 		else
 		{
-			return SDL_SetRelativeMouseMode(SDL_FALSE);
+			SDL_SetRelativeMouseMode(SDL_FALSE);
 		}
 	}
 	

--- a/project/src/backend/sdl/SDLMouse.cpp
+++ b/project/src/backend/sdl/SDLMouse.cpp
@@ -17,6 +17,18 @@ namespace lime {
 	SDL_Cursor* SDLMouse::textCursor = 0;
 	SDL_Cursor* SDLMouse::waitCursor = 0;
 	SDL_Cursor* SDLMouse::waitArrowCursor = 0;
+
+
+	int Mouse::SetRelative (bool value) {
+		if(value)
+		{
+			return SDL_SetRelativeMouseMode(SDL_TRUE);
+		}
+		else
+		{
+			return SDL_SetRelativeMouseMode(SDL_FALSE);
+		}
+	}
 	
 	
 	void Mouse::Hide () {

--- a/project/src/backend/sdl/SDLWindow.cpp
+++ b/project/src/backend/sdl/SDLWindow.cpp
@@ -146,6 +146,13 @@ namespace lime {
 	}
 	
 	
+	void SDLWindow::WarpMouse (int x, int y) {
+		
+		SDL_WarpMouseInWindow (sdlWindow,x,y);
+		
+	}
+	
+	
 	Window* CreateWindow (Application* application, int width, int height, int flags, const char* title) {
 		
 		return new SDLWindow (application, width, height, flags, title);

--- a/project/src/backend/sdl/SDLWindow.h
+++ b/project/src/backend/sdl/SDLWindow.h
@@ -23,6 +23,7 @@ namespace lime {
 			virtual bool SetFullscreen (bool fullscreen);
 			virtual void SetIcon (ImageBuffer *imageBuffer);
 			virtual bool SetMinimized (bool minimized);
+			virtual void WarpMouse (int x, int y);
 			
 			SDL_Window* sdlWindow;
 		


### PR DESCRIPTION
This pull request contains 3 things:
 - `lime.Mouse.lock`, a boolean that hides the cursor and prevents it from leaving the window. AFAIK there isn't a way to keep the cursor from being hidden using `SDL_SetRelativeMouseMode`
- `lime.Mouse.globalWarp`, a function that warps the cursor anywhere in screen space
- `window.warpMouse`, a function that warps the cursor anywhere in window space

Not having relative mouse motion events is mitigated by having window.warpMouse, as users can log the position of the mouse after it moves and then warp it back to the center. It is worth noting, however, that both of the warp functions will fire a `mouseMove` event.