### PR TITLE
Fix crash after reading file on Android

### DIFF
--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -401,7 +401,8 @@ namespace lime {
 		
 		#ifndef HX_WINDOWS
 		
-		return ((SDL_RWops*)handle)->type == SDL_RWOPS_STDFILE;
+		int type = ((SDL_RWops*)handle)->type;
+		return type == SDL_RWOPS_STDFILE || type == SDL_RWOPS_JNIFILE;
 		
 		#else
 		


### PR DESCRIPTION
PiratePig runs now with this fix, though only white background and text shows up on the screen.