### PR TITLE
Fix correct path to recover the usual behaviour of Lime during Windows Build

### DIFF
--- a/lime/tools/platforms/WindowsPlatform.hx
+++ b/lime/tools/platforms/WindowsPlatform.hx
@@ -260,7 +260,7 @@ class WindowsPlatform extends PlatformTarget {
 		} else if (project.target == PlatformHelper.hostPlatform) {
 			
 			arguments = arguments.concat ([ "-livereload" ]);
-			ProcessHelper.runCommand (applicationDirectory, Path.withoutDirectory (executablePath), arguments);
+			ProcessHelper.runCommand (applicationDirectory, "./" + Path.withoutDirectory (executablePath), arguments);
 			
 		}
 		


### PR DESCRIPTION
In Linux, 'lime build linux' automatically lets you see the compiled project by running it after build, in build windows this is not the case. 

Although WindowsPlatform.hx is programmed to do so, it does not happen due to typo.