### PR TITLE
Fixed Linux cross compilation

### DIFF
--- a/lime/tools/platforms/WindowsPlatform.hx
+++ b/lime/tools/platforms/WindowsPlatform.hx
@@ -38,7 +38,7 @@ class WindowsPlatform extends PlatformTarget {
 		
 		super (command, _project, targetFlags);
 		
-		if (project.targetFlags.exists ("neko") ) {
+		if (project.targetFlags.exists ("neko")) {
 			
 			targetType = "neko";
 			
@@ -170,7 +170,7 @@ class WindowsPlatform extends PlatformTarget {
 				
 				FileHelper.copyFile (targetDirectory + "/obj/ApplicationMain" + (project.debug ? "-debug" : "") + ".exe", executablePath);
 				FileHelper.copyFile (targetDirectory + "/obj/libwinpthread-1.dll", applicationDirectory + "libwinpthread-1.dll");
-
+				
 			} else {
 				
 				ProcessHelper.runCommand ("", "haxe", haxeArgs.concat ([ "-D", "static_link" ]));

--- a/lime/tools/platforms/WindowsPlatform.hx
+++ b/lime/tools/platforms/WindowsPlatform.hx
@@ -157,9 +157,7 @@ class WindowsPlatform extends PlatformTarget {
 			
 			if (enableLinuxMingw) {
 
-				flags.push ("-Dtoolchain=mingw");
-				flags.push ("-Dlinux_host");
-				flags.push ("-DMINGW_ROOT=/usr/i686-w64-mingw32");
+				flags.push ("-DHXCPP_M32");
 
 			}
 			


### PR DESCRIPTION
Fixed Linux cross compilation using Mingw.

It is interesting to note that Fedora and Ubuntu could cross compile Windows 32bit application using Mingw.

Resulting binaries have been found out to be fully functional in Wine Abstraction Layer, Windows 7 and Windows 10.