### PR TITLE
FIXES linker flags for RPi Debian Wheezy and Jessie

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -349,9 +349,9 @@
 			
 			<section if="rpi">
 				
-				<!-- <lib name="-lbcm_host" /> -->
-				<lib name="-ldl" />
+				<lib name="-lbcm_host" />
 				<lib name="-lm" />
+				<lib name="-L/opt/vc/lib" />
 				<lib name="-lGLESv2" />
 				<lib name="-lEGL" />
 				


### PR DESCRIPTION
Adds missing `-L/opt/vc/lib` and `-lbcm_host` linker flags that are needed for linking GLES on the Raspberry Pi running Debian Wheezy or Jessie.

Together with 2 extra defines in sdl/includes/config/rpi/sdl_config.h
`#define HAVE_LIBUDEV_H 1`
`#define SDL_VIDEO_DRIVER_RPI 1`

 this is the minimum requirement to be able to compile lime with gles2 and device input support on Raspberry Pi running Wheeze or Jessie
