### PR TITLE
Fix desktop cross build

### DIFF
--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -7,6 +7,7 @@ import lime.tools.helpers.ArrayHelper;
 import lime.tools.helpers.LogHelper;
 import lime.tools.helpers.ObjectHelper;
 import lime.tools.helpers.PathHelper;
+import lime.tools.helpers.PlatformHelper;
 import lime.tools.helpers.StringMapHelper;
 import lime.project.Asset;
 import lime.project.AssetType;
@@ -78,7 +79,7 @@ class ProjectXMLParser extends HXProject {
 			
 		}
 		
-		if (targetFlags.exists ("neko")) {
+		if (targetFlags.exists ("neko") || (platformType == DESKTOP && target != PlatformHelper.hostPlatform)) {
 			
 			defines.set ("native", "1");
 			defines.set ("neko", "1");

--- a/lime/tools/platforms/MacPlatform.hx
+++ b/lime/tools/platforms/MacPlatform.hx
@@ -109,8 +109,8 @@ class MacPlatform extends PlatformTarget {
 		if (targetType == "neko") {
 			
 			ProcessHelper.runCommand ("", "haxe", [ hxml ]);
-			NekoHelper.createExecutable (project.templatePaths, "Mac" + (is64 ? "64" : ""), targetDirectory + "/obj/ApplicationMain.n", executablePath);
-			NekoHelper.copyLibraries (project.templatePaths, "Mac" + (is64 ? "64" : ""), executableDirectory);
+			NekoHelper.createExecutable (project.templatePaths, "mac" + (is64 ? "64" : ""), targetDirectory + "/obj/ApplicationMain.n", executablePath);
+			NekoHelper.copyLibraries (project.templatePaths, "mac" + (is64 ? "64" : ""), executableDirectory);
 			
 		} else if (targetType == "java") {
 			


### PR DESCRIPTION
I figured out why when doing a cross build hxcpp's ndll where trying to be copied,
it was coming from these three lines https://github.com/openfl/lime/blob/master/include.xml#L52-L54
cpp was defined incorrectly instead of neko.

Also a fix for the mac template folder name, since linux is case sensitive.