### PR TITLE
Fixed issue on DLL not copied during cross-compile

### DIFF
--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -14,6 +14,7 @@ import lime.project.AssetType;
 import lime.project.Dependency;
 import lime.project.Haxelib;
 import lime.project.HXProject;
+import lime.project.Platform;
 import sys.io.File;
 import sys.FileSystem;
 
@@ -79,7 +80,7 @@ class ProjectXMLParser extends HXProject {
 			
 		}
 		
-		if (targetFlags.exists ("neko") || (platformType == DESKTOP && target != PlatformHelper.hostPlatform)) {
+		if (targetFlags.exists ("neko") || (platformType == DESKTOP && target != PlatformHelper.hostPlatform && PlatformHelper.hostPlatform != Platform.LINUX)) {
 			
 			defines.set ("native", "1");
 			defines.set ("neko", "1");


### PR DESCRIPTION
The suggested fix recovers the ability of lime to automatically copy DLL files to bin directory during Mingw cross compilation from Linux to windows.