### PR TITLE
Integrate gamepad API in lime Gamepad Support

### DIFF
--- a/js/html/GamepadEvent.hx
+++ b/js/html/GamepadEvent.hx
@@ -1,0 +1,14 @@
+package js.html;
+
+import js.html.Gamepad;
+
+@:native("GamepadEvent")
+extern class GamepadEvent extends Event
+{
+	var gamepad(default,null) : Gamepad;
+	var elapsedTime(default,null) : Float;
+	var pseudoElement(default,null) : String;
+	
+	/** @throws DOMError */
+	function new( type : String, ?eventInitDict : GamepadEventInit ) : Void;
+}

--- a/js/html/GamepadEventInit.hx
+++ b/js/html/GamepadEventInit.hx
@@ -1,0 +1,9 @@
+package js.html;
+
+import js.html.Gamepad;
+
+typedef GamepadEventInit =
+{
+	> EventInit,
+	@:optional var gamepad : Gamepad;
+}

--- a/lime/_backend/html5/HTML5Application.hx
+++ b/lime/_backend/html5/HTML5Application.hx
@@ -3,6 +3,7 @@ package lime._backend.html5;
 
 import js.html.KeyboardEvent;
 import js.Browser;
+import lime._backend.html5.HTML5GamepadManager;
 import lime.app.Application;
 import lime.app.Config;
 import lime.audio.AudioManager;
@@ -15,6 +16,8 @@ import lime.ui.Window;
 @:access(lime.app.Application)
 @:access(lime.graphics.Renderer)
 @:access(lime.ui.Window)
+@:access(lime._backend.html5.HTML5GamepadManager)
+
 
 
 class HTML5Application {
@@ -120,6 +123,8 @@ class HTML5Application {
 		Browser.window.addEventListener ("resize", handleWindowEvent, false);
 		Browser.window.addEventListener ("beforeunload", handleWindowEvent, false);
 		
+		HTML5GamepadManager.init();
+
 		#if stats
 		stats = untyped __js__("new Stats ()");
 		stats.domElement.style.position = "absolute";
@@ -212,6 +217,8 @@ class HTML5Application {
 			#if stats
 			stats.end ();
 			#end
+			
+			HTML5GamepadManager.update();
 			
 			if (framePeriod < 0) {
 				

--- a/lime/_backend/html5/HTML5GamepadManager.hx
+++ b/lime/_backend/html5/HTML5GamepadManager.hx
@@ -1,0 +1,199 @@
+package lime._backend.html5;#if (js && html5)
+
+import js.Browser;
+import js.html.GamepadEvent;
+import js.html.Navigator;
+import lime.ui.Gamepad;
+import lime.ui.GamepadButton;
+
+
+
+typedef LocalGamepadButton = {
+	var pressed: Bool;
+	var value: Float;
+}
+
+class LocalGamepad{
+	public var connected : Bool;
+	public var buttons : Array<LocalGamepadButton>;
+	public var axes : Array<Float>;
+	public var timestamp: Float;
+	
+	public function new()
+	{
+		connected = false;
+		buttons = new Array<LocalGamepadButton>();
+		axes = new Array<Float>();
+		timestamp = 0;
+	}
+	
+	public static function fromJSGamepad(gamepad:js.html.Gamepad):LocalGamepad
+	{
+		var newGamepad = new LocalGamepad();
+		newGamepad.timestamp = gamepad.timestamp;
+		newGamepad.connected = gamepad.connected;
+		
+		for (i in 0...gamepad.buttons.length)
+		{
+			newGamepad.buttons.push(normalizeJSButton(gamepad.buttons[i]));
+		}
+		
+		for (i in 0...gamepad.axes.length)
+		{
+			newGamepad.axes.push(gamepad.axes[i]);
+		}
+		
+		return newGamepad;
+	}
+	
+	public static function normalizeJSButton(button:Dynamic):LocalGamepadButton
+	{
+		if (untyped __js__("'pressed' in button")) {
+			return { pressed: button.pressed, value: button.value };
+		} else {
+			return { pressed: button == 1.0, value: button };
+		}
+	}
+}
+
+@:access(lime.ui.Gamepad)
+@:access(lime.app.Application)
+class HTML5GamepadManager {
+	private static inline var epsilon:Float = 0.00002;
+	private static var hasGamepadEvents:Bool;
+	
+	private static var _gamepads:Array<LocalGamepad>;
+
+	public static function init(){
+		hasGamepadEvents = untyped __js__("'GamepadEvent' in window");
+
+		_gamepads = new Array<LocalGamepad>();
+		
+		if (hasGamepadEvents){
+			Browser.window.addEventListener ("gamepadconnected", handleGamepadEvent, false);
+			Browser.window.addEventListener ("gamepaddisconnected", handleGamepadEvent, false);
+		}
+	}
+	
+	public static function update(){
+		var gamepads:Array<js.html.Gamepad> = getGamepads();
+		
+		for (gamepad in gamepads)
+		{
+			if (gamepad != null) {
+				addGamepad(gamepad);
+				updateGamepad(gamepad);
+			}
+		}
+	}
+	
+	private static function updateGamepad(gamepad:js.html.Gamepad):Void
+	{
+		if (!Gamepad.devices.exists(gamepad.index)) return;
+		
+		var limeGamepad = Gamepad.devices.get(gamepad.index);
+		var localGamepad = _gamepads[gamepad.index];
+		
+		for (idx in 0...gamepad.buttons.length) {
+			if (isButtonPressed(gamepad.buttons[idx])) {
+				
+				
+				if (!localGamepad.buttons[idx].pressed) {
+					limeGamepad.onButtonDown.dispatch(idx);
+				}
+				
+			} else {
+				
+				if (localGamepad.buttons[idx].pressed) {
+					limeGamepad.onButtonUp.dispatch(idx);
+				}
+				
+			}
+			
+			localGamepad.buttons[idx] = LocalGamepad.normalizeJSButton(gamepad.buttons[idx]);
+		}
+		
+		for (idx in 0...gamepad.axes.length) {
+			
+			if (Math.abs(gamepad.axes[idx] - localGamepad.axes[idx]) > epsilon) {
+				limeGamepad.onAxisMove.dispatch(idx, gamepad.axes[idx]);
+			}
+			
+			localGamepad.axes[idx] = gamepad.axes[idx];
+		}
+	}
+	
+	private static function isButtonPressed(button:Dynamic):Bool
+	{
+		if (untyped __js__("'pressed' in button")) {
+			return button.pressed;
+		} else {
+			return button == 1.0;
+		}
+	}
+	
+	private static function getButtonValue(button:Dynamic):Bool
+	{
+		if (untyped __js__("'value' in button")) {
+			return button.value;
+		} else {
+			return button;
+		}
+	}
+	
+	//TODO: Normalize buttons on add
+	
+	
+	private static function getGamepads():Array<js.html.Gamepad>
+	{
+		if (untyped __js__("navigator.getGamepads")) {
+			
+			return untyped navigator.getGamepads();
+			
+		} else if (untyped navigator.webkitGetGamepads) {
+			
+			return untyped navigator.webkitGetGamepads();
+			
+		} else {
+			
+			return new Array<js.html.Gamepad>();
+			
+		}
+	}
+
+	private static function handleGamepadEvent( event: GamepadEvent ):Void {
+
+		switch (event.type) {
+
+			case "gamepadconnected":
+				addGamepad(event.gamepad);
+
+			case "gamepaddisconnected":
+				removeGamepad(event.gamepad);
+
+		}
+	}
+
+	private static function addGamepad(gm:js.html.Gamepad):Void
+	{
+		if (!Gamepad.devices.exists(gm.index)) {
+
+			var gamepad = new Gamepad(gm.index);
+			Gamepad.devices.set( gm.index, gamepad);
+			Gamepad.onConnect.dispatch (gamepad);
+			_gamepads[gm.index] = LocalGamepad.fromJSGamepad(gm);
+
+		}
+	}
+
+	private static function removeGamepad(gm:js.html.Gamepad):Void
+	{
+		var gamepad = Gamepad.devices.get (gm.index);
+		if (gamepad != null) gamepad.connected = false;
+		Gamepad.devices.remove (gm.index);
+		_gamepads[gm.index] = null;
+		if (gamepad != null) gamepad.onDisconnect.dispatch();
+		
+	}
+}
+#end


### PR DESCRIPTION
Pool the gamepad updates on each game iteration and inject them in Lime's gamepad framework.

End up creating two externs for GamepadEvents missing from js haxe externs (chrome don't actually has an implementation of those events)
In the future, whenever haxe includes them, this can be removed.