### PR TITLE
Allow use of HAXELIB_PATH within Xcode environment

### DIFF
--- a/lime/tools/platforms/IOSPlatform.hx
+++ b/lime/tools/platforms/IOSPlatform.hx
@@ -314,8 +314,15 @@ class IOSPlatform extends PlatformTarget {
 		
 		//updateIcon ();
 		//updateLaunchImage ();
-		
-		return context;
+
+        var customHaxelib = Sys.getEnv("HAXELIB_PATH");
+        if (customHaxelib != null) {
+            context.CUSTOM_HAXELIB_PATH = 'export HAXELIB_PATH=$customHaxelib;';
+        } else {
+            context.CUSTOM_HAXELIB_PATH = '';
+        }
+
+        return context;
 		
 	}
 	

--- a/lime/tools/platforms/TVOSPlatform.hx
+++ b/lime/tools/platforms/TVOSPlatform.hx
@@ -298,6 +298,13 @@ class TVOSPlatform extends PlatformTarget {
 		
 		//updateIcon ();
 		//updateLaunchImage ();
+
+        var customHaxelib = Sys.getEnv("HAXELIB_PATH");
+        if (customHaxelib != null) {
+            context.CUSTOM_HAXELIB_PATH = 'export HAXELIB_PATH=$customHaxelib;';
+        } else {
+            context.CUSTOM_HAXELIB_PATH = '';
+        }
 		
 		return context;
 		

--- a/templates/iphone/PROJ/haxe/makefile
+++ b/templates/iphone/PROJ/haxe/makefile
@@ -48,35 +48,35 @@ LIB_DEST := $(DEBUG)/libApplicationMain.a
 build-haxe-i386:
 	@echo "Haxe simulator build: $(CONFIG)"
 	haxe Build.hxml -D simulator -cpp build/$(CONFIG) $(DEBUG)
-	cd build/$(CONFIG); export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -Dsimulator -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG); ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -Dsimulator -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).iphonesim.a ../lib/i386$(LIB_DEST)
 	touch ../Classes/Main.mm
 
 build-haxe-x86_64:
 	@echo "Haxe simulator build: $(CONFIG)-64"
 	haxe Build.hxml -D simulator -D HXCPP_M64 -cpp build/$(CONFIG)-64 $(DEBUG)
-	cd build/$(CONFIG)-64; export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -Dsimulator -DHXCPP_M64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG)-64; ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -Dsimulator -DHXCPP_M64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)-64/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).iphonesim-64.a ../lib/x86_64$(LIB_DEST)
 	touch ../Classes/Main.mm
 
 build-haxe-armv6:
 	@echo "Haxe device build: $(CONFIG)"
 	haxe Build.hxml -D HXCPP_ARMV6 -cpp build/$(CONFIG) $(DEBUG)
-	cd build/$(CONFIG); export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -DHXCPP_ARMV6 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG); ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -DHXCPP_ARMV6 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).iphoneos.a ../lib/armv6$(LIB_DEST)
 	touch ../Classes/Main.mm
 
 build-haxe-armv7:
 	@echo "Haxe device build: $(CONFIG)-v7"
 	haxe Build.hxml -D HXCPP_ARMV7 -cpp build/$(CONFIG)-v7 $(DEBUG)
-	cd build/$(CONFIG)-v7; export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -DHXCPP_ARMV7 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG)-v7; ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -DHXCPP_ARMV7 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)-v7/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).iphoneos-v7.a ../lib/armv7$(LIB_DEST)
 	touch ../Classes/Main.mm
 
 build-haxe-arm64:
 	@echo "Haxe device build: $(CONFIG)-64"
 	haxe Build.hxml -D HXCPP_ARM64 -cpp build/$(CONFIG)-64 $(DEBUG)
-	cd build/$(CONFIG)-64; export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -DHXCPP_ARM64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG)-64; ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dios -Diphone -DHXCPP_ARM64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)-64/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).iphoneos-64.a ../lib/arm64$(LIB_DEST)
 	touch ../Classes/Main.mm
 

--- a/templates/tvos/PROJ/haxe/makefile
+++ b/templates/tvos/PROJ/haxe/makefile
@@ -48,21 +48,21 @@ LIB_DEST := $(DEBUG)/libApplicationMain.a
 build-haxe-i386:
 	@echo "Haxe simulator build: $(CONFIG)"
 	haxe Build.hxml -D simulator -cpp build/$(CONFIG) $(DEBUG)
-	cd build/$(CONFIG); export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dtvos -Dsimulator -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG); ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dtvos -Dsimulator -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).appletvsim.a ../lib/i386$(LIB_DEST)
 	touch ../Classes/Main.mm
 
 build-haxe-x86_64:
 	@echo "Haxe simulator build: $(CONFIG)-64"
 	haxe Build.hxml -D simulator -D HXCPP_M64 -cpp build/$(CONFIG)-64 $(DEBUG)
-	cd build/$(CONFIG)-64; export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dtvos -Dsimulator -DHXCPP_M64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG)-64; ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dtvos -Dsimulator -DHXCPP_M64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)-64/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).appletvsim-64.a ../lib/x86_64$(LIB_DEST)
 	touch ../Classes/Main.mm
 
 build-haxe-arm64:
 	@echo "Haxe device build: $(CONFIG)-64"
 	haxe Build.hxml -D HXCPP_ARM64 -cpp build/$(CONFIG)-64 $(DEBUG)
-	cd build/$(CONFIG)-64; export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dtvos -DHXCPP_ARM64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
+	cd build/$(CONFIG)-64; ::CUSTOM_HAXELIB_PATH:: export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dtvos -DHXCPP_ARM64 -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
 	cp build/$(CONFIG)-64/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).appletvos-64.a ../lib/arm64$(LIB_DEST)
 	touch ../Classes/Main.mm
 


### PR DESCRIPTION
We use a local haxelib repo for our projects but when we build for iOS and then run the build step in Xcode, it no longer uses the local haxelib repo (since the local repo has limited functionality right now). This change adds the ability to have a `HAXELIB_PATH` set (which would be set for local repos) and would propagate through to the Xcode builds.

@jgranick