### PR TITLE
Improve Font API

### DIFF
--- a/lime/text/Font.hx
+++ b/lime/text/Font.hx
@@ -142,25 +142,16 @@ class Font {
 		
 		var bytes = new ByteArray ();
 		bytes.endian = "littleEndian";
+		var data:ByteArray = lime_font_render_glyph (src, glyph, bytes);
 		
-		if (lime_font_render_glyph (src, glyph, bytes)) {
+		if (data != null) {
 			
-			bytes.position = 0;
-			
-			var index = bytes.readUnsignedInt ();
 			var width = bytes.readUnsignedInt ();
 			var height = bytes.readUnsignedInt ();
-			var x = bytes.readUnsignedInt ();
-			var y = bytes.readUnsignedInt ();
+			var x = bytes.readInt ();
+			var y = bytes.readInt ();
 			
-			var data = new ByteArray (width * height);
-			bytes.readBytes (data, 0, width * height);
-			
-			#if js
-			var buffer = new ImageBuffer (data.byteView, width, height, 1);
-			#else
-			var buffer = new ImageBuffer (new UInt8Array (data), width, height, 1);
-			#end
+			var buffer = new ImageBuffer (getUInt8ArrayFromByteArray (data), width, height, 1);
 			var image = new Image (buffer, 0, 0, width, height);
 			image.x = x;
 			image.y = y;
@@ -176,161 +167,42 @@ class Font {
 	}
 	
 	
-	public function renderGlyphs (glyphs:Array<Glyph>, fontSize:Int):Map<Glyph, Image> {
+	public function renderGlyphs (glyphList:Array<Glyph>, fontSize:Int):Array<Image> {
 		
 		#if (cpp || neko || nodejs)
-		
-		var uniqueGlyphs = new Map<Int, Bool> ();
-		
-		for (glyph in glyphs) {
-			
-			uniqueGlyphs.set (glyph, true);
-			
-		}
-		
-		var glyphList = [];
-		
-		for (key in uniqueGlyphs.keys ()) {
-			
-			glyphList.push (key);
-			
-		}
 		
 		lime_font_set_size (src, fontSize);
 		
 		var bytes = new ByteArray ();
 		bytes.endian = "littleEndian";
 		
-		if (lime_font_render_glyphs (src, glyphList, bytes)) {
+		var rawImages:Array<ByteArray> = lime_font_render_glyphs (src, glyphList, bytes);
+		
+		if (rawImages != null) {
 			
-			bytes.position = 0;
-			
-			var count = bytes.readUnsignedInt ();
-			
-			var bufferWidth = 128;
-			var bufferHeight = 128;
-			var offsetX = 0;
-			var offsetY = 0;
-			var maxRows = 0;
-			
-			var width, height;
-			var i = 0;
-			
-			while (i < count) {
+			var results:Array<Image> = [];
+			for (i in 0 ... rawImages.length)
+			{
+				var width = bytes.readUnsignedInt ();
+				var height = bytes.readUnsignedInt ();
+				var x = bytes.readInt ();
+				var y = bytes.readInt ();
 				
-				bytes.position += 4;
-				width = bytes.readUnsignedInt ();
-				height = bytes.readUnsignedInt ();
-				bytes.position += (4 * 2) + width * height;
-				
-				if (offsetX + width > bufferWidth) {
-					
-					offsetY += maxRows + 1;
-					offsetX = 0;
-					maxRows = 0;
-					
-				}
-				
-				if (offsetY + height > bufferHeight) {
-					
-					if (bufferWidth < bufferHeight) {
-						
-						bufferWidth *= 2;
-						
-					} else {
-						
-						bufferHeight *= 2;
-						
-					}
-					
-					offsetX = 0;
-					offsetY = 0;
-					maxRows = 0;
-					
-					// TODO: make this better
-					
-					bytes.position = 4;
-					i = 0;
-					continue;
-					
-				}
-				
-				offsetX += width + 1;
-				
-				if (height > maxRows) {
-					
-					maxRows = height;
-					
-				}
-				
-				i++;
-				
+				var rawImage:ByteArray = rawImages[i];
+                var buffer, image = null;
+                if (rawImage != null)
+                {
+                    
+				    buffer = new ImageBuffer (getUInt8ArrayFromByteArray (rawImage), width, height, 1);
+				    image = new Image (buffer, 0, 0, width, height);
+				    image.x = x;
+				    image.y = y;
+                    
+                }
+                results.push (image);
 			}
 			
-			var map = new Map<Int, Image> ();
-			var buffer = new ImageBuffer (null, bufferWidth, bufferHeight, 1);
-			var data = new ByteArray (bufferWidth * bufferHeight);
-			
-			bytes.position = 4;
-			offsetX = 0;
-			offsetY = 0;
-			maxRows = 0;
-			
-			var index, x, y, image;
-			
-			for (i in 0...count) {
-				
-				index = bytes.readUnsignedInt ();
-				width = bytes.readUnsignedInt ();
-				height = bytes.readUnsignedInt ();
-				x = bytes.readUnsignedInt ();
-				y = bytes.readUnsignedInt ();
-				
-				if (offsetX + width > bufferWidth) {
-					
-					offsetY += maxRows + 1;
-					offsetX = 0;
-					maxRows = 0;
-					
-				}
-				
-				for (i in 0...height) {
-					
-					data.position = ((i + offsetY) * bufferWidth) + offsetX;
-					//bytes.readBytes (data, 0, width);
-					
-					for (x in 0...width) {
-						
-						var byte = bytes.readUnsignedByte ();
-						data.writeByte (byte);
-						
-					}
-					
-				}
-				
-				image = new Image (buffer, offsetX, offsetY, width, height);
-				image.x = x;
-				image.y = y;
-				
-				map.set (index, image);
-				
-				offsetX += width + 1;
-				
-				if (height > maxRows) {
-					
-					maxRows = height;
-					
-				}
-				
-			}
-			
-			#if js
-			buffer.data = data.byteView;
-			#else
-			buffer.data = new UInt8Array (data);
-			#end
-			
-			return map;
+			return results;
 			
 		}
 		
@@ -462,7 +334,14 @@ class Font {
 		
 	}
 	
-	
+	private inline function getUInt8ArrayFromByteArray(ba:ByteArray)
+	{
+		#if nodejs
+		return ba.byteView;
+		#else
+		return new UInt8Array(ba);
+		#end
+	}
 	
 	
 	// Native Methods

--- a/project/include/text/Font.h
+++ b/project/include/text/Font.h
@@ -27,12 +27,10 @@ namespace lime {
 	
 	typedef struct {
 		
-		uint32_t index;
 		uint32_t width;
 		uint32_t height;
 		uint32_t x;
 		uint32_t y;
-		unsigned char data;
 		
 	} GlyphImage;
 	
@@ -58,8 +56,8 @@ namespace lime {
 			int GetUnderlinePosition ();
 			int GetUnderlineThickness ();
 			int GetUnitsPerEM ();
-			int RenderGlyph (int index, ByteArray *bytes, int offset = 0);
-			int RenderGlyphs (value indices, ByteArray *bytes);
+			value RenderGlyph (int index, ByteArray *imageData, int offset = 0);
+			value RenderGlyphs (value indices, ByteArray *imageData);
 			void SetSize (size_t size);
 			
 			void* face;

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -314,9 +314,9 @@ namespace lime {
 		#ifdef LIME_FREETYPE
 		Font *font = (Font*)(intptr_t)val_float (fontHandle);
 		ByteArray bytes = ByteArray (data);
-		return alloc_bool (font->RenderGlyph (val_int (index), &bytes));
+		return font->RenderGlyph (val_int (index), &bytes);
 		#else
-		return alloc_bool (false);
+		return alloc_null ();
 		#endif
 		
 	}
@@ -327,9 +327,9 @@ namespace lime {
 		#ifdef LIME_FREETYPE
 		Font *font = (Font*)(intptr_t)val_float (fontHandle);
 		ByteArray bytes = ByteArray (data);
-		return alloc_bool (font->RenderGlyphs (indices, &bytes));
+		return font->RenderGlyphs (indices, &bytes);
 		#else
-		return alloc_bool (false);
+		return alloc_null ();
 		#endif
 		
 	}

--- a/project/src/text/Font.cpp
+++ b/project/src/text/Font.cpp
@@ -784,83 +784,69 @@ namespace lime {
 	}
 	
 	
-	int Font::RenderGlyph (int index, ByteArray *bytes, int offset) {
+	value Font::RenderGlyph (int index, ByteArray *imageData, int offset) {
 		
-		if (FT_Load_Glyph ((FT_Face)face, index, FT_LOAD_FORCE_AUTOHINT | FT_LOAD_DEFAULT) == 0) {
+		GlyphImage *data = (GlyphImage*)(imageData->Bytes () + offset);
+		
+		if (FT_Load_Glyph ((FT_Face)face, index, FT_LOAD_RENDER) != 0)
+		{
 			
-			if (FT_Render_Glyph (((FT_Face)face)->glyph, FT_RENDER_MODE_NORMAL) == 0) {
-				
-				FT_Bitmap bitmap = ((FT_Face)face)->glyph->bitmap;
-				
-				int height = bitmap.rows;
-				int width = bitmap.width;
-				int pitch = bitmap.pitch;
-				
-				if (width == 0 || height == 0) return 0;
-				
-				uint32_t size = (4 * 5) + (width * height);
-				
-				if (bytes->Size() < size + offset) {
-					
-					bytes->Resize (size + offset);
-					
-				}
-				
-				GlyphImage *data = (GlyphImage*)(bytes->Bytes () + offset);
-				
-				data->index = index;
-				data->width = width;
-				data->height = height;
-				data->x = ((FT_Face)face)->glyph->bitmap_left;
-				data->y = ((FT_Face)face)->glyph->bitmap_top;
-				
-				unsigned char* position = &data->data;
-				
-				for (int i = 0; i < height; i++) {
-					
-					memcpy (position + (i * width), bitmap.buffer + (i * pitch), width);
-					
-				}
-				
-				return size;
-				
-			}
+			data->width = 0;
+			data->height = 0;
+			data->x = 0;
+			data->y = 0;
+			return alloc_null();
 			
 		}
-		
-		return 0;
+		else
+		{
+			
+			FT_Bitmap bitmap = ((FT_Face)face)->glyph->bitmap;
+			
+			data->width = bitmap.width;
+			data->height = bitmap.rows;
+			data->x = ((FT_Face)face)->glyph->bitmap_left;
+			data->y = ((FT_Face)face)->glyph->bitmap_top;
+			
+			if (bitmap.width == 0 || bitmap.rows == 0)
+				return alloc_null();
+			
+			int width = bitmap.width;
+			int height = bitmap.rows;
+			int pitch = bitmap.pitch;
+			ByteArray image (bitmap.width * bitmap.rows);
+			unsigned char* position = image.Bytes();
+			memcpy (position, bitmap.buffer, image.Size());
+			
+			return image.mValue;
+			
+		}
 		
 	}
 	
 	
-	int Font::RenderGlyphs (value indices, ByteArray *bytes) {
+	value Font::RenderGlyphs (value indices, ByteArray *imageData) {
 		
 		int offset = 0;
 		int totalOffset = 4;
 		uint32_t count = 0;
 		
 		int numIndices = val_array_size (indices);
+		int imageDataSize = (4 * 4) * numIndices;
+		if (imageDataSize > imageData->Size ())
+			imageData->Resize (imageDataSize);
+		
+		value images = alloc_array (numIndices);
 		
 		for (int i = 0; i < numIndices; i++) {
 			
-			offset = RenderGlyph (val_int (val_array_i (indices, i)), bytes, totalOffset);
-			
-			if (offset > 0) {
-				
-				totalOffset += offset;
-				count++;
-				
-			}
+			value image = RenderGlyph (val_int (val_array_i (indices, i)), imageData, offset);
+			val_array_set_i (images, i, image);
+			offset += (4 * 4);
 			
 		}
 		
-		if (count > 0) {
-			
-			*(bytes->Bytes ()) = count;
-			
-		}
-		
-		return totalOffset;
+		return images;
 		
 	}
 	


### PR DESCRIPTION
```Font.renderGlyphs``` returns an array of images instead of map, and prefers Font's native hinting over FreeType's auto hinting. I think that FreeType's hinter should be disabled by default.

Previous pull request:
https://github.com/openfl/lime/pull/419

Related commits in other repos:
https://github.com/vroad/openfl/commit/1ee3067a11ec96d37df03975f630a000ce63613e
https://github.com/vroad/lime-samples/commit/4276461d06369b9fdb7c0581dc9b29ed37785a70