### PR TITLE
Fix copyPixels w/ alpha

### DIFF
--- a/lime/graphics/utils/ImageCanvasUtil.hx
+++ b/lime/graphics/utils/ImageCanvasUtil.hx
@@ -92,14 +92,43 @@ class ImageCanvasUtil {
 	
 	public static function copyPixels (image:Image, sourceImage:Image, sourceRect:Rectangle, destPoint:Vector2, alphaImage:Image = null, alphaPoint:Vector2 = null, mergeAlpha:Bool = false):Void {
 		
-		convertToCanvas (sourceImage);
-		createImageData (sourceImage);
-		if (alphaImage != null && alphaImage.transparent) {
-			convertToCanvas (alphaImage);
-			createImageData (alphaImage);
+		if (destPoint == null || destPoint.x >= image.width || destPoint.y >= image.height || sourceRect == null || sourceRect.width < 1 || sourceRect.height < 1) {
+			
+			return;
+			
 		}
 		
-		ImageDataUtil.copyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
+		if (alphaImage != null && alphaImage.transparent) {
+			
+			if (alphaPoint == null) alphaPoint = new Vector2 ();
+			
+			// TODO: use faster method
+			
+			var tempData = image.clone ();
+			tempData.copyChannel (alphaImage, new Rectangle (alphaPoint.x, alphaPoint.y, sourceRect.width, sourceRect.height), new Vector2 (sourceRect.x, sourceRect.y), ImageChannel.ALPHA, ImageChannel.ALPHA);
+			sourceImage = tempData;
+			
+		}
+		
+		sync (image, true);
+		
+		if (!mergeAlpha) {
+			
+			if (image.transparent && sourceImage.transparent) {
+				
+				image.buffer.__srcContext.clearRect (destPoint.x + image.offsetX, destPoint.y + image.offsetY, sourceRect.width + image.offsetX, sourceRect.height + image.offsetY);
+				
+			}
+			
+		}
+		
+		sync (sourceImage, false);
+		
+		if (sourceImage.buffer.src != null) {
+			
+			image.buffer.__srcContext.drawImage (sourceImage.buffer.src, Std.int (sourceRect.x + sourceImage.offsetX), Std.int (sourceRect.y + sourceImage.offsetY), Std.int (sourceRect.width), Std.int (sourceRect.height), Std.int (destPoint.x + image.offsetX), Std.int (destPoint.y + image.offsetY), Std.int (sourceRect.width), Std.int (sourceRect.height));
+			
+		}
 		
 	}
 	

--- a/lime/graphics/utils/ImageCanvasUtil.hx
+++ b/lime/graphics/utils/ImageCanvasUtil.hx
@@ -92,43 +92,14 @@ class ImageCanvasUtil {
 	
 	public static function copyPixels (image:Image, sourceImage:Image, sourceRect:Rectangle, destPoint:Vector2, alphaImage:Image = null, alphaPoint:Vector2 = null, mergeAlpha:Bool = false):Void {
 		
-		if (destPoint == null || destPoint.x >= image.width || destPoint.y >= image.height || sourceRect == null || sourceRect.width < 1 || sourceRect.height < 1) {
-			
-			return;
-			
-		}
-		
+		convertToCanvas (sourceImage);
+		createImageData (sourceImage);
 		if (alphaImage != null && alphaImage.transparent) {
-			
-			if (alphaPoint == null) alphaPoint = new Vector2 ();
-			
-			// TODO: use faster method
-			
-			var tempData = image.clone ();
-			tempData.copyChannel (alphaImage, new Rectangle (alphaPoint.x, alphaPoint.y, sourceRect.width, sourceRect.height), new Vector2 (sourceRect.x, sourceRect.y), ImageChannel.ALPHA, ImageChannel.ALPHA);
-			sourceImage = tempData;
-			
+			convertToCanvas (alphaImage);
+			createImageData (alphaImage);
 		}
 		
-		sync (image, true);
-		
-		if (!mergeAlpha) {
-			
-			if (image.transparent && sourceImage.transparent) {
-				
-				image.buffer.__srcContext.clearRect (destPoint.x + image.offsetX, destPoint.y + image.offsetY, sourceRect.width + image.offsetX, sourceRect.height + image.offsetY);
-				
-			}
-			
-		}
-		
-		sync (sourceImage, false);
-		
-		if (sourceImage.buffer.src != null) {
-			
-			image.buffer.__srcContext.drawImage (sourceImage.buffer.src, Std.int (sourceRect.x + sourceImage.offsetX), Std.int (sourceRect.y + sourceImage.offsetY), Std.int (sourceRect.width), Std.int (sourceRect.height), Std.int (destPoint.x + image.offsetX), Std.int (destPoint.y + image.offsetY), Std.int (sourceRect.width), Std.int (sourceRect.height));
-			
-		}
+		ImageDataUtil.copyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
 		
 	}
 	

--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -205,8 +205,9 @@ class ImageDataUtil {
 			var needsMultiplyAlpha = alphaImage != null && alphaImage.transparent;
 			var needsBlending = mergeAlpha || (needsMultiplyAlpha && !image.transparent);
 			
-			var alphaData, alphaFormat, alphaPremultiplied, alphaView;
-			var alphaPosition, alphaPixel:RGBA;
+			// TODO: it should be safe to remove these initialiazitions when transitioning to haxe 3.3.0+
+			var alphaData = null, alphaFormat = 0, alphaPremultiplied = false, alphaView = null;
+			var alphaPosition = 0, alphaPixel:RGBA;
 			
 			if (needsMultiplyAlpha) {
 				

--- a/project/src/graphics/utils/ImageDataUtil.cpp
+++ b/project/src/graphics/utils/ImageDataUtil.cpp
@@ -150,17 +150,18 @@ namespace lime {
 		ImageDataView* alphaView = NULL;
 		int alphaPosition;
 		RGBA alphaPixel;
+		Vector2 zeroVec;
 		
 		if (alphaImage != NULL) {
 			
-			if (alphaPoint == NULL) alphaPoint = new Vector2 ();
+			if (alphaPoint == NULL) alphaPoint = &zeroVec;
 			
 			alphaData = (uint8_t*)alphaImage->buffer->data->Data ();
 			alphaFormat = alphaImage->buffer->format;
 			alphaPremultiplied = alphaImage->buffer->premultiplied;
 			
 			Rectangle alphaRect = Rectangle (alphaPoint->x, alphaPoint->y, destView.width, destView.height);
-			alphaView = &ImageDataView (alphaImage, &alphaRect);
+			alphaView = new ImageDataView (alphaImage, &alphaRect);
 		}	
 		
 		bool needsMultiplyAlpha = alphaImage != NULL && alphaImage->buffer->transparent;
@@ -195,6 +196,8 @@ namespace lime {
 			}
 			
 		}
+		
+		if (alphaView != NULL) delete alphaView;
 		
 	}
 	


### PR DESCRIPTION
This PR attempts to make copyPixels() behave like flash on all targets (currently 99% similar, due to off-by-one values in some cases).
- [cffi] I've gone with a readable impl., as moving the ifs outside and using different loops didn't seem to bring significant performance improvements (maybe branch prediction at work?!)
- [html] now uses the pure haxe non-cffi copyPixels(), after creating buffers (canvas/data) for source and alpha images

ref: https://github.com/openfl/openfl/issues/910

tested with https://gist.github.com/azrafe7/85e3cf486ffe23b13102

![after](https://cloud.githubusercontent.com/assets/1266447/11412987/0c55f7a6-93e4-11e5-89b1-4ce43c5bd07e.gif)

Additional notes:
- in my benchmarks flash is still slighly faster than cffi (0.001s vs 0.003s)
- probably html5 could be improved as actually relies on convertToCanvas/createImageData (but it's already around 0.006s)
- although my tests are passing mind that they're programmatically created BitmapDatas, so it might be wise to test further using actual pngs
- also this needs the other PR about fillRect alpha to behave _better_ (you can spot a difference in `neko with transparent ON`)
