### PR TITLE
Fix touch coords in Android SDLActivity

### DIFF
--- a/templates/android/template/src/org/libsdl/app/SDLActivity.java
+++ b/templates/android/template/src/org/libsdl/app/SDLActivity.java
@@ -1170,8 +1170,8 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                 case MotionEvent.ACTION_MOVE:
                     for (i = 0; i < pointerCount; i++) {
                         pointerFingerId = event.getPointerId(i);
-                        x = event.getX(i) / mWidth;
-                        y = event.getY(i) / mHeight;
+                        x = event.getX(i);
+                        y = event.getY(i);
                         p = event.getPressure(i);
                         if (p > 1.0f) {
                             // may be larger than 1.0f on some devices
@@ -1194,8 +1194,8 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                     }
 
                     pointerFingerId = event.getPointerId(i);
-                    x = event.getX(i) / mWidth;
-                    y = event.getY(i) / mHeight;
+                    x = event.getX(i);
+                    y = event.getY(i);
                     p = event.getPressure(i);
                     if (p > 1.0f) {
                         // may be larger than 1.0f on some devices
@@ -1208,8 +1208,8 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                 case MotionEvent.ACTION_CANCEL:
                     for (i = 0; i < pointerCount; i++) {
                         pointerFingerId = event.getPointerId(i);
-                        x = event.getX(i) / mWidth;
-                        y = event.getY(i) / mHeight;
+                        x = event.getX(i);
+                        y = event.getY(i);
                         p = event.getPressure(i);
                         if (p > 1.0f) {
                             // may be larger than 1.0f on some devices


### PR DESCRIPTION
The coordinates are already relative to the display so they should be
kept as such when passing them to SDL native.