### PR TITLE
Fixes Icon Issue on Neko Cross Compile Linux to Windows, fix openfl/lime#626

### DIFF
--- a/lime/tools/helpers/NekoHelper.hx
+++ b/lime/tools/helpers/NekoHelper.hx
@@ -6,6 +6,7 @@ import sys.io.File;
 import lime.tools.helpers.PlatformHelper;
 import lime.project.Platform;
 
+
 class NekoHelper {
 	
 	

--- a/lime/tools/helpers/NekoHelper.hx
+++ b/lime/tools/helpers/NekoHelper.hx
@@ -43,7 +43,7 @@ class NekoHelper {
 		output.write (executable);
 		output.close ();
 		
-		if (iconPath != null  && PlatformHelper.hostPlatform == Platform.WINDOWS) {
+		if (iconPath != null && PlatformHelper.hostPlatform == Platform.WINDOWS) {
 			
 			var templates = [ PathHelper.getHaxelib (new Haxelib ("lime")) + "/templates" ].concat (templatePaths);
 			ProcessHelper.runCommand ("", PathHelper.findTemplate (templates, "bin/ReplaceVistaIcon.exe"), [ target, iconPath, "1" ], true, true);

--- a/lime/tools/helpers/NekoHelper.hx
+++ b/lime/tools/helpers/NekoHelper.hx
@@ -3,7 +3,8 @@ package lime.tools.helpers;
 
 import lime.project.Haxelib;
 import sys.io.File;
-
+import lime.tools.helpers.PlatformHelper;
+import lime.project.Platform;
 
 class NekoHelper {
 	
@@ -41,7 +42,7 @@ class NekoHelper {
 		output.write (executable);
 		output.close ();
 		
-		if (iconPath != null) {
+		if (iconPath != null  && PlatformHelper.hostPlatform == Platform.WINDOWS) {
 			
 			var templates = [ PathHelper.getHaxelib (new Haxelib ("lime")) + "/templates" ].concat (templatePaths);
 			ProcessHelper.runCommand ("", PathHelper.findTemplate (templates, "bin/ReplaceVistaIcon.exe"), [ target, iconPath, "1" ], true, true);


### PR DESCRIPTION
During Cross-Compile from Linux to Windows, Neko Compilation chain will normally call into ReplaceVistaIcon.exe, unfortunately, EXE files are not native applications of NON-Windows systems, thus a permission issue occurs.

By indicating to the Source Code that ReplaceVistaIcon.exe be called only when it detected Windows systems through 

    PlatformHelper.hostPlatform == Platform.WINDOWS

The issue is fixed.