### PR TITLE
Fixed html5 image loading through DefaultAssetLibrary where id and path doesn't match

### DIFF
--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -611,7 +611,7 @@ class DefaultAssetLibrary extends AssetLibrary {
 				handler (Image.fromImageElement (image));
 				
 			}
-			image.src = id;
+			image.src = path.get (id);
 			
 		} else {
 			


### PR DESCRIPTION
Currently images are loaded with the id as the source. This should be the path instead.