### PR TITLE
Fix Bytes implementation

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -948,13 +948,18 @@ class Image {
 			
 			if (data != null) {
 				
+				#if nodejs
+				var u8a = data.data.b;
+				#else
 				#if neko
 				var bytes = @:privateAccess (new Bytes (data.data.length, data.data.b));
 				#else
 				var bytes = Bytes.ofString (data.data.b);
 				@:privateAccess (bytes).length = data.data.length;
 				#end
-				__fromImageBuffer (new ImageBuffer (new UInt8Array (bytes), data.width, data.height, data.bitsPerPixel));
+				var u8a = new UInt8Array (bytes);
+				#end
+				__fromImageBuffer (new ImageBuffer (u8a, data.width, data.height, data.bitsPerPixel));
 				
 				if (onload != null) {
 					
@@ -1021,6 +1026,9 @@ class Image {
 				
 				if (data != null) {
 					
+					#if nodejs
+					var u8a = data.data.b;
+					#else
 					#if neko
 					var bytes = @:privateAccess (new Bytes (data.data.length, data.data.b));
 					#else
@@ -1028,6 +1036,7 @@ class Image {
 					@:privateAccess (bytes).length = data.data.length;
 					#end
 					var u8a = new UInt8Array (bytes);
+					#end
 					buffer = new ImageBuffer (u8a, data.width, data.height, data.bitsPerPixel);
 					
 				}

--- a/lime/graphics/opengl/GL.hx
+++ b/lime/graphics/opengl/GL.hx
@@ -380,6 +380,18 @@ class GL {
 	private static var context:RenderingContext;
 	#end
 	
+	#if nodejs
+	@:noCompletion private static function createBytes(view:ArrayBufferView):Dynamic {
+		
+		return view != null ? {
+			
+			b: view,
+			length: view.byteLength
+			
+		} : null;
+		
+	}
+	#end
 	
 	public static inline function activeTexture (texture:Int):Void {
 		
@@ -546,7 +558,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_buffer_data (target, data.buffer, data.byteOffset, data.byteLength, usage);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_buffer_data (target, data, data.byteOffset, data.byteLength, usage);
+		lime_gl_buffer_data (target, createBytes(data), data.byteOffset, data.byteLength, usage);
 		#elseif java
 		//GL15.glBufferData (target, data.buffer, data.byteOffset, data.byteLength, usage);
 		#end
@@ -561,7 +573,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_buffer_sub_data (target, offset, data.buffer, data.byteOffset, data.byteLength);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_buffer_sub_data (target, offset, data, data.byteOffset, data.byteLength);
+		lime_gl_buffer_sub_data (target, offset, createBytes(data), data.byteOffset, data.byteLength);
 		#elseif java
 		//GL15.glBufferSubData (target, offset, data.buffer, data.byteOffset, data.byteLength);
 		#end
@@ -669,7 +681,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_compressed_tex_image_2d (target, level, internalformat, width, height, border, data == null ? null : data.buffer, data == null ? null : data.byteOffset);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_compressed_tex_image_2d (target, level, internalformat, width, height, border, data == null ? null : data , data == null ? null : data.byteOffset);
+		lime_gl_compressed_tex_image_2d (target, level, internalformat, width, height, border, createBytes(data), data == null ? null : data.byteOffset);
 		#elseif java
 		//GL13.glCompressedTexImage2D (target, level, internalformat, width, height, border, data == null ? null : data.buffer, data == null ? null : data.byteOffset);
 		#end
@@ -684,7 +696,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_compressed_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, data == null ? null : data.buffer, data == null ? null : data.byteOffset);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_compressed_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, data == null ? null : data, data == null ? null : data.byteOffset);
+		lime_gl_compressed_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, createBytes(data), data == null ? null : data.byteOffset);
 		#elseif java
 		//GL13.glCompressedTexSubImage2D (target, level, xoffset, yoffset, width, height, format, data == null ? null : data.buffer, data == null ? null : data.byteOffset);
 		#end
@@ -1651,7 +1663,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_read_pixels (x, y, width, height, format, type, pixels == null ? null : pixels.buffer, pixels == null ? null : pixels.byteOffset);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_read_pixels (x, y, width, height, format, type, pixels == null ? null : pixels, pixels == null ? null : pixels.byteOffset);
+		lime_gl_read_pixels (x, y, width, height, format, type, pixels == null ? null : createBytes(pixels), pixels == null ? null : pixels.byteOffset);
 		#end
 		
 	}
@@ -1774,7 +1786,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_tex_image_2d (target, level, internalformat, width, height, border, format, type, pixels == null ? null : pixels.buffer, pixels == null ? null : pixels.byteOffset);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_tex_image_2d (target, level, internalformat, width, height, border, format, type, pixels == null ? null : pixels, pixels == null ? null : pixels.byteOffset);
+		lime_gl_tex_image_2d (target, level, internalformat, width, height, border, format, type, createBytes(pixels), pixels == null ? null : pixels.byteOffset);
 		#end
 		
 	}
@@ -1809,7 +1821,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, type, pixels == null ? null : pixels.buffer, pixels == null ? null : pixels.byteOffset);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, type, pixels == null ? null : pixels, pixels == null ? null : pixels.byteOffset);
+		lime_gl_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, type, createBytes(pixels), pixels == null ? null : pixels.byteOffset);
 		#end
 		
 	}
@@ -1833,7 +1845,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform1fv (location, x.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform1fv (location, x);
+		lime_gl_uniform1fv (location, createBytes(x));
 		#end
 		
 	}
@@ -1857,7 +1869,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform1iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform1iv (location, v);
+		lime_gl_uniform1iv (location, createBytes(v));
 		#end
 		
 	}
@@ -1881,7 +1893,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform2fv (location, v.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform2fv (location, v);
+		lime_gl_uniform2fv (location, createBytes(v));
 		#end
 		
 	}
@@ -1905,7 +1917,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform2iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform2iv (location, v);
+		lime_gl_uniform2iv (location, createBytes(v));
 		#end
 		
 	}
@@ -1929,7 +1941,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform3fv (location, v.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform3fv (location, v);
+		lime_gl_uniform3fv (location, createBytes(v));
 		#end
 		
 	}
@@ -1953,7 +1965,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform3iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform3iv (location, v);
+		lime_gl_uniform3iv (location, createBytes(v));
 		#end
 		
 	}
@@ -1977,7 +1989,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform4fv (location, v.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform4fv (location, v);
+		lime_gl_uniform4fv (location, createBytes(v));
 		#end
 		
 	}
@@ -2001,7 +2013,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform4iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform4iv (location, v);
+		lime_gl_uniform4iv (location, createBytes(v));
 		#end
 		
 	}
@@ -2014,7 +2026,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform_matrix (location, transpose, v.buffer, 2);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform_matrix (location, transpose, v, 2);
+		lime_gl_uniform_matrix (location, transpose, createBytes(v), 2);
 		#end
 		
 	}
@@ -2027,7 +2039,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform_matrix (location, transpose, v.buffer, 3);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform_matrix (location, transpose, v, 3);
+		lime_gl_uniform_matrix (location, transpose, createBytes(v), 3);
 		#end
 		
 	}
@@ -2040,7 +2052,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_uniform_matrix (location, transpose, v.buffer, 4);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_uniform_matrix (location, transpose, v, 4);
+		lime_gl_uniform_matrix (location, transpose, createBytes(v), 4);
 		#end
 		
 	}
@@ -2093,7 +2105,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_vertex_attrib1fv (indx, values.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_vertex_attrib1fv (indx, values);
+		lime_gl_vertex_attrib1fv (indx, createBytes(values));
 		#end
 		
 	}
@@ -2117,7 +2129,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_vertex_attrib2fv (indx, values.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_vertex_attrib2fv (indx, values);
+		lime_gl_vertex_attrib2fv (indx, createBytes(values));
 		#end
 		
 	}
@@ -2141,7 +2153,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_vertex_attrib3fv (indx, values.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_vertex_attrib3fv (indx, values);
+		lime_gl_vertex_attrib3fv (indx, createBytes(values));
 		#end
 		
 	}
@@ -2165,7 +2177,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl)
 		lime_gl_vertex_attrib4fv (indx, values.buffer);
 		#elseif (nodejs && lime_opengl)
-		lime_gl_vertex_attrib4fv (indx, values);
+		lime_gl_vertex_attrib4fv (indx, createBytes(values));
 		#end
 		
 	}

--- a/lime/utils/ByteArray.hx
+++ b/lime/utils/ByteArray.hx
@@ -74,33 +74,8 @@ class ByteArray #if !js extends Bytes implements ArrayAccess<Int> implements IDa
 		#end
 		
 		#if nodejs
-		var bytes = function (bytes:Dynamic) {
-			if (Std.is (bytes, ByteArray))
-				return untyped bytes.byteView;
-			else if (Std.is (bytes, UInt8Array) ||
-				Std.is (bytes, UInt16Array) ||
-				Std.is (bytes, Int16Array) ||
-				Std.is (bytes, Float32Array))
-				return bytes;
-			
-			if (bytes != null)
-				trace("Couldn't get BytesData:" + bytes);
-			return null;
-		}
-		var slen = function (bytes:ByteArray) {
-			if (Std.is (bytes, ByteArray))
-				return untyped bytes.length;
-			else if (Std.is (bytes, UInt8Array) ||
-				Std.is (bytes, UInt16Array) ||
-				Std.is (bytes, UInt32Array) ||
-				Std.is (bytes, Int8Array) ||
-				Std.is (bytes, Int16Array) ||
-				Std.is (bytes, Int32Array) ||
-				Std.is (bytes, Float32Array))
-				return untyped bytes.byteLength;
-			
-			return 0;
-		}
+		var bytes = function (bytes:ByteArray) { return bytes == null ? null : bytes.byteView; }
+		var slen = function (bytes:ByteArray){ return bytes == null ? 0 : bytes.length; }
 		#else
 		var bytes = function (bytes:ByteArray) { return bytes == null ? null : bytes.b; }
 		var slen = function (bytes:ByteArray){ return bytes == null ? 0 : bytes.length; }

--- a/lime/utils/Float32Array.hx
+++ b/lime/utils/Float32Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Float64Array.hx
+++ b/lime/utils/Float64Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Int16Array.hx
+++ b/lime/utils/Int16Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Int32Array.hx
+++ b/lime/utils/Int32Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Int8Array.hx
+++ b/lime/utils/Int8Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/UInt16Array.hx
+++ b/lime/utils/UInt16Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/UInt32Array.hx
+++ b/lime/utils/UInt32Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/UInt8Array.hx
+++ b/lime/utils/UInt8Array.hx
@@ -41,7 +41,7 @@ package lime.utils;
     }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if ((haxe_ver < 3.2) || nodejs)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/project/include/utils/Bytes.h
+++ b/project/include/utils/Bytes.h
@@ -25,8 +25,6 @@ namespace lime {
 		void Resize (int size);
 		value Value ();
 		
-		unsigned char *_data;
-		int _length;
 		value _value;
 		
 		


### PR DESCRIPTION
Fixed performance and nodejs compilation issue.
SimpleImage example does not build on neko for some reason with/without fix. After applying this, I could execute ApplicationMain.n directly though.

    Called from ? line 1
    Called from CommandLineTools.hx line 1359
    Called from CommandLineTools.hx line 25
    Called from CommandLineTools.hx line 126
    Called from CommandLineTools.hx line 579
    Called from lime/project/PlatformTarget.hx line 77
    Called from lime/tools/platforms/WindowsPlatform.hx line 105
    Called from lime/tools/helpers/IconHelper.hx line 216
    Called from lime/graphics/format/BMP.hx line 139
    Uncaught exception - $sget