### PR TITLE
set armv7+x86 as default targets for Android builds

### DIFF
--- a/lime/project/HXProject.hx
+++ b/lime/project/HXProject.hx
@@ -148,15 +148,7 @@ class HXProject {
 					
 				} else if (target == Platform.ANDROID) {
 					
-					if (targetFlags.exists ("simulator") || targetFlags.exists ("emulator")) {
-						
-						architectures = [ Architecture.X86 ];
-						
-					} else {
-						
-						architectures = [ Architecture.ARMV7 ];
-						
-					}
+					architectures = [ Architecture.ARMV7, Architecture.X86 ];
 					
 				} else if (target == Platform.TVOS) {
 					


### PR DESCRIPTION
Hi,

They're more and more x86 devices on the market since 2012, such as the Google Nexus Player, Nokia n1, Tesco Hudl2, Asus Zenfones, Samsung Galaxy Tab 3 10.1, Motorola Razr i...
 
Currently full x86 architecture support is there when adding *-emulator* option or specifically adding x86 architecture for android inside *project.xml*, I'm proposing to change it so arm and x86 libraries are included by default in android builds, not only when building for the emulator.