### PR TITLE
BitmapData: added getColorBoundsRect implementation for next

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -460,6 +460,31 @@ class Image {
 		
 	}
 	
+	public function getColorBoundsRect(mask:Int, color:Int, findColor:Bool = true, format:PixelFormat = null):Rectangle {
+		
+		if (buffer == null) return null;
+		
+		//TODO: add all the other cases
+		
+		switch (type) {
+			
+			case CANVAS:
+				
+				return null;
+			
+			case DATA:
+				
+				return ImageDataUtil.getColorBoundsRect(this, mask, color, findColor, format);
+				
+			case FLASH:
+				
+				return buffer.__srcBitmapData.getColorBoundsRect(mask, color, findColor);
+				
+			default:
+				
+				return null;
+		}
+	}
 	
 	public function getPixel (x:Int, y:Int, format:PixelFormat = null):Int {
 		

--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -423,6 +423,136 @@ class ImageDataUtil {
 		
 	}
 	
+	public static function getColorBoundsRect(image:Image, mask:Int, color:Int, findColor:Bool = true, format:PixelFormat):Rectangle {
+		
+		var left:Int = image.width+1;
+		var right:Int = 0;
+		var top:Int = image.height+1;
+		var bottom:Int = 0;
+		
+		var r, g, b, a;
+		var mr, mg, mb, ma;
+		
+		if (format == ARGB) {
+			
+			a = (image.transparent) ? (color >> 24) & 0xFF : 0xFF;
+			r = (color >> 16) & 0xFF;
+			g = (color >> 8) & 0xFF;
+			b = color & 0xFF;
+			
+			ma = (image.transparent) ? (mask >> 24) & 0xFF : 0xFF;
+			mr = (mask >> 16) & 0xFF;
+			mg = (mask >> 8) & 0xFF;
+			mb = mask & 0xFF;
+			
+		} else {
+			
+			r = (color >> 24) & 0xFF;
+			g = (color >> 16) & 0xFF;
+			b = (color >> 8) & 0xFF;
+			a = (image.transparent) ? color & 0xFF : 0xFF;
+			
+			mr = (mask >> 24) & 0xFF;
+			mg = (mask >> 16) & 0xFF;
+			mb = (mask >> 8) & 0xFF;
+			ma = (image.transparent) ? mask & 0xFF : 0xFF;
+			
+		}
+		
+		color = (r | (g << 8) | (b << 16) | (a << 24));
+		mask = (mr | (mg << 8) | (mb << 16) | (mask << 24));
+		
+		var pix:Int;
+		
+		//Sweep from the left
+		for (ix in 0...image.width) {
+			
+			var hit:Bool = false;
+			for (iy in 0...image.height) {
+				
+				pix = image.getPixel32(ix, iy);
+				hit = findColor ? (pix & mask) == color : (pix & mask) != color;
+				if (hit) {
+					if (ix < left) left = ix;
+					break;
+				}
+			}
+			if (hit) {
+				break;
+			}
+		}
+		
+		//Sweep from the right
+		for (_ix in 0...image.width) {
+			
+			var ix = (image.width - 1) - _ix;
+			var hit:Bool = false;
+			for (iy in 0...image.height) {
+				
+				pix = image.getPixel32(ix, iy);
+				hit = findColor ? (pix & mask) == color : (pix & mask) != color;
+				if (hit) {
+					if (ix > right) right = ix;
+					break;
+				}
+			}
+			if (hit) {
+				break;
+			}
+		}
+		
+		//Sweep from the top
+		for (iy in 0...image.height) {
+			
+			var hit:Bool = false;
+			for (ix in 0...image.width) {
+				pix = image.getPixel32(ix, iy);
+				hit = findColor ? (pix & mask) == color : (pix & mask) != color;
+				if (hit) {
+					if (iy < top) top = iy;
+					break;
+				}
+			}
+			if (hit) {
+				break;
+			}
+		}
+		
+		//Sweep from the bottom
+		for (_iy in 0...image.height) {
+			
+			var iy = (image.height - 1) - _iy;
+			var hit:Bool = false;
+			for (ix in 0...image.width) {
+				pix = image.getPixel32(ix, iy);
+				hit = findColor ? (pix & mask) == color : (pix & mask) != color;
+				if (hit) {
+					if (iy > bottom) bottom = iy;
+					break;
+				}
+			}
+			if (hit) {
+				break;
+			}
+		}
+		
+		var w = right - left;
+		var h = bottom - top;
+		
+		if (w > 0) w++;
+		if (h > 0) h++;
+		
+		if (w < 0) w = 0;
+		if (h < 0) h = 0;
+		
+		if (left == right) w = 1;
+		if (top == bottom) h = 1;
+		
+		if (left > image.width) left = 0;
+		if (top > image.height) top = 0;
+		
+		return new Rectangle(left, top, w, h);
+	}
 	
 	public static function getPixel (image:Image, x:Int, y:Int, format:PixelFormat):Int {
 		


### PR DESCRIPTION
I've tested this on a wide range of bitmap images (including randomly generated ones) and it is confirmed accurate. I tried a few more "optimized" versions than this but the gains were marginal, the code was much more complex, and failed on edge cases. Best to keep it simple -- if this needs to be sped up, it could be dropped into C++ via CFFI.