### PR TITLE
settable lime.ui.Window.title, SDL only

### DIFF
--- a/lime/_backend/flash/FlashWindow.hx
+++ b/lime/_backend/flash/FlashWindow.hx
@@ -86,5 +86,12 @@ class FlashWindow {
 		
 	}
 	
+	public function setTitle (value:String):String {
+		
+		// not implemented
+		
+		return "";
+		
+	}
 	
 }

--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -415,5 +415,13 @@ class HTML5Window {
 		
 	}
 	
+	public function setTitle (value:String):String {
+		
+		// not implemented
+		
+		return "";
+		
+	}
+	
 	
 }

--- a/lime/_backend/native/NativeWindow.hx
+++ b/lime/_backend/native/NativeWindow.hx
@@ -179,6 +179,18 @@ class NativeWindow {
 		
 	}
 	
+	public function setTitle (value:String):String {
+		
+		if (handle != null) {
+			
+			return lime_window_set_title (handle, value);
+			
+		}
+		
+		return value;
+		
+	}
+	
 	
 	private static var lime_window_close = System.load ("lime", "lime_window_close", 1);
 	private static var lime_window_create = System.load ("lime", "lime_window_create", 5);
@@ -193,6 +205,7 @@ class NativeWindow {
 	private static var lime_window_set_fullscreen = System.load ("lime", "lime_window_set_fullscreen", 2);
 	private static var lime_window_set_icon = System.load ("lime", "lime_window_set_icon", 2);
 	private static var lime_window_set_minimized = System.load ("lime", "lime_window_set_minimized", 2);
+	private static var lime_window_set_title = System.load ("lime", "lime_window_set_title", 2);
 	
 	
 }

--- a/lime/ui/Window.hx
+++ b/lime/ui/Window.hx
@@ -49,6 +49,7 @@ class Window {
 	public var width (get, set):Int;
 	public var x (get, set):Int;
 	public var y (get, set):Int;
+	public var title (get, set):String;
 	
 	@:noCompletion private var backend:WindowBackend;
 	@:noCompletion private var __fullscreen:Bool;
@@ -57,6 +58,7 @@ class Window {
 	@:noCompletion private var __width:Int;
 	@:noCompletion private var __x:Int;
 	@:noCompletion private var __y:Int;
+	@:noCompletion private var __title:String;
 	
 	
 	public function new (config:Config = null) {
@@ -68,6 +70,7 @@ class Window {
 		__fullscreen = false;
 		__x = 0;
 		__y = 0;
+		__title = "";
 		
 		if (config != null) {
 			
@@ -76,6 +79,7 @@ class Window {
 			if (Reflect.hasField (config, "width")) __width = config.width;
 			if (Reflect.hasField (config, "height")) __height = config.height;
 			if (Reflect.hasField (config, "fullscreen")) __fullscreen = config.fullscreen;
+			if (Reflect.hasField (config, "title")) __title = config.title;
 			
 		}
 		
@@ -357,6 +361,21 @@ class Window {
 		
 		move (__x, value);
 		return __y;
+		
+	}
+	
+	@:noCompletion private inline function get_title ():String {
+		
+		return __title;
+		
+	}
+	
+	
+	@:noCompletion private function set_title (value:String):String {
+		
+		__title = value;
+		backend.setTitle(__title);
+		return __title;
 		
 	}
 	

--- a/project/include/ui/Window.h
+++ b/project/include/ui/Window.h
@@ -30,6 +30,7 @@ namespace lime {
 			virtual bool SetFullscreen (bool fullscreen) = 0;
 			virtual void SetIcon (ImageBuffer *imageBuffer) = 0;
 			virtual bool SetMinimized (bool minimized) = 0;
+			virtual const char* SetTitle (const char* title) = 0;
 			
 			Application* currentApplication;
 			int flags;

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -1145,6 +1145,13 @@ namespace lime {
 		
 	}
 	
+	value lime_window_set_title (value window, value title) {
+		
+		Window* targetWindow = (Window*)(intptr_t)val_float (window);
+		return alloc_string (targetWindow->SetTitle (val_string (title)));
+		
+	}
+	
 	
 	DEFINE_PRIM (lime_application_create, 1);
 	DEFINE_PRIM (lime_application_exec, 1);
@@ -1235,6 +1242,7 @@ namespace lime {
 	DEFINE_PRIM (lime_window_set_fullscreen, 2);
 	DEFINE_PRIM (lime_window_set_icon, 2);
 	DEFINE_PRIM (lime_window_set_minimized, 2);
+	DEFINE_PRIM (lime_window_set_title, 2);
 	
 	
 }

--- a/project/src/backend/sdl/SDLWindow.cpp
+++ b/project/src/backend/sdl/SDLWindow.cpp
@@ -247,6 +247,14 @@ namespace lime {
 		
 	}
 	
+	const char* SDLWindow::SetTitle (const char* title) {
+		
+		SDL_SetWindowTitle(sdlWindow, title);
+		
+		return title;
+		
+	}
+	
 	
 	Window* CreateWindow (Application* application, int width, int height, int flags, const char* title) {
 		

--- a/project/src/backend/sdl/SDLWindow.h
+++ b/project/src/backend/sdl/SDLWindow.h
@@ -29,6 +29,7 @@ namespace lime {
 			virtual bool SetFullscreen (bool fullscreen);
 			virtual void SetIcon (ImageBuffer *imageBuffer);
 			virtual bool SetMinimized (bool minimized);
+			virtual const char* SetTitle (const char* title);
 			
 			SDL_Window* sdlWindow;
 		


### PR DESCRIPTION
I needed to change native window title in runtime.
SDL only, not implemented for HTML5, nor Flash.
My first lime contribution, works for me like that, should be reviewed.