### PR TITLE
Improve legacy default alpha blending

### DIFF
--- a/legacy/project/src/opengl/OpenGLContext.cpp
+++ b/legacy/project/src/opengl/OpenGLContext.cpp
@@ -496,7 +496,12 @@ public:
                glBlendEquation( GL_FUNC_REVERSE_SUBTRACT);
                break;
             default:
-               glBlendFunc(premAlpha ? GL_ONE : GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
+               if (premAlpha){
+                  glBlendFunc(GL_ONE,GL_ONE_MINUS_SRC_ALPHA);
+               }
+               else {
+                  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+               }
                glBlendEquation( GL_FUNC_ADD);
          }
 


### PR DESCRIPTION
Change lime legacy default alpha blending blendFunc to correctly blend alpha for RGBA textures in non-premultiplied alpha mode