### PR TITLE
Fix system dir string leak

### DIFF
--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -988,7 +988,14 @@ namespace lime {
 	value lime_system_get_directory (int type, HxString company, HxString title) {
 		
 		const char* path = System::GetDirectory ((SystemDirectory)type, company.__s, title.__s);
-		return path ? alloc_string (path) : alloc_null ();
+
+        if (path) {
+            value dirPath = alloc_string(path);
+            free((char *)dirPath);
+            return dirPath;
+        } else {
+            return alloc_null();
+        }
 		
 	}
 	


### PR DESCRIPTION
We noticed a memory leak in iOS when getting the system application directory. The underlying string is never freed.

I'm not sure if this is the best place for this, but it does fix the leak. Happy to discuss alternatives since it seems like it should be closer to `alloc_string`

@jgranick 