### PR TITLE
Add lime color to/from UInt

### DIFF
--- a/lime/math/color/ARGB.hx
+++ b/lime/math/color/ARGB.hx
@@ -146,7 +146,23 @@ abstract ARGB(Int) from Int to Int {
 	}
 	
 	
+	@:from private static inline function __fromUInt (uint:UInt):ARGB {
+
+		var color : Int = uint;
+
+		return new ARGB (color);
+
+	}
+
 	
+	@:to private inline function __toUInt ():UInt {
+
+		return (this : Int);
+
+	}
+
+
+
 	
 	// Get & Set Methods
 	

--- a/lime/math/color/BGRA.hx
+++ b/lime/math/color/BGRA.hx
@@ -146,7 +146,23 @@ abstract BGRA(Int) from Int to Int {
 	}
 	
 	
+	@:from private static inline function __fromUInt (uint:UInt):BGRA {
+
+		var color : Int = uint;
+
+		return new BGRA (color);
+
+	}
+
 	
+	@:to private inline function __toUInt ():UInt {
+
+		return (this : Int);
+
+	}
+
+
+
 	
 	// Get & Set Methods
 	

--- a/lime/math/color/RGBA.hx
+++ b/lime/math/color/RGBA.hx
@@ -179,8 +179,24 @@ abstract RGBA(Int) from Int to Int {
 		return RGBA.create (bgra.r, bgra.g, bgra.b, bgra.a);
 		
 	}
+
+
+	@:from private static inline function __fromUInt (uint:UInt):RGBA {
+
+		var color : Int = uint;
+
+		return new RGBA (color);
+
+	}
 	
 	
+	@:to private inline function __toUInt ():UInt {
+
+		return (this : Int);
+
+	}
+
+
 	
 	
 	// Get & Set Methods


### PR DESCRIPTION
Since abstract implicit cast are not transitive we manually need to add color to/from UInt.

Remove errors like:
`lime/graphics/Image.hx:920: characters 7-41 : UInt should be lime.math.color.RGBA`
https://github.com/openfl/lime/blob/master/lime/graphics/Image.hx#L920
