### PR TITLE
fixed: webgl errors involving null/undefined arguments break the whole process

### DIFF
--- a/dependencies/webgl-debug.js
+++ b/dependencies/webgl-debug.js
@@ -170,7 +170,13 @@ function glFunctionArgToString(functionName, argumentIndex, value) {
       return glEnumToString(value);
     }
   }
-  return value.toString();
+  if (value === null) {
+    return "null";
+  } else if (value === undefined) {
+    return "undefined";
+  } else {
+    return value.toString();
+  }
 }
 
 function makePropertyWrapper(wrapper, original, propertyName) {


### PR DESCRIPTION
`glFunctionArgToString` in webgl-debug.js was broken for null and undefined arguments.

In fact the whole thing looks pretty old. We should maybe consider updating to the [newer version by Kronos](https://www.khronos.org/registry/webgl/sdk/devtools/src/debug/). *Buut* haven't tested that in replace, so just patched this simple bug for now :P.