### PR TITLE
Expose display device DPI

### DIFF
--- a/lime/system/Display.hx
+++ b/lime/system/Display.hx
@@ -20,6 +20,11 @@ class Display {
 	public var id (default, null):Int;
 	
 	/**
+	 * Pixel density of the display
+	 */
+	public var dpi (default, null): { diagonal:Float, horizontal:Float, vertical:Float };
+	
+	/**
 	 * The name of the device, such as "Samsung SyncMaster P2350", "iPhone 6", "Occulus Rift DK2", etc.
 	 **/
 	public var name (default, null):String;

--- a/lime/system/System.hx
+++ b/lime/system/System.hx
@@ -163,6 +163,19 @@ class System {
 			}
 			
 			display.currentMode = display.supportedModes[displayInfo.currentMode];
+			
+			var dpi:Dynamic = lime_system_get_display_dpi (id);
+			
+			if (dpi != null) {
+				
+				display.dpi = { vertical:0, horizontal:0, diagonal:0 };
+				
+				display.dpi.vertical   = dpi.vertical;
+				display.dpi.horizontal = dpi.horizontal;
+				display.dpi.diagonal   = dpi.diagonal;
+				
+			}
+			
 			return display;
 			
 		}
@@ -421,6 +434,7 @@ class System {
 	@:cffi private static function lime_system_set_allow_screen_timeout (value:Bool):Bool;
 	@:cffi private static function lime_system_get_directory (type:Int, company:String, title:String):Dynamic;
 	@:cffi private static function lime_system_get_display (index:Int):Dynamic;
+	@:cffi private static function lime_system_get_display_dpi (index:Int):Dynamic;
 	@:cffi private static function lime_system_get_num_displays ():Int;
 	@:cffi private static function lime_system_get_timer ():Float;
 	#end

--- a/project/include/system/System.h
+++ b/project/include/system/System.h
@@ -28,6 +28,7 @@ namespace lime {
 			static bool GetAllowScreenTimeout ();
 			static const char* GetDirectory (SystemDirectory type, const char* company, const char* title);
 			static value GetDisplay (int id);
+			static value GetDisplayDPI (int id);
 			static int GetNumDisplays ();
 			static double GetTimer ();
 			static bool SetAllowScreenTimeout (bool allow);

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -1160,6 +1160,12 @@ namespace lime {
 	}
 	
 	
+	value lime_system_get_display_dpi (int id) {
+		
+		return System::GetDisplayDPI (id);
+		
+	}
+	
 	int lime_system_get_num_displays () {
 		
 		return System::GetNumDisplays ();
@@ -1512,6 +1518,7 @@ namespace lime {
 	DEFINE_PRIME0 (lime_system_get_allow_screen_timeout);
 	DEFINE_PRIME3 (lime_system_get_directory);
 	DEFINE_PRIME1 (lime_system_get_display);
+	DEFINE_PRIME1 (lime_system_get_display_dpi);
 	DEFINE_PRIME0 (lime_system_get_num_displays);
 	DEFINE_PRIME0 (lime_system_get_timer);
 	DEFINE_PRIME1 (lime_system_set_allow_screen_timeout);

--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -304,6 +304,27 @@ namespace lime {
 		
 	}
 	
+	value System::GetDisplayDPI (int id) {
+		
+		value dpi = alloc_empty_object ();
+		
+		int id_diagonal   = val_id ("diagonal");
+		int id_horizontal = val_id ("horizontal");
+		int id_vertical   = val_id ("vertical");
+		
+		float ddpi = 0.0;
+		float hdpi = 0.0;
+		float vdpi = 0.0;
+		
+		SDL_GetDisplayDPI (id, &ddpi, &hdpi, &vdpi);
+		
+		alloc_field (dpi, id_diagonal  , alloc_float (ddpi));
+		alloc_field (dpi, id_horizontal, alloc_float (hdpi));
+		alloc_field (dpi, id_vertical  , alloc_float (vdpi));
+		
+		return dpi;
+		
+	}
 	
 	int System::GetNumDisplays () {
 		


### PR DESCRIPTION
This seems like it would be useful for various platforms.

Unfortunately, it doesn't seem to be aware of display scaling in win8/10 -- it just returns "96" for everything on my system regardless of display scale. But perhaps it will work nicely on other platforms until we can figure out what's going on with Win8/10.