### PR TITLE
Added AIR detection to FlashBackend and toplevel directory paths.

### DIFF
--- a/lime/_backend/flash/FlashApplication.hx
+++ b/lime/_backend/flash/FlashApplication.hx
@@ -108,6 +108,8 @@ class FlashApplication {
 		
 		if (config != null) {
 			
+			config.isAir = flash.system.ApplicationDomain.currentDomain.hasDefinition("flash.filesystem.File");
+			
 			setFrameRate (config.fps);
 			var window = new Window (config);
 			var renderer = new Renderer (window);

--- a/lime/app/Config.hx
+++ b/lime/app/Config.hx
@@ -27,5 +27,8 @@ typedef Config = {
 	@:optional var version:String;
 	@:optional var vsync:Bool;
 	@:optional var width:Int;
+	#if flash
+	@:optional var isAir:Bool;
+	#end
 	
 }

--- a/lime/system/System.hx
+++ b/lime/system/System.hx
@@ -518,6 +518,10 @@ class System {
 		
 		#if (cpp || neko || nodejs)
 		return lime_system_get_directory (SystemDirectory.APPLICATION, null, null);
+		#elseif flash
+		if(Application.current.config.isAir)
+			return Reflect.getProperty(Type.resolveClass("flash.filesystem.File"), "applicationDirectory").nativePath;
+		return null;
 		#else
 		return null;
 		#end
@@ -550,6 +554,10 @@ class System {
 		
 		#if (cpp || neko || nodejs)
 		return lime_system_get_directory (SystemDirectory.APPLICATION_STORAGE, company, file);
+		#elseif flash
+		if(Application.current.config.isAir)
+			return Reflect.getProperty(Type.resolveClass("flash.filesystem.File"), "applicationStorageDirectory").nativePath;
+		return null;
 		#else
 		return null;
 		#end
@@ -561,6 +569,10 @@ class System {
 		
 		#if (cpp || neko || nodejs)
 		return lime_system_get_directory (SystemDirectory.DESKTOP, null, null);
+		#elseif flash
+		if(Application.current.config.isAir)
+			return Reflect.getProperty(Type.resolveClass("flash.filesystem.File"), "desktopDirectory").nativePath;
+		return null;
 		#else
 		return null;
 		#end
@@ -572,6 +584,10 @@ class System {
 		
 		#if (cpp || neko || nodejs)
 		return lime_system_get_directory (SystemDirectory.DOCUMENTS, null, null);
+		#elseif flash
+		if(Application.current.config.isAir)
+			return Reflect.getProperty(Type.resolveClass("flash.filesystem.File"), "documentsDirectory").nativePath;
+		return null;
 		#else
 		return null;
 		#end
@@ -605,6 +621,10 @@ class System {
 		
 		#if (cpp || neko || nodejs)
 		return lime_system_get_directory (SystemDirectory.USER, null, null);
+		#elseif flash
+		if(Application.current.config.isAir)
+			return Reflect.getProperty(Type.resolveClass("flash.filesystem.File"), "userDirectory").nativePath;
+		return null;
 		#else
 		return null;
 		#end


### PR DESCRIPTION
I've added simple AIR detection for the lime FlashBackend. I really don't know if this is the best approach to take. I tried keeping the processing low by only doing the AIR check once within the backend itself. Then within the System class added handling of the "flash" compile directory getters.

It would be nice if we could cache ```Type.resolveClass("flash.filesystem.File")``` as it will always resolve the same.