### PR TITLE
Renderer.readPixels fix

### DIFF
--- a/project/src/backend/sdl/SDLRenderer.cpp
+++ b/project/src/backend/sdl/SDLRenderer.cpp
@@ -217,6 +217,10 @@ namespace lime {
 			
 			SDL_RenderReadPixels (sdlRenderer, &bounds, SDL_PIXELFORMAT_ABGR8888, buffer->data->Data (), buffer->Stride ());
 			
+			for (unsigned char *it=buffer->data->Data()+3; it<(buffer->data->Data()+buffer->data->Length());it+=4) {
+				*it = 0xff;
+			}
+
 		}
 		
 	}


### PR DESCRIPTION
On cpp, readPixels returns an image with alpha=0. Can be tested with:
```haxe
package;

import flash.display.Bitmap;
import flash.display.BitmapData;
import flash.events.MouseEvent;
import flash.Lib;
import lime.app.Application;
import lime.math.ColorMatrix;
import lime.math.Rectangle;
import openfl.display.Sprite;
import openfl.events.Event;

class Main extends Sprite {

	public function new () {
		super ();
		var gfx = this.graphics;
		gfx.beginFill(0xff0000);
		gfx.drawCircle(Lib.current.stage.stageWidth/2, Lib.current.stage.stageHeight/2, 200);
		gfx.endFill();
		addEventListener(MouseEvent.MOUSE_DOWN, readPixels);
		addEventListener(Event.ADDED_TO_STAGE, readPixels);
	}

	function readPixels (_) {
		var img = Application.current.renderer.readPixels();
		var spr = new Sprite();
		spr.scaleX = spr.scaleY = 0.5;
		/*
		var mat = new ColorMatrix();
		mat.alphaOffset = 256.0;
		img.colorTransform(new Rectangle(0, 0, img.width, img.height), mat);
		*/
		spr.addChild(new Bitmap(BitmapData.fromImage(img)));
		addChild(spr);
	}

}
```

Without this fix the commented code is necessary for this test to work correctly.
This code set all alpha bytes of the resulting image to 255.