### PR TITLE
Fix cross-compilation Halt on 64bit Machine

### DIFF
--- a/lime/tools/platforms/WindowsPlatform.hx
+++ b/lime/tools/platforms/WindowsPlatform.hx
@@ -133,6 +133,8 @@ class WindowsPlatform extends PlatformTarget {
 			var haxeArgs = [ hxml ];
 			var flags = [];
 			
+			flags.push ("-DHXCPP_M32");
+			
 			if (!project.environment.exists ("SHOW_CONSOLE")) {
 				
 				haxeArgs.push ("-D");


### PR DESCRIPTION
Recent Merge on Hxcpp may prevent 64bit machine users from compiling 32bit binary. Though the work around may be as easy adding compilation flag: -32.

Through this pull, OpenFl and Lime can now recover its usual compilation procedure.