### PR TITLE
Use "node" instead of "iojs"

### DIFF
--- a/lime/tools/helpers/NodeJSHelper.hx
+++ b/lime/tools/helpers/NodeJSHelper.hx
@@ -53,8 +53,7 @@ class NodeJSHelper {
 		
 		args.unshift (Path.withoutDirectory (modulePath));
 		
-		//ProcessHelper.runCommand (Path.directory (modulePath), node, args);
-		ProcessHelper.runCommand (Path.directory (modulePath), "iojs", args);
+		ProcessHelper.runCommand (Path.directory (modulePath), "node", args);
 		
 	}
 	


### PR DESCRIPTION
Now we should use "node" for running lime app, as two projects are recently merged and "iojs" command is removed from distribution.