### PR TITLE
formatUppercaseVariable() shouldn't mess up already-uppercase strings.

### DIFF
--- a/lime/tools/helpers/StringHelper.hx
+++ b/lime/tools/helpers/StringHelper.hx
@@ -92,6 +92,7 @@ class StringHelper {
 		var isAlpha = ~/[A-Z0-9]/i;
 		var variableName = "";
 		var lastWasUpperCase = false;
+		var lastWasAlpha = true;
 		
 		for (i in 0...name.length) {
 			
@@ -101,6 +102,7 @@ class StringHelper {
 				
 				variableName += "_";
 				lastWasUpperCase = false;
+				lastWasAlpha = false;
 				
 			} else {
 				
@@ -118,9 +120,13 @@ class StringHelper {
 							
 						}
 						
-					} else {
+					} else if (lastWasAlpha) {
 						
 						variableName += "_" + char;
+						
+					} else {
+						
+						variableName += char;
 						
 					}
 					
@@ -129,9 +135,11 @@ class StringHelper {
 				} else {
 					
 					variableName += char.toUpperCase ();
-					lastWasUpperCase = false;
+					lastWasUpperCase = i == 0 && char == char.toUpperCase ();
 					
 				}
+				
+				lastWasAlpha = true;
 				
 			}
 			


### PR DESCRIPTION
If you look at the template context generated by OpenFL, you notice a bunch of odd names for variables:

    SET_H_OMEDRIVE
    SET_P_ROCESSOR__IDENTIFIER
    SET_P_ROCESSOR__REVISION
    SET_L_OCALAPPDATA
    SET_N_EKO__INSTPATH

...and so on.

These odd names are caused by taking an already-uppercase string and running it through `formatUppercaseVariable()`. For instance, if you run `formatUppercaseVariable("NEKO_INSTPATH")`, it adds an underscore after the first letter and another after the existing underscore, giving "`N_EKO__INSTPATH`."

This pull request fixes both bugs.