### PR TITLE
Additional key mappings for Flash and HTML5 targets

### DIFF
--- a/lime/_backend/flash/FlashApplication.hx
+++ b/lime/_backend/flash/FlashApplication.hx
@@ -76,6 +76,7 @@ class FlashApplication {
 			case 105: return KeyCode.NUMPAD_9;
 			case 106: return KeyCode.NUMPAD_MULTIPLY;
 			case 107: return KeyCode.NUMPAD_PLUS;
+			case 108: return KeyCode.NUMPAD_ENTER;
 			case 109: return KeyCode.NUMPAD_MINUS;
 			case 110: return KeyCode.NUMPAD_PERIOD;
 			case 111: return KeyCode.NUMPAD_DIVIDE;
@@ -91,9 +92,21 @@ class FlashApplication {
 			case 121: return KeyCode.F10;
 			case 122: return KeyCode.F11;
 			case 123: return KeyCode.F12;
+			case 124: return KeyCode.F13;
+			case 125: return KeyCode.F14;
+			case 126: return KeyCode.F15;
 			case 144: return KeyCode.NUM_LOCK;
+			case 186: return KeyCode.SEMICOLON;
+			case 187: return KeyCode.EQUALS;
+			case 188: return KeyCode.COMMA;
+			case 189: return KeyCode.MINUS;
+			case 190: return KeyCode.PERIOD;
+			case 191: return KeyCode.SLASH;
+			case 192: return KeyCode.GRAVE;
 			case 219: return KeyCode.LEFT_BRACKET;
+			case 220: return KeyCode.BACKSLASH;
 			case 221: return KeyCode.RIGHT_BRACKET;
+			case 222: return KeyCode.SINGLE_QUOTE;
 			
 		}
 		

--- a/lime/_backend/html5/HTML5Application.hx
+++ b/lime/_backend/html5/HTML5Application.hx
@@ -82,6 +82,20 @@ class HTML5Application {
 			case 121: return KeyCode.F10;
 			case 122: return KeyCode.F11;
 			case 123: return KeyCode.F12;
+			case 124: return KeyCode.F13;
+			case 125: return KeyCode.F14;
+			case 126: return KeyCode.F15;
+			case 186: return KeyCode.SEMICOLON;
+			case 187: return KeyCode.EQUALS;
+			case 188: return KeyCode.COMMA;
+			case 189: return KeyCode.MINUS;
+			case 190: return KeyCode.PERIOD;
+			case 191: return KeyCode.SLASH;
+			case 192: return KeyCode.GRAVE;
+			case 219: return KeyCode.LEFT_BRACKET;
+			case 220: return KeyCode.BACKSLASH;
+			case 221: return KeyCode.RIGHT_BRACKET;
+			case 222: return KeyCode.SINGLE_QUOTE;
 			
 		}
 		


### PR DESCRIPTION
Extending key mappings in Flash and HTML5 targets, based on the constants listed in the [AS3 Keyboard class reference] (http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/ui/Keyboard.html).

Both targets tested in Safari.