### PR TITLE
Guard against doppleganger gamepad connection

### DIFF
--- a/lime/_backend/native/NativeApplication.hx
+++ b/lime/_backend/native/NativeApplication.hx
@@ -144,9 +144,11 @@ class NativeApplication {
 				
 				case CONNECT:
 					
-					var gamepad = new Gamepad (gamepadEventInfo.id);
-					Gamepad.devices.set (gamepadEventInfo.id, gamepad);
-					parent.window.onGamepadConnect.dispatch (gamepad);
+					if (!Gamepad.devices.exists(gamepadEventInfo.id)) {
+						var gamepad = new Gamepad (gamepadEventInfo.id);
+						Gamepad.devices.set (gamepadEventInfo.id, gamepad);
+						parent.window.onGamepadConnect.dispatch (gamepad);
+					}
 				
 				case DISCONNECT:
 					


### PR DESCRIPTION
Gamepad connect can fire twice in a row the event for the same device (tested on Mac OSX). Prevent that.