### PR TITLE
Fixed CPP target embedded assets

### DIFF
--- a/lime/app/Preloader.hx
+++ b/lime/app/Preloader.hx
@@ -286,7 +286,14 @@ class Preloader #if flash extends Sprite #end {
 	
 	#if flash
 	private function current_onEnter (event:Event):Void {
-		
+
+		// Failsafe for small binary missing the 'onComplete' handler
+		if(!complete && Lib.current.loaderInfo.bytesLoaded == Lib.current.loaderInfo.bytesTotal)
+		{
+			complete = true;
+			update (Lib.current.loaderInfo.bytesLoaded, Lib.current.loaderInfo.bytesTotal);
+		}
+
 		if (complete) {
 			
 			Lib.current.removeEventListener (Event.ENTER_FRAME, current_onEnter);

--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -792,7 +792,7 @@ class DefaultAssetLibrary extends AssetLibrary {
 ::if (assets != null)::::foreach assets::::if (!embed)::::if (type == "font")::@:keep #if display private #end class __ASSET__::flatName:: extends lime.text.Font { public function new () { __fontPath = #if ios "assets/" + #end "::targetPath::"; name = "::fontName::"; super (); }}
 ::end::::end::::end::::end::
 
-#if (windows || mac || linux)
+#if (windows || mac || linux || cpp)
 
 ::if (assets != null)::
 ::foreach assets::::if (embed)::::if (type == "image")::@:image("::sourcePath::") #if display private #end class __ASSET__::flatName:: extends lime.graphics.Image {}


### PR DESCRIPTION
Embedding fonts for Android isn't currently working as the assets for CPP targets aren't embedded anywhere. NOTE: I've only tested for Android with Fonts. To recreate this issue, create the TextMetrics sample project. Set the assets to embed in the project.xml and try to compile.

Edit: Added failsafe to Preloader for small AIR binaries. Sometimes the the on complete handler would miss the dispatch, which causes the app to be stuck on the preloader screen. I've added a simple check in the enterframe loop to prevent the app from getting stuck.