### PR TITLE
fixed: html5 async asset loading

### DIFF
--- a/templates/compatibility/DefaultAssetLibrary.hx
+++ b/templates/compatibility/DefaultAssetLibrary.hx
@@ -204,7 +204,15 @@ class DefaultAssetLibrary extends AssetLibrary {
 		#elseif (js || openfl_html5 || pixi)
 		
 		var bytes:ByteArray = null;
-		var data = ApplicationMain.urlLoaders.get (path.get (id)).data;
+		var loader = ApplicationMain.urlLoaders.get (path.get (id));
+
+		if (loader = null) {
+
+			return null;
+			
+		}
+
+		var data = loader.data;
 		
 		if (Std.is (data, String)) {
 			
@@ -339,7 +347,15 @@ class DefaultAssetLibrary extends AssetLibrary {
 		#if js
 		
 		var bytes:ByteArray = null;
-		var data = ApplicationMain.urlLoaders.get (path.get (id)).data;
+		var loader = ApplicationMain.urlLoaders.get (path.get (id));
+
+		if (loader = null) {
+
+			return null;
+
+		}
+
+		var data = loader.data;
 		
 		if (Std.is (data, String)) {
 			

--- a/templates/compatibility/DefaultAssetLibrary.hx
+++ b/templates/compatibility/DefaultAssetLibrary.hx
@@ -206,7 +206,7 @@ class DefaultAssetLibrary extends AssetLibrary {
 		var bytes:ByteArray = null;
 		var loader = ApplicationMain.urlLoaders.get (path.get (id));
 
-		if (loader = null) {
+		if (loader == null) {
 
 			return null;
 			
@@ -349,7 +349,7 @@ class DefaultAssetLibrary extends AssetLibrary {
 		var bytes:ByteArray = null;
 		var loader = ApplicationMain.urlLoaders.get (path.get (id));
 
-		if (loader = null) {
+		if (loader == null) {
 
 			return null;
 

--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -17,7 +17,10 @@ import lime.Assets;
 import sys.FileSystem;
 #end
 
-#if flash
+#if (js && html5)
+import lime.net.URLLoader;
+import lime.net.URLRequest;
+#elseif flash
 import flash.display.Bitmap;
 import flash.display.BitmapData;
 import flash.display.Loader;
@@ -516,6 +519,25 @@ class DefaultAssetLibrary extends AssetLibrary {
 			handler (getBytes (id));
 			
 		}
+
+		#elseif html5
+
+		if (path.exists (id)) {
+
+			var loader = new URLLoader ();
+			loader.dataFormat = BINARY;
+			loader.onComplete.add (function (_):Void {
+
+				handler(loader.data);
+
+			});
+			loader.load (new URLRequest (path.get (id)));
+				
+		} else {
+
+			handler (getBytes (id));
+
+		}
 		
 		#else
 		
@@ -547,6 +569,24 @@ class DefaultAssetLibrary extends AssetLibrary {
 			
 		}
 		
+		#elseif html5
+
+		if (path.exists (id)) {
+
+			var image = new js.html.Image ();
+			image.onload = function (_):Void {
+
+				handler (Image.fromImageElement (image));
+
+			}
+			image.src = id;
+
+		} else {
+
+			handler (getImage (id));
+
+		}
+
 		#else
 		
 		handler (getImage (id));
@@ -653,15 +693,15 @@ class DefaultAssetLibrary extends AssetLibrary {
 	
 	public override function loadText (id:String, handler:String -> Void):Void {
 		
-		//#if html5
+		#if html5
 		
-		/*if (path.exists (id)) {
+		if (path.exists (id)) {
 			
 			var loader = new URLLoader ();
-			loader.addEventListener (Event.COMPLETE, function (event:Event) {
-				
-				handler (event.currentTarget.data);
-				
+			loader.onComplete.add (function (_):Void {
+
+				handler(loader.data);
+
 			});
 			loader.load (new URLRequest (path.get (id)));
 			
@@ -669,9 +709,9 @@ class DefaultAssetLibrary extends AssetLibrary {
 			
 			handler (getText (id));
 			
-		}*/
+		}
 		
-		//#else
+		#else
 		
 		var callback = function (bytes:ByteArray):Void {
 			
@@ -689,7 +729,7 @@ class DefaultAssetLibrary extends AssetLibrary {
 		
 		loadBytes (id, callback);
 		
-		//#end
+		#end
 		
 	}
 	

--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -219,7 +219,15 @@ class DefaultAssetLibrary extends AssetLibrary {
 		#elseif html5
 		
 		var bytes:ByteArray = null;
-		var data = Preloader.loaders.get (path.get (id)).data;
+		var loader = Preloader.loaders.get (path.get (id));
+
+		if (loader == null) {
+
+			return null;
+
+		}
+
+		var data = loader.data;
 		
 		if (Std.is (data, String)) {
 			
@@ -366,7 +374,15 @@ class DefaultAssetLibrary extends AssetLibrary {
 		#if html5
 		
 		var bytes:ByteArray = null;
-		var data = Preloader.loaders.get (path.get (id)).data;
+		var loader = Preloader.loaders.get (path.get (id));
+
+		if (loader == null) {
+
+			return null;
+			
+		}
+
+		var data = loader.data;
 		
 		if (Std.is (data, String)) {
 			


### PR DESCRIPTION
`Assets.loadImage`, `loadText` and `loadBytes` were all sync and didn't support non-embedded assets.

This fixes https://github.com/openfl/openfl/issues/369.