### PR TITLE
Do not use Sys.exit on nodejs as it closes the app without cleanup

### DIFF
--- a/lime/_backend/native/NativeApplication.hx
+++ b/lime/_backend/native/NativeApplication.hx
@@ -108,12 +108,14 @@ class NativeApplication {
 			
 			if (!active) {
 				
-				var result = lime_application_quit (handle);
-				System.exit (result);
+				untyped process.exitCode = lime_application_quit (handle);
+				parent.onExit.dispatch (untyped process.exitCode);
+				
+			} else {
+				
+				untyped setImmediate (eventLoop);
 				
 			}
-			
-			untyped setImmediate (eventLoop);
 			
 		}
 		


### PR DESCRIPTION
On nodejs onExit event is not dispatched, and it's problematic to call ```Sys.exit()``` on nodejs because calling that will result in closing app without doing cleanup.