### PR TITLE
Cleaning up leaked references in JNI caused by function arguments

### DIFF
--- a/project/src/system/JNI.cpp
+++ b/project/src/system/JNI.cpp
@@ -1715,6 +1715,7 @@ namespace lime {
 		value CallStatic (value inArgs) {
 			
 			JNIEnv *env = (JNIEnv*)JNI::GetEnv ();
+			env->PushLocalFrame(128);
 			jvalue jargs[MAX];
 			
 			if (!HaxeToJNIArgs (env, inArgs, jargs)) {
@@ -1792,6 +1793,7 @@ namespace lime {
 			
 			CleanStringArgs ();
 			CheckException (env);
+			env->PopLocalFrame(NULL);
 			return result;
 			
 		}


### PR DESCRIPTION
This is related to Android Extensions.

It looks like HaxeToJNIArgs creates some references that need to be cleaned up. Pushing and Popping a local frame seems to fix this. This fix is only for CallStatic(...) and it is very possible a similar issue exists with the other JNI functions.

Without this fix, after 512 arguments passed into CallStatic, the app will crash. 

Fix for: https://github.com/openfl/lime/issues/644