### PR TITLE
Legacy: Fixes virtual keyboard on BlackBerry

### DIFF
--- a/legacy/project/src/sdl/SDLStage.cpp
+++ b/legacy/project/src/sdl/SDLStage.cpp
@@ -652,6 +652,10 @@ public:
       
       if (enabled) {
          
+         //Sets the keyboard as a standard web layout with the default enter key
+         //More info: https://developer.blackberry.com/native/reference/core/com.qnx.doc.bps.lib_ref/topic/virtualkeyboard_change_options.html
+         virtualkeyboard_change_options(VIRTUALKEYBOARD_LAYOUT_WEB, VIRTUALKEYBOARD_ENTER_DEFAULT);
+         
          virtualkeyboard_show();
          
       } else {


### PR DESCRIPTION
If `virtualkeyboard_change_options()` is not called, whenever the user requests the virtual keyboard the last one used by the operating system will be displayed. For instance, if the user unlocks the phone (numeric layout), goes directly to a Lime / OpenFL application and requests the keyboard, the one displayed will be the numeric one.