### PR TITLE
Fixed icon issue on cross-compilation

### DIFF
--- a/lime/tools/platforms/WindowsPlatform.hx
+++ b/lime/tools/platforms/WindowsPlatform.hx
@@ -19,6 +19,7 @@ import lime.project.Asset;
 import lime.project.AssetType;
 import lime.project.Haxelib;
 import lime.project.HXProject;
+import lime.project.Platform;
 import lime.project.PlatformTarget;
 import sys.io.File;
 import sys.FileSystem;
@@ -159,7 +160,7 @@ class WindowsPlatform extends PlatformTarget {
 			
 			var iconPath = PathHelper.combine (applicationDirectory, "icon.ico");
 			
-			if (IconHelper.createWindowsIcon (icons, iconPath) && PlatformHelper.hostPlatform == WINDOWS) {
+			if (IconHelper.createWindowsIcon (icons, iconPath) && PlatformHelper.hostPlatform == Platform.WINDOWS) {
 				
 				var templates = [ PathHelper.getHaxelib (new Haxelib ("lime")) + "/templates" ].concat (project.templatePaths);
 				ProcessHelper.runCommand ("", PathHelper.findTemplate (templates, "bin/ReplaceVistaIcon.exe"), [ executablePath, iconPath, "1" ], true, true);


### PR DESCRIPTION
Terminal typically displays a permission problem with ReplaceVistaIcon.exe on cross-compilation. ReplaceVistaIcon.exe is not a native application for Linux or Mac, however It appears that 

PlatformHelper.hostPlatfrom == WINDOWS (old file)

is registered as always TRUE regardless of host platform, so adding an Import for lime.project.Platform registers the correct TRUE or FALSE for 

PlatformHelper.hostPlatform == Platform.WINDOWS (pull request)