### PR TITLE
Dropped flag for toggling bitcode on tvOS builds

### DIFF
--- a/lime/tools/platforms/TVOSPlatform.hx
+++ b/lime/tools/platforms/TVOSPlatform.hx
@@ -211,7 +211,6 @@ class TVOSPlatform extends PlatformTarget {
 			
 		}
 		
-		context.ENABLE_BITCODE = project.config.getBool ("tvos.enable-bitcode", true);
 		context.IOS_COMPILER = project.config.getString ("tvos.compiler", "clang");
 		context.CPP_BUILD_LIBRARY = project.config.getString ("cpp.buildLibrary", "hxcpp");
 		

--- a/templates/tvos/PROJ.xcodeproj/project.pbxproj
+++ b/templates/tvos/PROJ.xcodeproj/project.pbxproj
@@ -303,7 +303,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				ENABLE_BITCODE = ::if (ENABLE_BITCODE)::YES::else::NO::end::;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					::foreach frameworkSearchPaths:: "\"::__current__::\"",
@@ -356,7 +355,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				ENABLE_BITCODE = ::if (ENABLE_BITCODE)::YES::else::NO::end::;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					::foreach frameworkSearchPaths:: "\"::__current__::\"",


### PR DESCRIPTION
I had some issues getting the flag to be set at all. Plus, considering that apps compiled without it will not even run on the devices I can't see any reason for keeping it around.