### PR TITLE
add device choice for ios simulator

### DIFF
--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -201,7 +201,7 @@ class IOSHelper {
 
             // device config
             var defaultDevice = "iphone-6";
-            var devices:Array<String> = ["iphone-4s", "iphone-5", "iphone-5s", "iphone-6-Plus", "iphone-6", "ipad-2", "ipad-retina", "ipad-air"];
+            var devices:Array<String> = ["iphone-4s", "iphone-5", "iphone-5s", "iphone-6-plus", "iphone-6", "ipad-2", "ipad-retina", "ipad-air"];
             var oldDevices:Map<String, String> = ["iphone" => "iphone-6", "ipad" => "ipad-air"];
 
             var deviceFlag:String = null;

--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -195,21 +195,73 @@ class IOSHelper {
 				
 			}
 			
-			var family = "iphone";
-			
-			if (project.targetFlags.exists ("ipad")) {
-				
-				family = "ipad";
-				
-			}
-			
 			var templatePaths = [ PathHelper.combine (PathHelper.getHaxelib (new Haxelib ("lime")), "templates") ].concat (project.templatePaths);
 			var launcher = PathHelper.findTemplate (templatePaths, "bin/ios-sim");
 			Sys.command ("chmod", [ "+x", launcher ]);
-			
-			ProcessHelper.runCommand ("", launcher, [ "launch", FileSystem.fullPath (applicationPath), /*"--sdk", project.environment.get ("IPHONE_VER"), "--family", family,*/ "--timeout", "60" ] );
-			
-		} else {
+
+            // device config
+            var defaultDevice = "iphone-6";
+            var devices:Array<String> = ["iphone-4s", "iphone-5", "iphone-5s", "iphone-6-Plus", "iphone-6", "ipad-2", "ipad-retina", "ipad-air"];
+            var oldDevices:Map<String, String> = ["iphone" => "iphone-6", "ipad" => "ipad-air"];
+
+            var deviceFlag:String = null;
+            var deviceTypeID = null;
+
+            // check if old device flag and convert to current
+            for (key in oldDevices.keys())
+            {
+                if (project.targetFlags.exists(key))
+                {
+                    deviceFlag = oldDevices[key];
+                    break;
+                }
+            }
+
+            // check known device in command line args
+            if(deviceFlag == null)
+            {
+                for( i in 0...devices.length )
+                {
+                    if (project.targetFlags.exists(devices[i]))
+                    {
+                        deviceFlag = devices[i];
+                        break;
+                    }
+                }
+            }
+
+            // default to iphone 6
+            if(deviceFlag == null)
+                deviceFlag = defaultDevice;
+
+            // check if device is available
+            // $ ios-sim showdevicetypes
+            var devicesOutput:String = ProcessHelper.runProcess ("", launcher, [ "showdevicetypes" ] );
+            var deviceTypeList:Array<String> = devicesOutput.split("\n");
+
+            for ( i in 0...deviceTypeList.length )
+            {
+                var r:EReg = new EReg(deviceFlag+",", "i");
+                if(r.match(deviceTypeList[i]))
+                {
+                    deviceTypeID = deviceTypeList[i];
+                    break;
+                }
+            }
+
+            if(deviceTypeID == null)
+                LogHelper.warn("Device \""+deviceFlag+"\" was not found");
+            else
+                LogHelper.info("Launch app on \""+deviceTypeID+"\"");
+
+
+            // run command with --devicetypeid if exists
+            if(deviceTypeID != null)
+                ProcessHelper.runCommand ("", launcher, [ "launch", FileSystem.fullPath (applicationPath), /*"--sdk", project.environment.get ("IPHONE_VER"),*/ "--devicetypeid", deviceTypeID, "--timeout", "60" ] );
+            else
+                ProcessHelper.runCommand ("", launcher, [ "launch", FileSystem.fullPath (applicationPath), /*"--sdk", project.environment.get ("IPHONE_VER"), "--devicetypeid", deviceTypeID,*/ "--timeout", "60" ] );
+
+        } else {
 			
 			var applicationPath = "";
 			


### PR DESCRIPTION
Hi,

This commit allows you to choose the device like this:
```
openfl test ios -simulator -ipad-2
```
Available devices are :
iphone-4s, iphone-5, iphone-5s, iphone-6-plus, iphone-6, ipad-2, ipad-retina, ipad-air

Old flag "-iphone" map to "-iphone-6"
Old flag  "-ipad" map to "-ipad-air"

Jonas