### PR TITLE
Cater for two's complement in joypad analog axis

### DIFF
--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -270,7 +270,7 @@ namespace lime {
 					}
 					
 					gamepadsAxisMap[event->caxis.which][event->caxis.axis] = event->caxis.value;
-					gamepadEvent.axisValue = event->caxis.value / 32768.0;
+					gamepadEvent.axisValue = event->caxis.value / (event->caxis.value>0?32767.0:32768.0);
 					
 					GamepadEvent::Dispatch (&gamepadEvent);
 					break;


### PR DESCRIPTION
Cater for two's complement in joypad analog axis - positive analog and triggers would otherwise send wrong value if divided by 32768 when 32767 is max.