### PR TITLE
Image.hx: fix buffer overflow vulnerability in copyPixels() by setting a...

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -251,6 +251,9 @@ class Image {
 		if (sourceRect.y + sourceRect.height > sourceImage.height) sourceRect.height = sourceImage.height - sourceRect.y;
 		if (sourceRect.width <= 0 || sourceRect.height <= 0) return;
 		
+		if (destPoint.x + sourceRect.width > width) sourceRect.width = width - destPoint.x;
+		if (destPoint.y + sourceRect.height > height) sourceRect.height = height - destPoint.y;
+		
 		switch (type) {
 			
 			case CANVAS:


### PR DESCRIPTION
...n explicit width/height bounds check on destPoint+sourceRect in addition to sourceRect itself

(This is a big fix! Horrible crashes without it!)