### PR TITLE
Fill rect alpha (closes #631)

### DIFF
--- a/lime/graphics/utils/ImageCanvasUtil.hx
+++ b/lime/graphics/utils/ImageCanvasUtil.hx
@@ -203,7 +203,7 @@ class ImageCanvasUtil {
 			
 			if (image.transparent && ((color & 0xFF) == 0)) {
 				
-				image.buffer.__srcCanvas.width = image.buffer.width;
+				image.buffer.__srcCanvas.width = image.buffer.width; // force clear canvas
 				return;
 				
 			}
@@ -228,6 +228,8 @@ class ImageCanvasUtil {
 			
 		}
 		
+		// clear first to avoid blending
+		image.buffer.__srcContext.clearRect (rect.x + image.offsetX, rect.y + image.offsetY, rect.width + image.offsetX, rect.height + image.offsetY);
 		image.buffer.__srcContext.fillStyle = 'rgba(' + r + ', ' + g + ', ' + b + ', ' + (a / 255) + ')';
 		image.buffer.__srcContext.fillRect (rect.x + image.offsetX, rect.y + image.offsetY, rect.width + image.offsetX, rect.height + image.offsetY);
 		

--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -322,7 +322,7 @@ class ImageDataUtil {
 		var data = image.buffer.data;
 		if (data == null) return;
 		
-		#if (false && (cpp || neko) && !disable_cffi && !macro)
+		#if ((cpp || neko) && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_fill_rect (image, rect, (fillColor >> 16) & 0xFFFF, (fillColor) & 0xFFFF); else // TODO: Better Int32 solution
 		#end
 		{

--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -313,12 +313,6 @@ class ImageDataUtil {
 			
 		}
 		
-		if (!image.transparent) {
-			
-			fillColor.a = 0xFF;
-			
-		}
-		
 		var data = image.buffer.data;
 		if (data == null) return;
 		
@@ -331,7 +325,9 @@ class ImageDataUtil {
 			
 			var dataView = new ImageDataView (image, rect);
 			var row;
-			var pixel:RGBA;
+			
+			if (!image.transparent) fillColor.a = 0xFF;
+			if (premultiplied) fillColor.multiplyAlpha();
 			
 			for (y in 0...dataView.height) {
 				
@@ -339,8 +335,7 @@ class ImageDataUtil {
 				
 				for (x in 0...dataView.width) {
 					
-					pixel = fillColor; // use a copy of fillColor to prevent multiplyAlpha to override values
-					pixel.writeUInt8 (data, row + (x * 4), format, premultiplied);
+					fillColor.writeUInt8 (data, row + (x * 4), format, false);
 					
 				}
 				

--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -322,16 +322,16 @@ class ImageDataUtil {
 		var data = image.buffer.data;
 		if (data == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (false && (cpp || neko) && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_fill_rect (image, rect, (fillColor >> 16) & 0xFFFF, (fillColor) & 0xFFFF); else // TODO: Better Int32 solution
 		#end
 		{
-			
 			var format = image.buffer.format;
 			var premultiplied = image.buffer.premultiplied;
 			
 			var dataView = new ImageDataView (image, rect);
 			var row;
+			var pixel:RGBA;
 			
 			for (y in 0...dataView.height) {
 				
@@ -339,7 +339,8 @@ class ImageDataUtil {
 				
 				for (x in 0...dataView.width) {
 					
-					fillColor.writeUInt8 (data, row + (x * 4), format, premultiplied);
+					pixel = fillColor; // use a copy of fillColor to prevent multiplyAlpha to override values
+					pixel.writeUInt8 (data, row + (x * 4), format, premultiplied);
 					
 				}
 				

--- a/project/src/graphics/utils/ImageDataUtil.cpp
+++ b/project/src/graphics/utils/ImageDataUtil.cpp
@@ -251,7 +251,13 @@ namespace lime {
 		
 		ImageDataView dataView = ImageDataView (image, rect);
 		int row;
-		RGBA fillColor (color);
+		RGBA fillColor (color), pixel;
+		
+		if (!image.transparent) {
+			
+			fillColor.a = 0xFF;
+			
+		}
 		
 		for (int y = 0; y < dataView.height; y++) {
 			
@@ -259,7 +265,8 @@ namespace lime {
 			
 			for (int x = 0; x < dataView.width; x++) {
 				
-				fillColor.WriteUInt8 (data, row + (x * 4), format, premultiplied);
+				pixel = fillColor; // use a copy of fillColor to prevent multiplyAlpha() to override values
+				pixel.WriteUInt8 (data, row + (x * 4), format, premultiplied);
 				
 			}
 			

--- a/project/src/graphics/utils/ImageDataUtil.cpp
+++ b/project/src/graphics/utils/ImageDataUtil.cpp
@@ -251,13 +251,10 @@ namespace lime {
 		
 		ImageDataView dataView = ImageDataView (image, rect);
 		int row;
-		RGBA fillColor (color), pixel;
+		RGBA fillColor (color);
 		
-		if (!image.transparent) {
-			
-			fillColor.a = 0xFF;
-			
-		}
+		if (!image->buffer->transparent) fillColor.a = 0xFF;
+		if (premultiplied) fillColor.MultiplyAlpha ();
 		
 		for (int y = 0; y < dataView.height; y++) {
 			
@@ -265,8 +262,7 @@ namespace lime {
 			
 			for (int x = 0; x < dataView.width; x++) {
 				
-				pixel = fillColor; // use a copy of fillColor to prevent multiplyAlpha() to override values
-				pixel.WriteUInt8 (data, row + (x * 4), format, premultiplied);
+				fillColor.WriteUInt8 (data, row + (x * 4), format, false);
 				
 			}
 			


### PR DESCRIPTION
This PR fixes fillRect() by taking care of the alpha value in the `color` parameter. Specifically:
- clears the rect before drawing it in html5 (otherwise blending would be applied)
- uses multiplyAlpha once on fillColor (which also prevents the overriding of values caused by RGBA.multiply)
- similar code for both cpp and pure hx

see https://github.com/openfl/lime/issues/631
