### PR TITLE
Fix skipping BEXT Chunk (BWF format in .wav)

### DIFF
--- a/legacy/project/src/common/Audio.cpp
+++ b/legacy/project/src/common/Audio.cpp
@@ -484,7 +484,7 @@ namespace nme
 					wave_format.subChunkID[2] != 't' ||
 					wave_format.subChunkID[3] != ' ') 
 				{
-					fseek(f, wave_data.subChunkSize, SEEK_CUR);
+					fseek(f, wave_format.subChunkSize-16, SEEK_CUR);
 				}
 				else
 				{


### PR DESCRIPTION
Hi. This is clearly a typo since wave_data.subChunkSize (undefined) was used instead of wave_format.subChunkSize obtained from the fread. I am not sure about the extra 16 bytes, but this fixes my BWF files (just skips the chunk) and should not affect the normal WAV files.  Thanks.