### PR TITLE
add "fullscreenHotkey" to project.xml window config

### DIFF
--- a/lime/app/Config.hx
+++ b/lime/app/Config.hx
@@ -30,6 +30,7 @@ typedef WindowConfig = {
 	@:optional var element:#if (haxe_ver >= "3.2") js.html.Element #else js.html.HtmlElement #end;
 	#end
 	@:optional var fullscreen:Bool;
+	@:optional var fullscreenHotkey:Bool;
 	@:optional var hardware:Bool;
 	@:optional var height:Int;
 	@:optional var parameters:String;

--- a/lime/project/HXProject.hx
+++ b/lime/project/HXProject.hx
@@ -118,7 +118,7 @@ class HXProject {
 		
 		defaultMeta = { title: "MyApplication", description: "", packageName: "com.example.myapp", version: "1.0.0", company: "Example, Inc.", companyUrl: "", buildNumber: "1", companyId: "" }
 		defaultApp = { main: "Main", file: "MyApplication", path: "bin", preloader: "", swfVersion: 11.2, url: "", init: null }
-		defaultWindow = { width: 800, height: 600, parameters: "{}", background: 0xFFFFFF, fps: 30, hardware: true, display: 0, resizable: true, borderless: false, orientation: Orientation.AUTO, vsync: false, fullscreen: false, antialiasing: 0, allowShaders: true, requireShaders: false, depthBuffer: false, stencilBuffer: false }
+		defaultWindow = { width: 800, height: 600, parameters: "{}", background: 0xFFFFFF, fps: 30, hardware: true, display: 0, resizable: true, borderless: false, orientation: Orientation.AUTO, vsync: false, fullscreen: false, fullscreenHotkey: true, antialiasing: 0, allowShaders: true, requireShaders: false, depthBuffer: false, stencilBuffer: false }
 		
 		platformType = PlatformType.DESKTOP;
 		architectures = [];
@@ -198,7 +198,8 @@ class HXProject {
 		
 		meta = ObjectHelper.copyFields (defaultMeta, {});
 		app = ObjectHelper.copyFields (defaultApp, {});
-		window = ObjectHelper.copyFields (defaultWindow, {});
+		window = ObjectHelper.copyFields (defaultWindow, { } );
+		
 		windows = [ window ];
 		assets = new Array <Asset> ();
 		defines = new Map <String, Dynamic> ();

--- a/lime/project/WindowData.hx
+++ b/lime/project/WindowData.hx
@@ -16,6 +16,7 @@ typedef WindowData = {
 	@:optional var borderless:Bool;
 	@:optional var vsync:Bool;
 	@:optional var fullscreen:Bool;
+	@:optional var fullscreenHotkey:Bool;
 	@:optional var antialiasing:Int;
 	@:optional var orientation:Orientation;
 	@:optional var allowShaders:Bool;

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -83,6 +83,7 @@ class ApplicationMain {
 					depthBuffer: ::depthBuffer::,
 					display: ::display::,
 					fullscreen: ::fullscreen::,
+					fullscreenHotkey: ::fullscreenHotkey::,
 					hardware: ::hardware::,
 					height: ::height::,
 					parameters: "::parameters::",


### PR DESCRIPTION
default value is true, if true, alt+enter for windows/linux (and ctrl+meta+F for mac) will fullscreen the app. If false, it will not when such keystrokes are pressed.

the config value is "fullscreenHotkey", and the value in xml is "fullscreen-hotkey"

I'm not particularly attached to the names/style, just the functionality.