### PR TITLE
Fix problem with cairo on nodejs

### DIFF
--- a/lime/graphics/cairo/CairoSurface.hx
+++ b/lime/graphics/cairo/CairoSurface.hx
@@ -57,7 +57,7 @@ abstract CairoSurface(Dynamic) {
 	public static function fromImage (image:Image):CairoSurface {
 		
 		#if lime_cairo
-		return createForData (image.data.buffer.__getNativePointer (), CairoFormat.ARGB32, image.width, image.height, image.buffer.stride);
+		return createForData (#if nodejs lime_buffer_get_native_pointer (image.data) #else image.data.buffer.__getNativePointer () #end, CairoFormat.ARGB32, image.width, image.height, image.buffer.stride);
 		#else
 		return null;
 		#end
@@ -108,6 +108,7 @@ abstract CairoSurface(Dynamic) {
 	private static var lime_cairo_image_surface_get_width = System.load ("lime", "lime_cairo_image_surface_get_width", 1);
 	private static var lime_cairo_surface_destroy = System.load ("lime", "lime_cairo_surface_destroy", 1);
 	private static var lime_cairo_surface_flush = System.load ("lime", "lime_cairo_surface_flush", 1);
+	private static var lime_buffer_get_native_pointer = System.load ("lime", "lime_buffer_get_native_pointer", 1);
 	#end
 	
 	

--- a/project/src/utils/ByteArray.cpp
+++ b/project/src/utils/ByteArray.cpp
@@ -145,6 +145,12 @@ namespace lime {
 		return alloc_null ();
 		
 	}
+
+	value lime_buffer_get_native_pointer (buffer inBuffer) {
+		
+		return alloc_float ((intptr_t)buffer_data (inBuffer));
+		
+	}
 	
 	
 	value lime_byte_array_init (value inFactory, value inLen, value inResize, value inBytes) {
@@ -201,6 +207,8 @@ namespace lime {
 	DEFINE_PRIM (lime_byte_array_init, 4);
 	DEFINE_PRIM (lime_byte_array_overwrite_file, 2);
 	DEFINE_PRIM (lime_byte_array_read_file, 1);
+
+	DEFINE_PRIM (lime_buffer_get_native_pointer, 1);
 	
 	
 }


### PR DESCRIPTION
This line prevented us from compiling for nodejs since on nodejs Uint8Array does not contain ByteArray.

I've also found strange #if in SimpleImage example. I don't know what this does because the example just works fine without that #if.

https://github.com/vroad/lime-samples/blob/master/SimpleImage/Source/Main.hx#L117