### PR TITLE
FIX linker paths for raspberry pi

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -349,11 +349,11 @@
 			
 			<section if="rpi">
 				
-				<!-- <lib name="-lbcm_host" /> -->
-				<lib name="-ldl" />
+				<lib name="-lbcm_host" />
 				<lib name="-lm" />
 				<lib name="-lGLESv2" />
 				<lib name="-lEGL" />
+				<lib name="-L/opt/vc/lib" />
 				
 			</section>
 			


### PR DESCRIPTION
Adds linker flags to build.xml to enable compiling SDL with SDL_VIDEO_DRIVER_RPI
on Raspbian Wheezy and Jessie.

No raspberry pi specific changes in sdl-module in this pullrequest just yet.