### PR TITLE
Implement touch support in SDLApplication

### DIFF
--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -159,6 +159,13 @@ namespace lime {
 				
 				ProcessMouseEvent (event);
 				break;
+
+			case SDL_FINGERMOTION:
+			case SDL_FINGERDOWN:
+			case SDL_FINGERUP:
+
+				ProcessTouchEvent (event);
+				break;
 			
 			case SDL_TEXTINPUT:
 			case SDL_TEXTEDITING:
@@ -387,9 +394,39 @@ namespace lime {
 	
 	
 	void SDLApplication::ProcessTouchEvent (SDL_Event* event) {
-		
-		
-		
+
+		if (TouchEvent::callback) {
+
+			switch (event->type) {
+				case SDL_FINGERMOTION:
+
+					touchEvent.type = TOUCH_MOVE;
+					touchEvent.x = event->tfinger.x;
+					touchEvent.y = event->tfinger.y;
+					touchEvent.id = event->tfinger.fingerId;
+					break;
+
+				case SDL_FINGERDOWN:
+
+					touchEvent.type = TOUCH_START;
+					touchEvent.x = event->tfinger.x;
+					touchEvent.y = event->tfinger.y;
+					touchEvent.id = event->tfinger.fingerId;
+					break;
+
+				case SDL_FINGERUP:
+
+					touchEvent.type = TOUCH_END;
+					touchEvent.x = event->tfinger.x;
+					touchEvent.y = event->tfinger.y;
+					touchEvent.id = event->tfinger.fingerId;
+					break;
+			}
+
+			TouchEvent::Dispatch (&touchEvent);
+
+		}
+
 	}
 	
 	

--- a/project/src/ui/TouchEvent.cpp
+++ b/project/src/ui/TouchEvent.cpp
@@ -46,7 +46,7 @@ namespace lime {
 			alloc_field (object, id_x, alloc_float (event->x));
 			alloc_field (object, id_y, alloc_float (event->y));
 			
-			val_call1 (TouchEvent::callback->get (), object);
+			val_call0 (TouchEvent::callback->get ());
 			
 		}
 		


### PR DESCRIPTION
Adds touch support in SDLApplication (regular lime, not legacy).

However I am experiencing crashes as soon as a touch event comes in, with no output.
So far I saw it reach IModule.onTouchStart but did not reach my test app's event handler.
Still needs debugging to find out where the crash happens.
