### PR TITLE
Minor fixes for tvOS + ARC

### DIFF
--- a/lime/tools/platforms/IOSPlatform.hx
+++ b/lime/tools/platforms/IOSPlatform.hx
@@ -224,7 +224,6 @@ class IOSPlatform extends PlatformTarget {
 			context.OBJC_ARC = true;
 			
 		}
-		LogHelper.info("OBJC_ARC:" + context.OBJC_ARC);
 
 		//context.ENABLE_BITCODE = (project.config.getFloat ("ios.deployment", 5.1) >= 6);
 		context.ENABLE_BITCODE = project.config.getBool ("ios.enable-bitcode", false);

--- a/lime/tools/platforms/IOSPlatform.hx
+++ b/lime/tools/platforms/IOSPlatform.hx
@@ -224,7 +224,8 @@ class IOSPlatform extends PlatformTarget {
 			context.OBJC_ARC = true;
 			
 		}
-		
+		LogHelper.info("OBJC_ARC:" + context.OBJC_ARC);
+
 		//context.ENABLE_BITCODE = (project.config.getFloat ("ios.deployment", 5.1) >= 6);
 		context.ENABLE_BITCODE = project.config.getBool ("ios.enable-bitcode", false);
 		context.IOS_COMPILER = project.config.getString ("ios.compiler", "clang");
@@ -331,12 +332,12 @@ class IOSPlatform extends PlatformTarget {
 		
 		var commands = [];
 		
-		if (armv6) commands.push ([ "-Dios", "-DHXCPP_CPP11" ]);
-		if (armv7) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARMV7" ]);
-		if (armv7s) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARMV7S" ]);
-		if (arm64) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARM64" ]);
-		if (i386) commands.push ([ "-Dios", "-Dsimulator", "-DHXCPP_CPP11" ]);
-		if (x86_64) commands.push ([ "-Dios", "-Dsimulator", "-DHXCPP_M64", "-DHXCPP_CPP11" ]);
+		if (armv6) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DOBJC_ARC" ]);
+		if (armv7) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARMV7", "-DOBJC_ARC" ]);
+		if (armv7s) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARMV7S", "-DOBJC_ARC" ]);
+		if (arm64) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARM64", "-DOBJC_ARC" ]);
+		if (i386) commands.push ([ "-Dios", "-Dsimulator", "-DHXCPP_CPP11", "-DOBJC_ARC" ]);
+		if (x86_64) commands.push ([ "-Dios", "-Dsimulator", "-DHXCPP_M64", "-DHXCPP_CPP11", "-DOBJC_ARC" ]);
 		
 		CPPHelper.rebuild (project, commands);
 		

--- a/lime/tools/platforms/TVOSPlatform.hx
+++ b/lime/tools/platforms/TVOSPlatform.hx
@@ -313,9 +313,9 @@ class TVOSPlatform extends PlatformTarget {
 		
 		var commands = [];
 		
-		if (arm64) commands.push ([ "-Dtvos", "-Dappletvos", "-DHXCPP_CPP11", "-DHXCPP_ARM64" ]);
-		if (i386) commands.push ([ "-Dtvos", "-Dappletvsim", "-Dsimulator", "-DHXCPP_CPP11" ]);
-		if (x86_64) commands.push ([ "-Dtvos", "-Dappletvsim", "-Dsimulator", "-DHXCPP_M64", "-DHXCPP_CPP11" ]);
+		if (arm64) commands.push ([ "-Dtvos", "-Dappletvos", "-DHXCPP_CPP11", "-DHXCPP_ARM64", "-DOBJC_ARC" ]);
+		if (i386) commands.push ([ "-Dtvos", "-Dappletvsim", "-Dsimulator", "-DHXCPP_CPP11", "-DOBJC_ARC" ]);
+		if (x86_64) commands.push ([ "-Dtvos", "-Dappletvsim", "-Dsimulator", "-DHXCPP_M64", "-DHXCPP_CPP11", "-DOBJC_ARC" ]);
 		
 		CPPHelper.rebuild (project, commands);
 		

--- a/lime/ui/Window.hx
+++ b/lime/ui/Window.hx
@@ -225,6 +225,18 @@ class Window {
 		];
 		
 		Gamepad.addMappings (mappings);
+
+		#elseif (ios || tvos)
+		
+		var mappings = [
+			
+		    "4d466947616d65706164010000000000,MFi Extended Gamepad,a:b0,b:b1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,righttrigger:a5,rightx:a3,righty:a4,start:b6,x:b2,y:b3,",
+		    "4d466947616d65706164020000000000,MFi Gamepad,a:b0,b:b1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,rightshoulder:b5,start:b6,x:b2,y:b3,",
+		    "4d466947616d65706164030000000000,MFi Apple TV Remote,a:b0,b:b1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,rightshoulder:b5,start:b6,x:b2,y:b3,",
+			
+		];
+		
+		Gamepad.addMappings (mappings);
 		
 		#end
 		

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -365,6 +365,25 @@
 				<vflag name="-framework" value="AudioToolbox" />
 				<vflag name="-framework" value="AudioUnit" />
 				<vflag name="-framework" value="OpenAL"/>
+				<vflag name="-framework" value="GameController"/>
+
+				<lib name="-ldl" />
+				<lib name="-lEGL" />
+				<lib name="-lGLESv2" />
+
+			</section>
+
+			<section if="ios">
+
+				<vflag name="-framework" value="UIKit" />
+				<vflag name="-framework" value="Foundation" />
+				<vflag name="-framework" value="CoreAudio" />
+				<vflag name="-framework" value="CoreVideo" />
+				<vflag name="-framework" value="OpenGLES" />
+				<vflag name="-framework" value="AudioToolbox" />
+				<vflag name="-framework" value="AudioUnit" />
+				<vflag name="-framework" value="OpenAL"/>
+				<vflag name="-framework" value="CoreMotion"/>
 
 				<lib name="-ldl" />
 				<lib name="-lEGL" />

--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -712,7 +712,7 @@ class DefaultAssetLibrary extends AssetLibrary {
 							
 							if (!className.exists (asset.id)) {
 								
-								#if ios || tvos
+								#if (ios || tvos)
 								path.set (asset.id, "assets/" + asset.path);
 								#else
 								path.set (asset.id, asset.path);


### PR DESCRIPTION
I've fixed a few bugs in the tvOS implementation and force the iOS target to use ARC as SDL takes it for granted and some of the files of the latest revisions won't compile if it's not enabled for iOS/tvOS targets.
