### PR TITLE
Allow modification of project config in the command line

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1352,6 +1352,10 @@ class CommandLineTools {
 				
 				project.templatePaths.push (projectDefines.get (key));
 				
+			} else if (field == "config") {
+
+				project.config.set (attribute, projectDefines.get (key));
+
 			} else {
 				
 				if (Reflect.hasField (project, field)) {


### PR DESCRIPTION
To modify the project config through the command line,
for instance `lime build linux --config-cpp.requireBuild=false`,
doesn't work with Reflect.setField since it doesn't do it recursively on the `.` like config.set,
so this add a special case to make it work.