### PR TITLE
[Legacy] Fix Blackberry crash when calling system's "iswalpha" or "isdigit"

### DIFF
--- a/legacy/project/src/common/TextField.cpp
+++ b/legacy/project/src/common/TextField.cpp
@@ -13,6 +13,25 @@
 #define iswalpha isalpha
 #endif
 
+// For some reason normal "iswalpha" or "isdigit" makes Blackberry crash, workarround:
+#if defined(BLACKBERRY)
+
+   int iswalphaBB(int c)
+   {
+      return((c >='a' && c <='z') || (c >='A' && c <='Z'));
+   }
+   #undef iswalpha
+   #define iswalpha iswalphaBB
+   
+   int isdigitBB(int c)
+   {
+      return(c >='0' && c <='9');
+   }
+   #undef isdigit
+   #define isdigit isdigitBB
+
+#endif
+
 
 namespace nme
 {


### PR DESCRIPTION
For some reason calling "iswalpha" and "isdigit" with korean unicode chars makes apps crash.
To reproduce modify the "AddingText" example and set the text to something like "한국어 조선말", it will crash on Blackberry.
This pull request fixes that problem.
