### PR TITLE
Fix Bytes issues on nodejs

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -26,7 +26,7 @@
 	<templatePath name="templates" unless="lime-legacy" />
 	<sample path="samples" unless="openfl" />
 	
-	<haxelib name="nodejs" if="nodejs" />
+	<haxelib name="hxnodejs" if="nodejs" />
 	<haxelib name="format" if="java" />
 	
 	<target name="ps3" handler="lime-ps3" />

--- a/lime/audio/AudioBuffer.hx
+++ b/lime/audio/AudioBuffer.hx
@@ -6,6 +6,7 @@ import lime.audio.openal.AL;
 import lime.net.URLLoader;
 import lime.net.URLRequest;
 import lime.utils.ByteArray;
+import lime.utils.BytesUtil;
 import lime.utils.UInt8Array;
 
 #if (js && html5)
@@ -88,7 +89,7 @@ class AudioBuffer {
 			var audioBuffer = new AudioBuffer ();
 			audioBuffer.bitsPerSample = data.bitsPerSample;
 			audioBuffer.channels = data.channels;
-			audioBuffer.data = new UInt8Array (@:privateAccess new Bytes (data.data.length, data.data.b));
+			audioBuffer.data = BytesUtil.getUInt8ArrayFromAnonBytes (data.data);
 			audioBuffer.sampleRate = data.sampleRate;
 			return audioBuffer;
 			
@@ -128,7 +129,7 @@ class AudioBuffer {
 			var audioBuffer = new AudioBuffer ();
 			audioBuffer.bitsPerSample = data.bitsPerSample;
 			audioBuffer.channels = data.channels;
-			audioBuffer.data = new UInt8Array (@:privateAccess new Bytes (data.data.length, data.data.b));
+			audioBuffer.data = BytesUtil.getUInt8ArrayFromAnonBytes (data.data);
 			audioBuffer.sampleRate = data.sampleRate;
 			return audioBuffer;
 			

--- a/lime/audio/openal/AL.hx
+++ b/lime/audio/openal/AL.hx
@@ -2,6 +2,7 @@ package lime.audio.openal;
 
 
 import lime.utils.ArrayBufferView;
+import lime.utils.BytesUtil;
 
 #if ((haxe_ver >= 3.2) && cpp)
 import cpp.Float32;
@@ -86,7 +87,7 @@ class AL {
 		#if ((cpp || neko) && lime_openal && !macro)
 		lime_al_buffer_data (buffer, format, data.buffer, size, freq);
 		#elseif (nodejs && lime_openal && !macro)
-		lime_al_buffer_data (buffer, format, data, size, freq);
+		lime_al_buffer_data (buffer, format, BytesUtil.getAnonBytesFromTypedArray (data), size, freq);
 		#elseif (nodejs && lime_openal && !macro)
 		lime_al_buffer_data (buffer, format, data, size, freq);
 		#end

--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -21,6 +21,7 @@ import lime.math.Vector2;
 import lime.system.CFFI;
 import lime.utils.ArrayBuffer;
 import lime.utils.ByteArray;
+import lime.utils.BytesUtil;
 import lime.utils.UInt8Array;
 
 #if (js && html5)
@@ -961,7 +962,7 @@ class Image {
 				
 			}
 			
-			return __base64Encoder.encodeBytes (Bytes.ofData (cast bytes.byteView)).toString () + extension;
+			return __base64Encoder.encodeBytes (Bytes.ofData (cast bytes.b)).toString () + extension;
 			
 		#else
 		
@@ -1081,7 +1082,7 @@ class Image {
 			
 			if (data != null) {
 				
-				__fromImageBuffer (new ImageBuffer (new UInt8Array (@:privateAccess new Bytes (data.data.length, data.data.b)), data.width, data.height, data.bitsPerPixel));
+				__fromImageBuffer (new ImageBuffer (BytesUtil.getUInt8ArrayFromAnonBytes (data.data), data.width, data.height, data.bitsPerPixel));
 				
 				if (onload != null) {
 					
@@ -1200,7 +1201,7 @@ class Image {
 				
 				if (data != null) {
 					
-					var u8a = new UInt8Array (@:privateAccess new Bytes (data.data.length, data.data.b));
+					var u8a = BytesUtil.getUInt8ArrayFromAnonBytes (data.data);
 					buffer = new ImageBuffer (u8a, data.width, data.height, data.bitsPerPixel);
 					
 				}

--- a/lime/graphics/format/JPEG.hx
+++ b/lime/graphics/format/JPEG.hx
@@ -7,6 +7,7 @@ import lime.graphics.Image;
 import lime.graphics.ImageBuffer;
 import lime.system.CFFI;
 import lime.utils.ByteArray;
+import lime.utils.BytesUtil;
 
 #if (js && html5)
 import js.Browser;
@@ -81,7 +82,7 @@ class JPEG {
 		#elseif (sys && (!disable_cffi || !format) && !macro)
 			
 			var data:Dynamic = lime_image_encode (image.buffer, 1, quality);
-			var bytes = @:privateAccess new Bytes (data.length, data.b);
+			var bytes = BytesUtil.createBytes (data.length, data.b);
 			return ByteArray.fromBytes (bytes);
 			
 		#elseif (js && html5)
@@ -100,7 +101,7 @@ class JPEG {
 			
 			for (i in 0...buffer.length) {
 				
-				byteArray.byteView[i] = buffer.charCodeAt (i);
+				byteArray.b[i] = buffer.charCodeAt (i);
 				
 			}
 			

--- a/lime/graphics/format/PNG.hx
+++ b/lime/graphics/format/PNG.hx
@@ -5,6 +5,7 @@ import haxe.io.Bytes;
 import lime.graphics.Image;
 import lime.system.CFFI;
 import lime.utils.ByteArray;
+import lime.utils.BytesUtil;
 
 #if (js && html5)
 import js.Browser;
@@ -89,7 +90,7 @@ class PNG {
 		if (CFFI.enabled) {
 			
 			var data:Dynamic = lime_image_encode (image.buffer, 0, 0);
-			var bytes = @:privateAccess new Bytes (data.length, data.b);
+			var bytes = BytesUtil.createBytes (data.length, data.b);
 			return ByteArray.fromBytes (bytes);
 			
 		}

--- a/lime/graphics/opengl/GL.hx
+++ b/lime/graphics/opengl/GL.hx
@@ -3,6 +3,7 @@ package lime.graphics.opengl;
 
 import lime.utils.ArrayBuffer;
 import lime.utils.ArrayBufferView;
+import lime.utils.BytesUtil;
 import lime.utils.Float32Array;
 import lime.utils.IMemoryRange;
 import lime.utils.Int32Array;
@@ -557,7 +558,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_buffer_data (target, data.buffer, data.byteOffset, data.byteLength, usage);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_buffer_data (target, data, data.byteOffset, data.byteLength, usage);
+		lime_gl_buffer_data (target, BytesUtil.getAnonBytesFromTypedArray (data), 0, data.byteLength, usage);
 		#elseif java
 		//GL15.glBufferData (target, data.buffer, data.byteOffset, data.byteLength, usage);
 		#end
@@ -572,7 +573,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_buffer_sub_data (target, offset, data.buffer, data.byteOffset, data.byteLength);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_buffer_sub_data (target, offset, data, data.byteOffset, data.byteLength);
+		lime_gl_buffer_sub_data (target, offset, BytesUtil.getAnonBytesFromTypedArray (data), 0, data.byteLength);
 		#elseif java
 		//GL15.glBufferSubData (target, offset, data.buffer, data.byteOffset, data.byteLength);
 		#end
@@ -681,7 +682,7 @@ class GL {
 		var buffer = data == null ? null : data.buffer;
 		lime_gl_compressed_tex_image_2d (target, level, internalformat, width, height, border, buffer, data == null ? 0 : data.byteOffset);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_compressed_tex_image_2d (target, level, internalformat, width, height, border, data == null ? null : data , data == null ? null : data.byteOffset);
+		lime_gl_compressed_tex_image_2d (target, level, internalformat, width, height, border, data == null ? null : BytesUtil.getAnonBytesFromTypedArray (data), 0);
 		#elseif java
 		//GL13.glCompressedTexImage2D (target, level, internalformat, width, height, border, data == null ? null : data.buffer, data == null ? null : data.byteOffset);
 		#end
@@ -697,7 +698,7 @@ class GL {
 		var buffer = data == null ? null : data.buffer;
 		lime_gl_compressed_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, buffer, data == null ? 0 : data.byteOffset);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_compressed_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, data == null ? null : data, data == null ? null : data.byteOffset);
+		lime_gl_compressed_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, data == null ? null : BytesUtil.getAnonBytesFromTypedArray (data), 0);
 		#elseif java
 		//GL13.glCompressedTexSubImage2D (target, level, xoffset, yoffset, width, height, format, data == null ? null : data.buffer, data == null ? null : data.byteOffset);
 		#end
@@ -1666,7 +1667,7 @@ class GL {
 		var buffer = pixels == null ? null : pixels.buffer;
 		lime_gl_read_pixels (x, y, width, height, format, type, buffer, pixels == null ? 0 : pixels.byteOffset);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_read_pixels (x, y, width, height, format, type, pixels == null ? null : pixels, pixels == null ? null : pixels.byteOffset);
+		lime_gl_read_pixels (x, y, width, height, format, type, pixels == null ? null : BytesUtil.getAnonBytesFromTypedArray (pixels), 0);
 		#end
 		
 	}
@@ -1790,7 +1791,7 @@ class GL {
 		var buffer = pixels == null ? null : pixels.buffer;
 		lime_gl_tex_image_2d (target, level, internalformat, width, height, border, format, type, buffer, pixels == null ? 0 : pixels.byteOffset);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_tex_image_2d (target, level, internalformat, width, height, border, format, type, pixels == null ? null : pixels, pixels == null ? null : pixels.byteOffset);
+		lime_gl_tex_image_2d (target, level, internalformat, width, height, border, format, type, pixels == null ? null : BytesUtil.getAnonBytesFromTypedArray (pixels), 0);
 		#end
 		
 	}
@@ -1826,7 +1827,7 @@ class GL {
 		var buffer = pixels == null ? null : pixels.buffer;
 		lime_gl_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, type, buffer, pixels == null ? 0 : pixels.byteOffset);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, type, pixels == null ? null : pixels, pixels == null ? null : pixels.byteOffset);
+		lime_gl_tex_sub_image_2d (target, level, xoffset, yoffset, width, height, format, type, pixels == null ? null : BytesUtil.getAnonBytesFromTypedArray (pixels), 0);
 		#end
 		
 	}
@@ -1874,7 +1875,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform1iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform1iv (location, v);
+		lime_gl_uniform1iv (location, BytesUtil.getAnonBytesFromTypedArray (v));
 		#end
 		
 	}
@@ -1898,7 +1899,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform2fv (location, v.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform2fv (location, v);
+		lime_gl_uniform2fv (location, BytesUtil.getAnonBytesFromTypedArray (v));
 		#end
 		
 	}
@@ -1922,7 +1923,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform2iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform2iv (location, v);
+		lime_gl_uniform2iv (location, BytesUtil.getAnonBytesFromTypedArray (v));
 		#end
 		
 	}
@@ -1946,7 +1947,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform3fv (location, v.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform3fv (location, v);
+		lime_gl_uniform3fv (location, BytesUtil.getAnonBytesFromTypedArray (v));
 		#end
 		
 	}
@@ -1970,7 +1971,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform3iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform3iv (location, v);
+		lime_gl_uniform3iv (location, BytesUtil.getAnonBytesFromTypedArray (v));
 		#end
 		
 	}
@@ -1994,7 +1995,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform4fv (location, v.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform4fv (location, v);
+		lime_gl_uniform4fv (location, BytesUtil.getAnonBytesFromTypedArray (v));
 		#end
 		
 	}
@@ -2018,7 +2019,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform4iv (location, v.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform4iv (location, v);
+		lime_gl_uniform4iv (location, BytesUtil.getAnonBytesFromTypedArray (v));
 		#end
 		
 	}
@@ -2031,7 +2032,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform_matrix (location, transpose, v.buffer, 2);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform_matrix (location, transpose, v, 2);
+		lime_gl_uniform_matrix (location, transpose, BytesUtil.getAnonBytesFromTypedArray (v), 2);
 		#end
 		
 	}
@@ -2044,7 +2045,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform_matrix (location, transpose, v.buffer, 3);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform_matrix (location, transpose, v, 3);
+		lime_gl_uniform_matrix (location, transpose, BytesUtil.getAnonBytesFromTypedArray (v), 3);
 		#end
 		
 	}
@@ -2057,7 +2058,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_uniform_matrix (location, transpose, v.buffer, 4);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_uniform_matrix (location, transpose, v, 4);
+		lime_gl_uniform_matrix (location, transpose, BytesUtil.getAnonBytesFromTypedArray (v), 4);
 		#end
 		
 	}
@@ -2110,7 +2111,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_vertex_attrib1fv (indx, values.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_vertex_attrib1fv (indx, values);
+		lime_gl_vertex_attrib1fv (indx, BytesUtil.getAnonBytesFromTypedArray (values));
 		#end
 		
 	}
@@ -2134,7 +2135,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_vertex_attrib2fv (indx, values.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_vertex_attrib2fv (indx, values);
+		lime_gl_vertex_attrib2fv (indx, BytesUtil.getAnonBytesFromTypedArray (values));
 		#end
 		
 	}
@@ -2158,7 +2159,7 @@ class GL {
 		#elseif ((cpp || neko) && lime_opengl && !macro)
 		lime_gl_vertex_attrib3fv (indx, values.buffer);
 		#elseif (nodejs && lime_opengl && !macro)
-		lime_gl_vertex_attrib3fv (indx, values);
+		lime_gl_vertex_attrib3fv (indx, BytesUtil.getAnonBytesFromTypedArray (values));
 		#end
 		
 	}

--- a/lime/net/URLLoader.hx
+++ b/lime/net/URLLoader.hx
@@ -4,6 +4,7 @@ package lime.net;
 import haxe.io.Bytes;
 import lime.app.Event;
 import lime.utils.ByteArray;
+import lime.utils.BytesUtil;
 
 #if (js && html5)
 import js.html.EventTarget;
@@ -390,7 +391,7 @@ class URLLoader {
 	}
 
 	private function readFunction(max:Int, input:ByteArray):Bytes {
-		return input;
+		return BytesUtil.getBytesFromByteArray (input);
 	}
 
 	#end

--- a/lime/net/curl/CURLEasy.hx
+++ b/lime/net/curl/CURLEasy.hx
@@ -3,6 +3,7 @@ package lime.net.curl;
 
 import haxe.io.Bytes;
 import lime.net.curl.CURL;
+import lime.utils.BytesUtil;
 
 #if !macro
 @:build(lime.system.CFFI.build())
@@ -163,7 +164,7 @@ class CURLEasy {
 		
 		if (output != null) {
 			
-			bytes = @:privateAccess new Bytes (output.length, output.b);
+			bytes = BytesUtil.createBytes (output.length, output.b);
 			
 		}
 		

--- a/lime/text/Font.hx
+++ b/lime/text/Font.hx
@@ -6,6 +6,7 @@ import lime.graphics.ImageBuffer;
 import lime.math.Vector2;
 import lime.system.System;
 import lime.utils.ByteArray;
+import lime.utils.BytesUtil;
 import lime.utils.UInt8Array;
 
 #if (js && html5)
@@ -172,11 +173,7 @@ class Font {
 			var data = new ByteArray (width * height);
 			bytes.readBytes (data, 0, width * height);
 			
-			#if js
-			var buffer = new ImageBuffer (data.byteView, width, height, 1);
-			#else
-			var buffer = new ImageBuffer (new UInt8Array (data), width, height, 1);
-			#end
+			var buffer = new ImageBuffer (BytesUtil.getUInt8ArrayFromByteArray (data), width, height, 1);
 			var image = new Image (buffer, 0, 0, width, height);
 			image.x = x;
 			image.y = y;
@@ -340,11 +337,7 @@ class Font {
 				
 			}
 			
-			#if js
-			buffer.data = data.byteView;
-			#else
-			buffer.data = new UInt8Array (data);
-			#end
+			buffer.data = BytesUtil.getUInt8ArrayFromByteArray (data);
 			
 			return map;
 			

--- a/lime/utils/AnonBytes.hx
+++ b/lime/utils/AnonBytes.hx
@@ -1,0 +1,6 @@
+package lime.utils;
+
+typedef AnonBytes = {
+	length:Int,
+	b:Dynamic
+}

--- a/lime/utils/BytesUtil.hx
+++ b/lime/utils/BytesUtil.hx
@@ -1,0 +1,74 @@
+package lime.utils;
+
+import haxe.io.Bytes;
+
+class BytesUtil
+{
+
+	public static function getAnonBytesFromByteArray (byteArray:ByteArray):AnonBytes {
+		
+		#if js
+		var u8a:UInt8Array = cast byteArray.b;
+		return {length:u8a.byteLength, b:u8a};
+		#else
+		return cast byteArray;
+		#end
+		
+	}
+	
+	public static function getAnonBytesFromTypedArray (array:ArrayBufferView):AnonBytes {
+		
+		#if js
+		return {length:array.byteLength, b:array};
+		#else
+		return cast array;
+		#end
+		
+	}
+	
+	public static function getBytesFromByteArray (byteArray:ByteArray):Bytes {
+		
+		#if js
+		var u8a:UInt8Array = cast byteArray.b;
+		return u8a.toBytes ();
+		#else
+		return byteArray;
+		#end
+		
+	}
+
+	public static function getUInt8ArrayFromByteArray (byteArray:ByteArray):UInt8Array {
+		
+		#if js
+		return byteArray.b;
+		#elseif flash
+		var u8a:UInt8Array = new UInt8Array (byteArray.length);
+		u8a.buffer.getData ().readBytes (byteArray);
+		return u8a;
+		#else
+		return new UInt8Array (byteArray);
+		#end
+		
+	}
+	
+	public static function getUInt8ArrayFromAnonBytes (ab:AnonBytes):UInt8Array {
+		
+		#if js
+		return ab.b;
+		#else
+		return new UInt8Array (@:privateAccess new Bytes (ab.length, ab.b));
+		#end
+		
+	}
+	
+	public static function createBytes (length:Int, b:Dynamic):Bytes {
+		
+		#if ((js && haxe < 3.2) || !js)
+		@:privateAccess return new Bytes (length, b);
+		#else
+		@:privateAccess return new Bytes (b);
+		#end
+		
+	}
+	
+}

--- a/lime/utils/Float32Array.hx
+++ b/lime/utils/Float32Array.hx
@@ -46,7 +46,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Float64Array.hx
+++ b/lime/utils/Float64Array.hx
@@ -46,7 +46,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Int16Array.hx
+++ b/lime/utils/Int16Array.hx
@@ -46,7 +46,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Int32Array.hx
+++ b/lime/utils/Int32Array.hx
@@ -46,7 +46,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/Int8Array.hx
+++ b/lime/utils/Int8Array.hx
@@ -44,7 +44,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/LZMA.hx
+++ b/lime/utils/LZMA.hx
@@ -15,7 +15,7 @@ class LZMA {
 		
 		#if ((cpp || neko || nodejs) && !macro)
 		var data:Dynamic = lime_lzma_decode (bytes);
-		return ByteArray.fromBytes (@:privateAccess new Bytes (data.length, data.b));
+		return ByteArray.fromBytes (BytesUtil.createBytes (data.length, data.b));
 		#else
 		return null;
 		#end
@@ -27,7 +27,7 @@ class LZMA {
 		
 		#if ((cpp || neko || nodejs) && !macro)
 		var data:Dynamic = lime_lzma_encode (bytes);
-		return ByteArray.fromBytes (@:privateAccess new Bytes (data.length, data.b));
+		return ByteArray.fromBytes (BytesUtil.createBytes (data.length, data.b));
 		#else
 		return null;
 		#end

--- a/lime/utils/UInt16Array.hx
+++ b/lime/utils/UInt16Array.hx
@@ -46,7 +46,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/UInt32Array.hx
+++ b/lime/utils/UInt32Array.hx
@@ -46,7 +46,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/UInt8Array.hx
+++ b/lime/utils/UInt8Array.hx
@@ -46,7 +46,9 @@ package lime.utils;
     }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast this) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/lime/utils/UInt8ClampedArray.hx
+++ b/lime/utils/UInt8ClampedArray.hx
@@ -46,7 +46,9 @@ package lime.utils;
         }
 
         public function toBytes() : haxe.io.Bytes {
-            #if (haxe_ver < 3.2)
+            #if nodejs
+            return @:privateAccess new haxe.io.Bytes( new js.node.buffer.Buffer(cast new js.html.Uint8Array(this.buffer, this.byteOffset, this.byteLength)) );
+            #elseif (haxe_ver < 3.2)
             return @:privateAccess new haxe.io.Bytes( this.byteLength, cast new js.html.Uint8Array(this.buffer) );
             #else
                 return @:privateAccess new haxe.io.Bytes( cast new js.html.Uint8Array(this.buffer) );

--- a/project/src/utils/Bytes.cpp
+++ b/project/src/utils/Bytes.cpp
@@ -1,5 +1,6 @@
 #include <system/System.h>
 #include <utils/Bytes.h>
+#include <hx/CFFIPrimePatch.h>
 
 
 namespace lime {
@@ -161,7 +162,12 @@ namespace lime {
 				
 				_value = alloc_empty_object ();
 				_root = alloc_root ();
-				*_root = _value;
+				
+				if (_root) {
+					
+					*_root = _value;
+					
+				}
 				
 			}
 			
@@ -233,7 +239,13 @@ namespace lime {
 			
 			_value = bytes;
 			_root = alloc_root ();
-			*_root = _value;
+			
+			if (_root) {
+				
+				*_root = _value;
+				
+			}
+			
 			_length = val_int (val_field (bytes, id_length));
 			
 			if (_length > 0) {
@@ -302,6 +314,36 @@ namespace lime {
 		}
 		
 	}
+	
+	
+	void lime_bytes_overwrite_file (HxString inFilename, value inBytes) {
+		
+		// file is created if it doesn't exist,
+		// if it exists, it is truncated to zero
+		FILE_HANDLE *file = lime::fopen (inFilename.__s, "wb");
+		
+		if (!file) {
+			
+			#ifdef ANDROID
+			// [todo]
+			#endif
+			
+		}
+		
+		Bytes bytes (inBytes);
+		
+		// The function fwrite() writes nitems objects, each size bytes long, to the
+		// stream pointed to by stream, obtaining them from the location given by
+		// ptr.
+		// fwrite(const void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream);
+		lime::fwrite (bytes.Data (), 1, bytes.Length (), file);
+		
+		lime::fclose (file);
+		
+	}
+	
+	
+	DEFINE_PRIME2v (lime_bytes_overwrite_file);
 	
 	
 }


### PR DESCRIPTION
 - Renames ByteArray.byteView to b, deprecating byteView
 - Switches to hxnodejs from nodejs

I renamed byteView to "b" because lime CFFI APIs can recognize ByteArrays without creating temporary Bytes objects in haxe side.
You can still access with older name(byteView) but it now generate deprecated warning.

Also, I switched nodejs library to hxnodejs because it's getting outdated. Official version was missing BytesInput and BytesBuffer that works on haxe 3.2, so I copied these from nodejs repo.
https://github.com/vroad/hxnodejs

From this commit, most samples from lime-samples starts working again on nodejs.
To be able to use Font/TextRendering we need further changes to lime APIs.