### PR TITLE
Fix legacy Surface.BlitChannel source rect

### DIFF
--- a/legacy/project/src/common/Surface.cpp
+++ b/legacy/project/src/common/Surface.cpp
@@ -815,7 +815,7 @@ void SimpleSurface::BlitChannel(const RenderTarget &outTarget, const Rect &inSrc
 
 
    // Start with unclipped dest rect
-   Rect src_rect(inSrcRect.x+inPosX,inSrcRect.x+inPosY, inSrcRect.w, inSrcRect.h );
+   Rect src_rect(inSrcRect.x+inPosX,inSrcRect.y+inPosY, inSrcRect.w, inSrcRect.h );
    // Clip to dest size...
    src_rect = src_rect.Intersect(outTarget.mRect);
 


### PR DESCRIPTION
When you see it... :)

(I don't see any equivalent on V2, but if there was any copy&paste maybe we should double check that too).