### PR TITLE
Conversion issue that prevent openfl webgl rendering

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -240,6 +240,7 @@ class Image {
 				
 				#if (js && html5)
 				ImageCanvasUtil.convertToData (this);
+				ImageCanvasUtil.convertToData (sourceImage);
 				#end
 				
 				ImageDataUtil.copyChannel (this, sourceImage, sourceRect, destPoint, sourceChannel, destChannel);

--- a/lime/graphics/utils/ImageCanvasUtil.hx
+++ b/lime/graphics/utils/ImageCanvasUtil.hx
@@ -50,7 +50,8 @@ class ImageCanvasUtil {
 			
 			createCanvas (image, buffer.width, buffer.height);
 			createImageData (image);
-			
+			buffer.__srcContext.putImageData (buffer.__srcImageData, 0, 0);
+
 		} else if (buffer.data == null && buffer.__srcImageData != null) {
 			
 			buffer.data = cast buffer.__srcImageData.data;


### PR DESCRIPTION
This MR contains 2 small fixes that prevented correct webgl rendering in openfl 

- The conversion of image to canvas was missing a data copy. Then all canvas rendered images (swf shapes with bitmap fill,...) were empty
- Image.copyChannel was not converting the source to data. In openfl, all transparent images are composed as jpg+ alpha in png. All loaded images would then be opaque, black in transparent area