### PR TITLE
Guard against doppleganger gamepad connection

### DIFF
--- a/lime/_backend/native/NativeApplication.hx
+++ b/lime/_backend/native/NativeApplication.hx
@@ -143,11 +143,11 @@ class NativeApplication {
 					parent.window.onGamepadButtonUp.dispatch (Gamepad.devices.get (gamepadEventInfo.id), gamepadEventInfo.button);
 				
 				case CONNECT:
-					
-					var gamepad = new Gamepad (gamepadEventInfo.id);
-					Gamepad.devices.set (gamepadEventInfo.id, gamepad);
-					parent.window.onGamepadConnect.dispatch (gamepad);
-				
+					if (!Gamepad.devices.exists(gamepadEventInfo.id))
+						var gamepad = new Gamepad (gamepadEventInfo.id);
+						Gamepad.devices.set (gamepadEventInfo.id, gamepad);
+						parent.window.onGamepadConnect.dispatch (gamepad);
+					}
 				case DISCONNECT:
 					
 					var gamepad = Gamepad.devices.get (gamepadEventInfo.id);


### PR DESCRIPTION
Gamepad connect can fire twice in a row the event for the same device (tested on Mac OSX). Prevent that.