### PR TITLE
Shorten expressions of #if and #elseif

### DIFF
--- a/haxe/Timer.hx
+++ b/haxe/Timer.hx
@@ -1,5 +1,5 @@
 package haxe;
-#if (!neko && !cpp && !nodejs)
+#if !lime_native
 
 
 // Original haxe.Timer class

--- a/include.xml
+++ b/include.xml
@@ -3,7 +3,8 @@
 	
 	<set name="lime" />
 	<haxedef name="lime-html5" if="html5" />
-	<haxedef name="lime-native" if="native" />
+	<haxedef name="lime-native" if="native" unless="doc" />
+	<haxedef name="lime-image-data-cffi" if="cpp || neko" />
 	
 	<haxedef name="no-compilation" />
 	

--- a/lime/Assets.hx
+++ b/lime/Assets.hx
@@ -508,7 +508,7 @@ class Assets {
 	private static function isValidImage (buffer:Image):Bool {
 		
 		#if (tools && !display)
-		#if (cpp || neko || nodejs)
+		#if lime_native
 		
 		return (buffer != null);
 		//return (bitmapData.__handle != null);

--- a/lime/_backend/html5/HTML5Renderer.hx
+++ b/lime/_backend/html5/HTML5Renderer.hx
@@ -89,7 +89,7 @@ class HTML5Renderer {
 				#end
 				
 				GL.context = webgl;
-				#if (js && html5)
+				#if lime_html5
 				parent.context = OPENGL (cast GL.context);
 				#else
 				parent.context = OPENGL (new GLRenderContext ());

--- a/lime/app/Application.hx
+++ b/lime/app/Application.hx
@@ -868,7 +868,7 @@ class Application extends Module {
 
 #if flash
 @:noCompletion private typedef ApplicationBackend = lime._backend.flash.FlashApplication;
-#elseif (js && html5)
+#elseif lime_html5
 @:noCompletion private typedef ApplicationBackend = lime._backend.html5.HTML5Application;
 #else
 @:noCompletion private typedef ApplicationBackend = lime._backend.native.NativeApplication;

--- a/lime/app/Config.hx
+++ b/lime/app/Config.hx
@@ -3,7 +3,7 @@ package lime.app;
 
 typedef Config = {
 	
-	#if (js && html5)
+	#if lime_html5
 	@:optional var assetsPrefix:String;
 	#end
 	@:optional var build:String;
@@ -27,7 +27,7 @@ typedef WindowConfig = {
 	@:optional var borderless:Bool;
 	@:optional var depthBuffer:Bool;
 	@:optional var display:Int;
-	#if (js && html5)
+	#if lime_html5
 	@:optional var element:#if (haxe_ver >= "3.2") js.html.Element #else js.html.HtmlElement #end;
 	#end
 	@:optional var fullscreen:Bool;

--- a/lime/app/Preloader.hx
+++ b/lime/app/Preloader.hx
@@ -4,7 +4,7 @@ package lime.app;
 import lime.app.Event;
 import lime.Assets;
 
-#if (js && html5)
+#if lime_html5
 import js.html.Image;
 import js.html.SpanElement;
 import js.Browser;
@@ -24,7 +24,7 @@ class Preloader #if flash extends Sprite #end {
 	public var onComplete = new Event<Void->Void> ();
 	public var onProgress = new Event<Int->Int->Void> ();
 	
-	#if (js && html5)
+	#if lime_html5
 	public static var images = new Map<String, Image> ();
 	public static var loaders = new Map<String, HTTPRequest> ();
 	private var loaded = 0;
@@ -63,7 +63,7 @@ class Preloader #if flash extends Sprite #end {
 	
 	public function load (urls:Array<String>, types:Array<AssetType>):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		
 		var url = null;
 		var cacheVersion = Assets.cache.version;
@@ -136,7 +136,7 @@ class Preloader #if flash extends Sprite #end {
 	}
 	
 	
-	#if (js && html5)
+	#if lime_html5
 	private function loadFont (font:String):Void {
 		
 		if (untyped (Browser.document).fonts && untyped (Browser.document).fonts.load) {
@@ -258,7 +258,7 @@ class Preloader #if flash extends Sprite #end {
 	
 	
 	
-	#if (js && html5)
+	#if lime_html5
 	private function image_onLoad (_):Void {
 		
 		loaded++;

--- a/lime/audio/AudioBuffer.hx
+++ b/lime/audio/AudioBuffer.hx
@@ -7,7 +7,7 @@ import lime.audio.openal.AL;
 //import lime.net.URLRequest;
 import lime.utils.UInt8Array;
 
-#if (js && html5)
+#if lime_html5
 import js.html.Audio;
 #elseif flash
 import flash.media.Sound;
@@ -29,7 +29,7 @@ class AudioBuffer {
 	public var id:UInt;
 	public var sampleRate:Int;
 	
-	#if (js && html5)
+	#if lime_html5
 	public var src:Audio;
 	#elseif flash
 	public var src:Sound;
@@ -75,7 +75,7 @@ class AudioBuffer {
 		
 		lime.Lib.notImplemented ("AudioBuffer.fromBytes");
 		
-		#elseif ((cpp || neko || nodejs) && !macro)
+		#elseif (lime_native && !macro)
 		
 		var data:Dynamic = lime_audio_load (bytes);
 		
@@ -123,7 +123,7 @@ class AudioBuffer {
 			
 		}
 		
-		#elseif ((cpp || neko || nodejs) && !macro)
+		#elseif (lime_native && !macro)
 		
 		var data:Dynamic = lime_audio_load (path);
 		
@@ -185,7 +185,7 @@ class AudioBuffer {
 	}
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_audio_load (data:Dynamic):Dynamic;
 	#end
 	

--- a/lime/audio/AudioManager.hx
+++ b/lime/audio/AudioManager.hx
@@ -6,7 +6,7 @@ import lime.audio.openal.ALC;
 import lime.audio.openal.ALContext;
 import lime.audio.openal.ALDevice;
 
-#if (js && html5)
+#if lime_html5
 import js.Browser;
 #end
 
@@ -23,7 +23,7 @@ class AudioManager {
 			
 			if (context == null) {
 				
-				#if (js && html5)
+				#if lime_html5
 					
 					try {
 						

--- a/lime/audio/AudioSource.hx
+++ b/lime/audio/AudioSource.hx
@@ -48,7 +48,7 @@ class AudioSource {
 	private var channel:FMODChannel;
 	#end
 	
-	#if (cpp || neko || nodejs)
+	#if lime_native
 	private var timer:Timer;
 	#end
 	
@@ -176,7 +176,7 @@ class AudioSource {
 			
 		}
 		
-		#else
+		#elseif lime_native
 		
 		if (playing || id == 0) {
 			
@@ -217,7 +217,7 @@ class AudioSource {
 			
 		}
 		
-		#else
+		#elseif lime_native
 		
 		playing = false;
 		AL.sourcePause (id);
@@ -254,7 +254,7 @@ class AudioSource {
 			
 		}
 		
-		#else
+		#elseif lime_native
 		
 		playing = false;
 		AL.sourceStop (id);
@@ -361,7 +361,7 @@ class AudioSource {
 	
 	private function timer_onRun () {
 		
-		#if (!flash && !html5)
+		#if lime_native
 		
 		playing = false;
 		
@@ -408,11 +408,15 @@ class AudioSource {
 		lime.Lib.notImplemented ("AudioSource.get_currentTime");
 		return 0;
 		
-		#else
+		#elseif lime_native
 		
 		var time = Std.int (AL.getSourcef (id, AL.SEC_OFFSET) * 1000) - offset;
 		if (time < 0) return 0;
 		return time;
+		
+		#else
+		
+		return 0;
 		
 		#end
 		
@@ -436,7 +440,7 @@ class AudioSource {
 		lime.Lib.notImplemented ("AudioSource.set_currentTime");
 		return value;
 		
-		#else
+		#elseif lime_native
 		
 		if (buffer != null) {
 			
@@ -467,6 +471,10 @@ class AudioSource {
 		
 		return value;
 		
+		#else
+		
+		return 0;
+		
 		#end
 		
 	}
@@ -487,9 +495,13 @@ class AudioSource {
 		lime.Lib.notImplemented ("AudioSource.get_gain");
 		return 1;
 		
-		#else
+		#elseif lime_native
 		
 		return AL.getSourcef (id, AL.GAIN);
+		
+		#else
+		
+		return 0;
 		
 		#end
 		
@@ -514,10 +526,14 @@ class AudioSource {
 		lime.Lib.notImplemented ("AudioSource.set_gain");
 		return value;
 		
-		#else
+		#elseif lime_native
 		
 		AL.sourcef (id, AL.GAIN, value);
 		return value;
+		
+		#else
+		
+		return 0;
 		
 		#end
 		
@@ -545,10 +561,14 @@ class AudioSource {
 		lime.Lib.notImplemented ("AudioSource.get_length");
 		return 0;
 		
-		#else
+		#elseif lime_native
 		
 		var samples = (buffer.data.length * 8) / (buffer.channels * buffer.bitsPerSample);
 		return Std.int (samples / buffer.sampleRate * 1000) - offset;
+		
+		#else
+		
+		return 0;
 		
 		#end
 		
@@ -562,7 +582,7 @@ class AudioSource {
 		lime.Lib.notImplemented ("AudioSource.set_length");
 		return value;
 
-		#elseif (!flash && !html5)
+		#elseif lime_native
 		
 		if (playing && __length != value) {
 			

--- a/lime/audio/HTML5AudioContext.hx
+++ b/lime/audio/HTML5AudioContext.hx
@@ -1,7 +1,7 @@
 package lime.audio;
 
 
-#if (js && html5)
+#if lime_html5
 import js.html.Audio;
 #end
 
@@ -29,7 +29,7 @@ class HTML5AudioContext {
 	
 	public function canPlayType (buffer:AudioBuffer, type:String):String {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.canPlayType (type);
@@ -44,7 +44,7 @@ class HTML5AudioContext {
 	
 	public function createBuffer (urlString:String = null):AudioBuffer {
 		
-		#if (js && html5)
+		#if lime_html5
 		var buffer = new AudioBuffer ();
 		buffer.src = new Audio ();
 		buffer.src.src = urlString;
@@ -59,7 +59,7 @@ class HTML5AudioContext {
 	#if (haxe_ver < "3.2")
 	public function getAudioDecodedByteCount (buffer:AudioBuffer):Int {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.audioDecodedByteCount;
@@ -75,7 +75,7 @@ class HTML5AudioContext {
 	
 	public function getAutoplay (buffer:AudioBuffer):Bool {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.autoplay;
@@ -90,7 +90,7 @@ class HTML5AudioContext {
 	
 	public function getBuffered (buffer:AudioBuffer):Dynamic /*TimeRanges*/ {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.buffered;
@@ -106,7 +106,7 @@ class HTML5AudioContext {
 	#if (haxe_ver < "3.2")
 	public function getController (buffer:AudioBuffer):Dynamic /*MediaController*/ {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.controller;
@@ -122,7 +122,7 @@ class HTML5AudioContext {
 	
 	public function getCurrentSrc (buffer:AudioBuffer):String {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.currentSrc;
@@ -137,7 +137,7 @@ class HTML5AudioContext {
 	
 	public function getCurrentTime (buffer:AudioBuffer):Float {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.currentTime;
@@ -152,7 +152,7 @@ class HTML5AudioContext {
 	
 	public function getDefaultPlaybackRate (buffer:AudioBuffer):Float {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.defaultPlaybackRate;
@@ -167,7 +167,7 @@ class HTML5AudioContext {
 	
 	public function getDuration (buffer:AudioBuffer):Float {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.duration;
@@ -182,7 +182,7 @@ class HTML5AudioContext {
 	
 	public function getEnded (buffer:AudioBuffer):Bool {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.ended;
@@ -197,7 +197,7 @@ class HTML5AudioContext {
 	
 	public function getError (buffer:AudioBuffer):Dynamic /*MediaError*/ {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.error;
@@ -213,7 +213,7 @@ class HTML5AudioContext {
 	#if (haxe_ver < "3.2")
 	public function getInitialTime (buffer:AudioBuffer):Float {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.initialTime;
@@ -229,7 +229,7 @@ class HTML5AudioContext {
 	
 	public function getLoop (buffer:AudioBuffer):Bool {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.loop;
@@ -245,7 +245,7 @@ class HTML5AudioContext {
 	#if (haxe_ver < "3.2")
 	public function getMediaGroup (buffer:AudioBuffer):String {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.mediaGroup;
@@ -261,7 +261,7 @@ class HTML5AudioContext {
 	
 	public function getMuted (buffer:AudioBuffer):Bool {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.muted;
@@ -276,7 +276,7 @@ class HTML5AudioContext {
 	
 	public function getNetworkState (buffer:AudioBuffer):Int {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.networkState;
@@ -291,7 +291,7 @@ class HTML5AudioContext {
 	
 	public function getPaused (buffer:AudioBuffer):Bool {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.paused;
@@ -306,7 +306,7 @@ class HTML5AudioContext {
 	
 	public function getPlaybackRate (buffer:AudioBuffer):Float {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.playbackRate;
@@ -321,7 +321,7 @@ class HTML5AudioContext {
 	
 	public function getPlayed (buffer:AudioBuffer):Dynamic /*TimeRanges*/ {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.played;
@@ -336,7 +336,7 @@ class HTML5AudioContext {
 	
 	public function getPreload (buffer:AudioBuffer):String {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.preload;
@@ -351,7 +351,7 @@ class HTML5AudioContext {
 	
 	public function getReadyState (buffer:AudioBuffer):Int {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.readyState;
@@ -366,7 +366,7 @@ class HTML5AudioContext {
 	
 	public function getSeekable (buffer:AudioBuffer):Dynamic /*TimeRanges*/ {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.seekable;
@@ -381,7 +381,7 @@ class HTML5AudioContext {
 	
 	public function getSeeking (buffer:AudioBuffer):Bool {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.seeking;
@@ -396,7 +396,7 @@ class HTML5AudioContext {
 	
 	public function getSrc (buffer:AudioBuffer):String {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.src;
@@ -411,7 +411,7 @@ class HTML5AudioContext {
 	
 	public function getStartTime (buffer:AudioBuffer):Float {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.playbackRate;
@@ -426,7 +426,7 @@ class HTML5AudioContext {
 	
 	public function getVolume (buffer:AudioBuffer):Float {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.volume;
@@ -441,7 +441,7 @@ class HTML5AudioContext {
 	
 	public function load (buffer:AudioBuffer):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.load ();
@@ -454,7 +454,7 @@ class HTML5AudioContext {
 	
 	public function pause (buffer:AudioBuffer):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.pause ();
@@ -467,7 +467,7 @@ class HTML5AudioContext {
 	
 	public function play (buffer:AudioBuffer):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			return buffer.src.play ();
@@ -480,7 +480,7 @@ class HTML5AudioContext {
 	
 	public function setAutoplay (buffer:AudioBuffer, value:Bool):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.autoplay = value;
@@ -494,7 +494,7 @@ class HTML5AudioContext {
 	#if (haxe_ver < "3.2")
 	public function setController (buffer:AudioBuffer, value:Dynamic /*MediaController*/):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.controller = value;
@@ -508,7 +508,7 @@ class HTML5AudioContext {
 	
 	public function setCurrentTime (buffer:AudioBuffer, value:Float):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.currentTime = value;
@@ -521,7 +521,7 @@ class HTML5AudioContext {
 	
 	public function setDefaultPlaybackRate (buffer:AudioBuffer, value:Float):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.defaultPlaybackRate = value;
@@ -534,7 +534,7 @@ class HTML5AudioContext {
 	
 	public function setLoop (buffer:AudioBuffer, value:Bool):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.loop = value;
@@ -548,7 +548,7 @@ class HTML5AudioContext {
 	#if (haxe_ver < "3.2")
 	public function setMediaGroup (buffer:AudioBuffer, value:String):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.mediaGroup = value;
@@ -562,7 +562,7 @@ class HTML5AudioContext {
 	
 	public function setMuted (buffer:AudioBuffer, value:Bool):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.muted = value;
@@ -575,7 +575,7 @@ class HTML5AudioContext {
 	
 	public function setPlaybackRate (buffer:AudioBuffer, value:Float):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.playbackRate = value;
@@ -588,7 +588,7 @@ class HTML5AudioContext {
 	
 	public function setPreload (buffer:AudioBuffer, value:String):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.preload = value;
@@ -601,7 +601,7 @@ class HTML5AudioContext {
 	
 	public function setSrc (buffer:AudioBuffer, value:String):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.src = value;
@@ -614,7 +614,7 @@ class HTML5AudioContext {
 	
 	public function setVolume (buffer:AudioBuffer, value:Float):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.src != null) {
 			
 			buffer.src.volume = value;

--- a/lime/audio/openal/AL.hx
+++ b/lime/audio/openal/AL.hx
@@ -96,7 +96,7 @@ class AL {
 	
 	public static function buffer3f (buffer:Int, param:Int, value1:Float, value2:Float, value3:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_buffer3f (buffer, param, value1, value2, value3);
 		#end
 		
@@ -105,7 +105,7 @@ class AL {
 	
 	public static function buffer3i (buffer:Int, param:Int, value1:Int, value2:Int, value3:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_buffer3i (buffer, param, value1, value2, value3);
 		#end
 		
@@ -114,7 +114,7 @@ class AL {
 	
 	public static function bufferf (buffer:Int, param:Int, value:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_bufferf (buffer, param, value);
 		#end
 		
@@ -123,7 +123,7 @@ class AL {
 	
 	public static function bufferfv (buffer:Int, param:Int, values:Array<Float>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_bufferfv (buffer, param, values);
 		#end
 		
@@ -132,7 +132,7 @@ class AL {
 	
 	public static function bufferi (buffer:Int, param:Int, value:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_bufferi (buffer, param, value);
 		#end
 		
@@ -141,7 +141,7 @@ class AL {
 	
 	public static function bufferiv (buffer:Int, param:Int, values:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_bufferiv (buffer, param, values);
 		#end
 		
@@ -150,7 +150,7 @@ class AL {
 	
 	public static function deleteBuffer (buffer:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_delete_buffer (buffer);
 		#end
 		
@@ -159,7 +159,7 @@ class AL {
 	
 	public static function deleteBuffers (buffers:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_delete_buffers (buffers.length, buffers);
 		#end
 		
@@ -168,7 +168,7 @@ class AL {
 	
 	public static function deleteSource (source:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_delete_source (source);
 		#end
 		
@@ -177,7 +177,7 @@ class AL {
 	
 	public static function deleteSources (sources:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_delete_sources (sources.length, sources);
 		#end
 		
@@ -186,7 +186,7 @@ class AL {
 	
 	public static function disable (capability:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_disable (capability);
 		#end
 		
@@ -195,7 +195,7 @@ class AL {
 	
 	public static function distanceModel (distanceModel:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_distance_model (distanceModel);
 		#end
 		
@@ -204,7 +204,7 @@ class AL {
 	
 	public static function dopplerFactor (value:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_doppler_factor (value);
 		#end
 		
@@ -213,7 +213,7 @@ class AL {
 	
 	public static function dopplerVelocity (value:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_doppler_velocity (value);
 		#end
 		
@@ -222,7 +222,7 @@ class AL {
 	
 	public static function enable (capability:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_enable (capability);
 		#end
 		
@@ -231,7 +231,7 @@ class AL {
 	
 	public static function genSource ():Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_gen_source ();
 		#else
 		return 0;
@@ -242,7 +242,7 @@ class AL {
 	
 	public static function genSources (n:Int):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_gen_sources (n);
 		#else
 		return null;
@@ -253,7 +253,7 @@ class AL {
 	
 	public static function genBuffer ():Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_gen_buffer ();
 		#else
 		return 0;
@@ -264,7 +264,7 @@ class AL {
 	
 	public static function genBuffers (n:Int):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_gen_buffers (n);
 		#else
 		return null;
@@ -275,7 +275,7 @@ class AL {
 	
 	public static function getBoolean (param:Int):Bool {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_boolean (param);
 		#else
 		return false;
@@ -286,7 +286,7 @@ class AL {
 	
 	public static function getBooleanv (param:Int, count:Int = 1):Array<Bool> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_booleanv (param, 1);
 		#else
 		return null;
@@ -297,7 +297,7 @@ class AL {
 	
 	public static function getBuffer3f (buffer:Int, param:Int):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_buffer3f (buffer, param);
 		#else
 		return null;
@@ -308,7 +308,7 @@ class AL {
 	
 	public static function getBuffer3i (buffer:Int, param:Int):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_buffer3i (buffer, param);
 		#else
 		return null;
@@ -319,7 +319,7 @@ class AL {
 	
 	public static function getBufferf (buffer:Int, param:Int):Float {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_bufferf (buffer, param);
 		#else
 		return 0;
@@ -330,7 +330,7 @@ class AL {
 	
 	public static function getBufferfv (buffer:Int, param:Int, count:Int = 1):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_bufferfv (buffer, param, count);
 		#else
 		return null;
@@ -341,7 +341,7 @@ class AL {
 	
 	public static function getBufferi (buffer:Int, param:Int):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_bufferi (buffer, param);
 		#else
 		return 0;
@@ -352,7 +352,7 @@ class AL {
 	
 	public static function getBufferiv (buffer:Int, param:Int, count:Int = 1):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_bufferiv (buffer, param, count);
 		#else
 		return null;
@@ -363,7 +363,7 @@ class AL {
 	
 	public static function getDouble (param:Int):Float {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_double (param);
 		#else
 		return 0;
@@ -374,7 +374,7 @@ class AL {
 	
 	public static function getDoublev (param:Int, count:Int = 1):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_doublev (param, count);
 		#else
 		return null;
@@ -385,7 +385,7 @@ class AL {
 	
 	public static function getEnumValue (ename:String):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_enum_value (ename);
 		#else
 		return 0;
@@ -396,7 +396,7 @@ class AL {
 	
 	public static function getError ():Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_error ();
 		#else
 		return 0;
@@ -423,7 +423,7 @@ class AL {
 	
 	public static function getFloat (param:Int):Float {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_float (param);
 		#else
 		return 0;
@@ -434,7 +434,7 @@ class AL {
 	
 	public static function getFloatv (param:Int, count:Int = 1):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_floatv (param, count);
 		#else
 		return null;
@@ -445,7 +445,7 @@ class AL {
 	
 	public static function getInteger (param:Int):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_integer (param);
 		#else
 		return 0;
@@ -456,7 +456,7 @@ class AL {
 	
 	public static function getIntegerv (param:Int, count:Int = 1):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_integerv (param, count);
 		#else
 		return null;
@@ -467,7 +467,7 @@ class AL {
 	
 	public static function getListener3f (param:Int):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_listener3f (param);
 		#else
 		return null;
@@ -478,7 +478,7 @@ class AL {
 	
 	public static function getListener3i (param:Int):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_listener3i (param);
 		#else
 		return null;
@@ -489,7 +489,7 @@ class AL {
 	
 	public static function getListenerf (param:Int):Float {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_listenerf (param);
 		#else
 		return 0;
@@ -500,7 +500,7 @@ class AL {
 	
 	public static function getListenerfv (param:Int, count:Int = 1):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_listenerfv (param, count);
 		#else
 		return null;
@@ -511,7 +511,7 @@ class AL {
 	
 	public static function getListeneri (param:Int):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_listeneri (param);
 		#else
 		return 0;
@@ -522,7 +522,7 @@ class AL {
 	
 	public static function getListeneriv (param:Int, count:Int = 1):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_listeneriv (param, count);
 		#else
 		return null;
@@ -533,7 +533,7 @@ class AL {
 	
 	public static function getProcAddress (fname:String):Dynamic {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_proc_address (fname);
 		#else
 		return null;
@@ -544,7 +544,7 @@ class AL {
 	
 	public static function getSource3f (source:Int, param:Int):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_source3f (source, param);
 		#else
 		return null;
@@ -555,7 +555,7 @@ class AL {
 	
 	public static function getSourcef (source:Int, param:Int):Float {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_sourcef (source, param);
 		#else
 		return 0;
@@ -566,7 +566,7 @@ class AL {
 	
 	public static function getSource3i (source:Int, param:Int):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_source3i (source, param);
 		#else
 		return null;
@@ -577,7 +577,7 @@ class AL {
 	
 	public static function getSourcefv (source:Int, param:Int, count:Int = 1):Array<Float> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_sourcefv (source, param, count);
 		#else
 		return null;
@@ -588,7 +588,7 @@ class AL {
 	
 	public static function getSourcei (source:Int, param:Int):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_sourcei (source, param);
 		#else
 		return 0;
@@ -599,7 +599,7 @@ class AL {
 	
 	public static function getSourceiv (source:Int, param:Int, count:Int = 1):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_sourceiv (source, param, count);
 		#else
 		return null;
@@ -610,7 +610,7 @@ class AL {
 	
 	public static function getString (param:Int):String {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_get_string (param);
 		#else
 		return null;
@@ -621,7 +621,7 @@ class AL {
 	
 	public static function isBuffer (buffer:Int):Bool {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_is_buffer (buffer);
 		#else
 		return false;
@@ -632,7 +632,7 @@ class AL {
 	
 	public static function isEnabled (capability:Int):Bool {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_is_enabled (capability);
 		#else
 		return false;
@@ -643,7 +643,7 @@ class AL {
 	
 	public static function isExtensionPresent (extname:String):Bool {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_is_extension_present (extname);
 		#else
 		return false;
@@ -654,7 +654,7 @@ class AL {
 	
 	public static function isSource (source:Int):Bool {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_is_source (source);
 		#else
 		return false;
@@ -665,7 +665,7 @@ class AL {
 	
 	public static function listener3f (param:Int, value1:Float, value2:Float, value3:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_listener3f (param, value1, value2, value3);
 		#end
 		
@@ -674,7 +674,7 @@ class AL {
 	
 	public static function listener3i (param:Int, value1:Int, value2:Int, value3:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_listener3i (param, value1, value2, value3);
 		#end
 		
@@ -683,7 +683,7 @@ class AL {
 	
 	public static function listenerf (param:Int, value:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_listenerf (param, value);
 		#end
 		
@@ -692,7 +692,7 @@ class AL {
 	
 	public static function listenerfv (param:Int, values:Array<Float>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_listenerfv (param, values);
 		#end
 		
@@ -701,7 +701,7 @@ class AL {
 	
 	public static function listeneri (param:Int, value:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_listeneri (param, value);
 		#end
 		
@@ -710,7 +710,7 @@ class AL {
 	
 	public static function listeneriv (param:Int, values:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_listeneriv (param, values);
 		#end
 		
@@ -719,7 +719,7 @@ class AL {
 	
 	public static function source3f (source:Int, param:Int, value1:Float, value2:Float, value3:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source3f (source, param, value1, value2, value3);
 		#end
 		
@@ -728,7 +728,7 @@ class AL {
 	
 	public static function source3i (source:Int, param:Int, value1:Int, value2:Int, value3:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source3i (source, param, value1, value2, value3);
 		#end
 		
@@ -737,7 +737,7 @@ class AL {
 	
 	public static function sourcef (source:Int, param:Int, value:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_sourcef (source, param, value);
 		#end
 		
@@ -746,7 +746,7 @@ class AL {
 	
 	public static function sourcefv (source:Int, param:Int, values:Array<Float>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_sourcefv (source, param, values);
 		#end
 		
@@ -755,7 +755,7 @@ class AL {
 	
 	public static function sourcei (source:Int, param:Int, value:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_sourcei (source, param, value);
 		#end
 		
@@ -764,7 +764,7 @@ class AL {
 	
 	public static function sourceiv (source:Int, param:Int, values:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_sourceiv (source, param, values);
 		#end
 		
@@ -773,7 +773,7 @@ class AL {
 	
 	public static function sourcePlay (source:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_play (source);
 		#end
 		
@@ -782,7 +782,7 @@ class AL {
 	
 	public static function sourcePlayv (sources:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_playv (sources.length, sources);
 		#end
 		
@@ -791,7 +791,7 @@ class AL {
 	
 	public static function sourceStop (source:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_stop (source);
 		#end
 		
@@ -800,7 +800,7 @@ class AL {
 	
 	public static function sourceStopv (sources:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_stopv (sources.length, sources);
 		#end
 		
@@ -809,7 +809,7 @@ class AL {
 	
 	public static function sourceRewind (source:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_rewind (source);
 		#end
 		
@@ -818,7 +818,7 @@ class AL {
 	
 	public static function sourceRewindv (sources:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_rewindv (sources.length, sources);
 		#end
 		
@@ -827,7 +827,7 @@ class AL {
 	
 	public static function sourcePause (source:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_pause (source);
 		#end
 		
@@ -836,7 +836,7 @@ class AL {
 	
 	public static function sourcePausev (sources:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_pausev (sources.length, sources);
 		#end
 		
@@ -845,7 +845,7 @@ class AL {
 	
 	public static function sourceQueueBuffer (source:Int, buffer:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_queue_buffers (source, 1, [ buffer ]);
 		#end
 		
@@ -854,7 +854,7 @@ class AL {
 	
 	public static function sourceQueueBuffers (source:Int, nb:Int, buffers:Array<Int>):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_source_queue_buffers (source, nb, buffers);
 		#end
 		
@@ -863,7 +863,7 @@ class AL {
 	
 	public static function sourceUnqueueBuffer (source:Int):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		var res = lime_al_source_unqueue_buffers (source, 1);
 		return res[0];
 		#else
@@ -875,7 +875,7 @@ class AL {
 	
 	public static function sourceUnqueueBuffers (source:Int, nb:Int):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_al_source_unqueue_buffers (source, nb);
 		#else
 		return null;
@@ -886,14 +886,14 @@ class AL {
 	
 	public static function speedOfSound (value:Float):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_al_speed_of_sound (value);
 		#end
 		
 	}
 	
 	
-	#if ((cpp || neko || nodejs) && lime_openal && !macro)
+	#if (lime_native && lime_openal && !macro)
 	@:cffi private static function lime_al_buffer_data (buffer:Int, format:Int, data:Dynamic, size:Int, freq:Int):Void;
 	@:cffi private static function lime_al_buffer3f (buffer:Int, param:Int, value1:Float32, value2:Float32, value3:Float32):Void;
 	@:cffi private static function lime_al_buffer3i (buffer:Int, param:Int, value1:Int, value2:Int, value3:Int):Void;

--- a/lime/audio/openal/ALC.hx
+++ b/lime/audio/openal/ALC.hx
@@ -36,7 +36,7 @@ class ALC {
 	
 	public static function closeDevice (device:ALDevice):Bool {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_alc_close_device (device);
 		#else
 		return false;
@@ -47,7 +47,7 @@ class ALC {
 	
 	public static function createContext (device:ALDevice, attrlist:Array<Int> = null):ALContext {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		var handle:Dynamic = lime_alc_create_context (device, attrlist);
 		
 		if (handle != null) {
@@ -64,7 +64,7 @@ class ALC {
 	
 	public static function destroyContext (context:ALContext):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_alc_destroy_context (context);
 		#end
 		
@@ -73,7 +73,7 @@ class ALC {
 	
 	public static function getContextsDevice (context:ALContext):ALDevice {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		var handle:Dynamic = lime_alc_get_contexts_device (context);
 		
 		if (handle != null) {
@@ -90,7 +90,7 @@ class ALC {
 	
 	public static function getCurrentContext ():ALContext {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		var handle:Dynamic = lime_alc_get_current_context ();
 		
 		if (handle != null) {
@@ -107,7 +107,7 @@ class ALC {
 	
 	public static function getError (device:ALDevice):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_alc_get_error (device);
 		#else
 		return 0;
@@ -134,7 +134,7 @@ class ALC {
 	
 	public static function getIntegerv (device:ALDevice, param:Int, size:Int):Array<Int> {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_alc_get_integerv (device, param, size);
 		#else
 		return null;
@@ -145,7 +145,7 @@ class ALC {
 	
 	public static function getString (device:ALDevice, param:Int):String {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_alc_get_string (device, param);
 		#else
 		return null;
@@ -156,7 +156,7 @@ class ALC {
 	
 	public static function makeContextCurrent (context:ALContext):Bool {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		return lime_alc_make_context_current (context);
 		#else
 		return false;
@@ -167,7 +167,7 @@ class ALC {
 	
 	public static function openDevice (deviceName:String = null):ALDevice {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		var handle:Dynamic = lime_alc_open_device (deviceName);
 		
 		if (handle != null) {
@@ -184,7 +184,7 @@ class ALC {
 	
 	public static function processContext (context:ALContext):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_alc_process_context (context);
 		#end
 		
@@ -193,14 +193,14 @@ class ALC {
 	
 	public static function suspendContext (context:ALContext):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_openal && !macro)
+		#if (lime_native && lime_openal && !macro)
 		lime_alc_suspend_context (context);
 		#end
 		
 	}
 	
 	
-	#if ((cpp || neko || nodejs) && lime_openal && !macro)
+	#if (lime_native && lime_openal && !macro)
 	@:cffi private static function lime_alc_close_device (device:CFFIPointer):Bool;
 	@:cffi private static function lime_alc_create_context (device:CFFIPointer, attrlist:Dynamic):CFFIPointer;
 	@:cffi private static function lime_alc_destroy_context (context:CFFIPointer):Void;

--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -22,7 +22,7 @@ import lime.system.CFFI;
 import lime.utils.ArrayBuffer;
 import lime.utils.UInt8Array;
 
-#if (js && html5)
+#if lime_html5
 import js.html.CanvasElement;
 import js.html.ImageElement;
 import js.html.Image in JSImage;
@@ -202,7 +202,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -238,7 +238,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -318,7 +318,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				ImageCanvasUtil.convertToData (sourceImage);
 				#end
@@ -383,7 +383,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -424,7 +424,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -487,7 +487,7 @@ class Image {
 	}
 	
 	
-	#if (js && html5)
+	#if lime_html5
 	public static function fromCanvas (canvas:CanvasElement):Image {
 	#else
 	public static function fromCanvas (canvas:Dynamic):Image {
@@ -510,7 +510,7 @@ class Image {
 	}
 	
 	
-	#if (js && html5)
+	#if lime_html5
 	public static function fromImageElement (image:ImageElement):Image {
 	#else
 	public static function fromImageElement (image:Dynamic):Image {
@@ -531,7 +531,7 @@ class Image {
 			
 			case CANVAS:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -565,7 +565,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -604,7 +604,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -643,7 +643,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -717,7 +717,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				ImageCanvasUtil.convertToData (sourceImage);
 				#end
@@ -787,7 +787,7 @@ class Image {
 			
 			case DATA:
 				
-				//#if (js && html5)
+				//#if lime_html5
 				//ImageCanvasUtil.convertToData (this);
 				//#end
 				
@@ -818,7 +818,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -855,7 +855,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -893,7 +893,7 @@ class Image {
 			
 			case DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -970,7 +970,7 @@ class Image {
 			
 			case CANVAS, DATA:
 				
-				#if (js && html5)
+				#if lime_html5
 				ImageCanvasUtil.convertToData (this);
 				#end
 				
@@ -1010,7 +1010,7 @@ class Image {
 	
 	private static function __base64Encode (bytes:Bytes):String {
 		
-		#if (js && html5)
+		#if lime_html5
 			
 			var extension = switch (bytes.length % 3) {
 				
@@ -1082,7 +1082,7 @@ class Image {
 	
 	private function __fromBase64 (base64:String, type:String, onload:Image -> Void = null):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		var image = new JSImage ();
 		image.crossOrigin = "Anonymous";
 		
@@ -1113,7 +1113,7 @@ class Image {
 	
 	private function __fromBytes (bytes:Bytes, onload:Image -> Void):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 			
 			var type = "";
 			
@@ -1141,7 +1141,7 @@ class Image {
 			
 			throw "Image.fromBytes not implemented for console target";
 			
-		#elseif ((cpp || neko || nodejs) && !macro)
+		#elseif (lime_native && !macro)
 			
 			var data:Dynamic = lime_image_load (bytes);
 			
@@ -1168,7 +1168,7 @@ class Image {
 	
 	private function __fromFile (path:String, onload:Image -> Void, onerror:Void -> Void):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 			
 			var image = new JSImage ();
 			image.crossOrigin = "Anonymous";
@@ -1258,7 +1258,7 @@ class Image {
 			
 			#else
 			
-			#if (!sys || disable_cffi || java || macro)
+			#if (!lime_native || disable_cffi || java || macro)
 			if (false) {}
 			#else
 			if (CFFI.enabled) {
@@ -1397,7 +1397,7 @@ class Image {
 		
 		if (buffer.data == null && buffer.width > 0 && buffer.height > 0) {
 			
-			#if (js && html5)
+			#if lime_html5
 				
 				ImageCanvasUtil.convertToCanvas (this);
 				ImageCanvasUtil.sync (this, false);
@@ -1524,7 +1524,7 @@ class Image {
 				
 				case DATA:
 					
-					#if (js && html5)
+					#if lime_html5
 					ImageCanvasUtil.convertToData (this);
 					#end
 					
@@ -1542,7 +1542,7 @@ class Image {
 				
 				case DATA:
 					
-					#if (js && html5)
+					#if lime_html5
 					ImageCanvasUtil.convertToData (this);
 					#end
 					
@@ -1570,7 +1570,7 @@ class Image {
 	
 	private function get_src ():Dynamic {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (buffer.__srcCanvas == null) {
 			
 			ImageCanvasUtil.convertToCanvas (this);
@@ -1614,7 +1614,7 @@ class Image {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_image_load (data:Dynamic):Dynamic;
 	#end
 	

--- a/lime/graphics/ImageBuffer.hx
+++ b/lime/graphics/ImageBuffer.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 import lime.graphics.cairo.CairoSurface;
 import lime.utils.UInt8Array;
 
-#if (js && html5)
+#if lime_html5
 import js.html.CanvasElement;
 import js.html.CanvasRenderingContext2D;
 import js.html.Image in HTMLImage;
@@ -33,11 +33,11 @@ class ImageBuffer {
 	public var width:Int;
 	
 	@:noCompletion private var __srcBitmapData:#if flash BitmapData #else Dynamic #end;
-	@:noCompletion private var __srcCanvas:#if (js && html5) CanvasElement #else Dynamic #end;
-	@:noCompletion private var __srcContext:#if (js && html5) CanvasRenderingContext2D #else Dynamic #end;
+	@:noCompletion private var __srcCanvas:#if lime_html5 CanvasElement #else Dynamic #end;
+	@:noCompletion private var __srcContext:#if lime_html5 CanvasRenderingContext2D #else Dynamic #end;
 	@:noCompletion private var __srcCustom:Dynamic;
-	@:noCompletion private var __srcImage:#if (js && html5) HTMLImage #else Dynamic #end;
-	@:noCompletion private var __srcImageData:#if (js && html5) ImageData #else Dynamic #end;
+	@:noCompletion private var __srcImage:#if lime_html5 HTMLImage #else Dynamic #end;
+	@:noCompletion private var __srcImageData:#if lime_html5 ImageData #else Dynamic #end;
 	
 	
 	public function new (data:UInt8Array = null, width:Int = 0, height:Int = 0, bitsPerPixel:Int = 32, format:PixelFormat = null) {
@@ -58,7 +58,7 @@ class ImageBuffer {
 		
 		#if flash
 		if (__srcBitmapData != null) buffer.__srcBitmapData = __srcBitmapData.clone ();
-		#elseif (js && html5)
+		#elseif lime_html5
 		if (data != null) {
 			
 			buffer.data = new UInt8Array (data.byteLength);
@@ -125,7 +125,7 @@ class ImageBuffer {
 	
 	private function get_src ():Dynamic {
 		
-		#if (js && html5)
+		#if lime_html5
 			
 			if (__srcImage != null) return __srcImage;
 			return __srcCanvas;
@@ -145,7 +145,7 @@ class ImageBuffer {
 	
 	private function set_src (value:Dynamic):Dynamic {
 		
-		#if (js && html5)
+		#if lime_html5
 			
 			if (Std.is (value, HTMLImage)) {
 				

--- a/lime/graphics/Renderer.hx
+++ b/lime/graphics/Renderer.hx
@@ -63,7 +63,7 @@ class Renderer {
 
 #if flash
 @:noCompletion private typedef RendererBackend = lime._backend.flash.FlashRenderer;
-#elseif (js && html5)
+#elseif lime_html5
 @:noCompletion private typedef RendererBackend = lime._backend.html5.HTML5Renderer;
 #else
 @:noCompletion private typedef RendererBackend = lime._backend.native.NativeRenderer;

--- a/lime/graphics/cairo/CairoFTFontFace.hx
+++ b/lime/graphics/cairo/CairoFTFontFace.hx
@@ -40,7 +40,7 @@ abstract CairoFTFontFace(CairoFontFace) from CairoFontFace to CairoFontFace from
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_cairo_ft_font_face_create (face:CFFIPointer, flags:Int):CFFIPointer;
 	#end
 	

--- a/lime/graphics/cairo/CairoFontFace.hx
+++ b/lime/graphics/cairo/CairoFontFace.hx
@@ -36,7 +36,7 @@ abstract CairoFontFace(CFFIPointer) from CFFIPointer to CFFIPointer {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_cairo_font_face_status (handle:CFFIPointer):Int;
 	#end
 	

--- a/lime/graphics/cairo/CairoFontOptions.hx
+++ b/lime/graphics/cairo/CairoFontOptions.hx
@@ -132,7 +132,7 @@ abstract CairoFontOptions(CFFIPointer) from CFFIPointer to CFFIPointer {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_cairo_font_options_create ():CFFIPointer;
 	@:cffi private static function lime_cairo_font_options_get_antialias (handle:CFFIPointer):Int;
 	@:cffi private static function lime_cairo_font_options_get_hint_metrics (handle:CFFIPointer):Int;

--- a/lime/graphics/format/JPEG.hx
+++ b/lime/graphics/format/JPEG.hx
@@ -7,7 +7,7 @@ import lime.graphics.Image;
 import lime.graphics.ImageBuffer;
 import lime.system.CFFI;
 
-#if (js && html5)
+#if lime_html5
 import js.Browser;
 #end
 
@@ -23,7 +23,7 @@ class JPEG {
 	
 	public static function decodeBytes (bytes:Bytes, decodeData:Bool = true):Image {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		var bufferData:Dynamic = lime_jpeg_decode_bytes (bytes, decodeData);
 		
@@ -44,7 +44,7 @@ class JPEG {
 	
 	public static function decodeFile (path:String, decodeData:Bool = true):Image {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		var bufferData:Dynamic = lime_jpeg_decode_file (path, decodeData);
 		
@@ -77,12 +77,12 @@ class JPEG {
 		
 		#if java
 		
-		#elseif (sys && (!disable_cffi || !format) && !macro)
+		#elseif (lime_native && (!disable_cffi || !format) && !macro)
 			
 			var data:Dynamic = lime_image_encode (image.buffer, 1, quality);
 			return @:privateAccess new Bytes (data.length, data.b);
 			
-		#elseif (js && html5)
+		#elseif lime_html5
 		
 		ImageCanvasUtil.sync (image, false);
 		
@@ -120,7 +120,7 @@ class JPEG {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_jpeg_decode_bytes (data:Dynamic, decodeData:Bool):Dynamic;
 	@:cffi private static function lime_jpeg_decode_file (path:String, decodeData:Bool):Dynamic;
 	@:cffi private static function lime_image_encode (data:Dynamic, type:Int, quality:Int):Dynamic;

--- a/lime/graphics/format/PNG.hx
+++ b/lime/graphics/format/PNG.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 import lime.graphics.Image;
 import lime.system.CFFI;
 
-#if (js && html5)
+#if lime_html5
 import js.Browser;
 #end
 
@@ -29,7 +29,7 @@ class PNG {
 	
 	public static function decodeBytes (bytes:Bytes, decodeData:Bool = true):Image {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		var bufferData:Dynamic = lime_png_decode_bytes (bytes, decodeData);
 		
@@ -50,7 +50,7 @@ class PNG {
 	
 	public static function decodeFile (path:String, decodeData:Bool = true):Image {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		var bufferData:Dynamic = lime_png_decode_file (path, decodeData);
 		
@@ -83,7 +83,7 @@ class PNG {
 		
 		#if java
 		
-		#elseif (sys && (!disable_cffi || !format) && !macro)
+		#elseif (lime_native && (!disable_cffi || !format) && !macro)
 		
 		if (CFFI.enabled) {
 			
@@ -133,7 +133,7 @@ class PNG {
 			
 		}
 		
-		#elseif (js && html5)
+		#elseif lime_html5
 		
 		ImageCanvasUtil.sync (image, false);
 		
@@ -168,7 +168,7 @@ class PNG {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_png_decode_bytes (data:Dynamic, decodeData:Bool):Dynamic;
 	@:cffi private static function lime_png_decode_file (path:String, decodeData:Bool):Dynamic;
 	@:cffi private static function lime_image_encode (data:Dynamic, type:Int, quality:Int):Dynamic;

--- a/lime/graphics/opengl/GL.hx
+++ b/lime/graphics/opengl/GL.hx
@@ -7,7 +7,7 @@ import lime.utils.Float32Array;
 import lime.utils.Int32Array;
 import lime.system.System;
 
-#if (js && html5)
+#if lime_html5
 import js.html.webgl.RenderingContext;
 #elseif java
 import org.lwjgl.opengl.EXTBlendColor;
@@ -386,7 +386,7 @@ class GL {
 	
 	public static var version (get, null):Int;
 	
-	#if (js && html5)
+	#if lime_html5
 	private static var context:RenderingContext;
 	#end
 	
@@ -395,7 +395,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.activeTexture (texture);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_active_texture (texture);
 		#elseif java
 		GL13.glActiveTexture (texture);
@@ -408,7 +408,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.attachShader (program, shader);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		program.attach (shader);
 		lime_gl_attach_shader (program.id, shader.id);
 		#elseif java
@@ -423,7 +423,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.bindAttribLocation (program, index, name);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_bind_attrib_location (program.id, index, name);
 		#elseif java
 		GL20.glBindAttribLocation (program.id, index, name);
@@ -436,7 +436,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.bindBuffer (target, buffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_bind_buffer (target, buffer == null ? 0 : buffer.id);
 		#elseif java
 		GL15.glBindBuffer (target, buffer == null ? 0 : buffer.id);
@@ -449,7 +449,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.bindFramebuffer (target, framebuffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_bind_framebuffer (target, framebuffer == null ? 0 : framebuffer.id);
 		#elseif java
 		GL30.glBindFramebuffer (target, framebuffer == null ? 0 : framebuffer.id);
@@ -462,7 +462,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.bindRenderbuffer (target, renderbuffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_bind_renderbuffer (target, renderbuffer == null ? 0 : renderbuffer.id);
 		#elseif java
 		GL30.glBindRenderbuffer (target, renderbuffer == null ? 0 : renderbuffer.id);
@@ -475,7 +475,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.bindTexture (target, texture);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_bind_texture (target, texture == null ? 0 : texture.id);
 		#elseif java
 		GL11.glBindTexture (target, texture == null ? 0 : texture.id);
@@ -488,7 +488,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.blendColor (red, green, blue, alpha);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_blend_color (red, green, blue, alpha);
 		#elseif java
 		EXTBlendColor.glBlendColorEXT (red, green, blue, alpha);
@@ -501,7 +501,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.blendEquation (mode);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_blend_equation (mode);
 		#elseif java
 		GL14.glBlendEquation (mode);
@@ -514,7 +514,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.blendEquationSeparate (modeRGB, modeAlpha);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_blend_equation_separate (modeRGB, modeAlpha);
 		#elseif java
 		GL20.glBlendEquationSeparate (modeRGB, modeAlpha);
@@ -527,7 +527,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.blendFunc (sfactor, dfactor);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_blend_func (sfactor, dfactor);
 		#elseif java
 		GL11.glBlendFunc (sfactor, dfactor);
@@ -540,7 +540,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.blendFuncSeparate (srcRGB, dstRGB, srcAlpha, dstAlpha);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_blend_func_separate (srcRGB, dstRGB, srcAlpha, dstAlpha);
 		#elseif java
 		GL14.glBlendFuncSeparate (srcRGB, dstRGB, srcAlpha, dstAlpha);
@@ -583,7 +583,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.checkFramebufferStatus (target);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_check_framebuffer_status (target);
 		#elseif java
 		return GL30.glCheckFramebufferStatus (target);
@@ -598,7 +598,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.clear (mask);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_clear (mask);
 		#elseif java
 		GL11.glClear (mask);
@@ -611,7 +611,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.clearColor (red, green, blue, alpha);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_clear_color (red, green, blue, alpha);
 		#elseif java
 		GL11.glClearColor (red, green, blue, alpha);
@@ -624,7 +624,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.clearDepth (depth);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_clear_depth (depth);
 		#elseif java
 		GL11.glClearDepth (depth);
@@ -637,7 +637,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.clearStencil (s);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_clear_stencil (s);
 		#elseif java
 		GL11.glClearStencil (s);
@@ -650,7 +650,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.colorMask (red, green, blue, alpha);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_color_mask (red, green, blue, alpha);
 		#elseif java
 		GL11.glColorMask (red, green, blue, alpha);
@@ -663,7 +663,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.compileShader (shader);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_compile_shader (shader.id);
 		#elseif java
 		GL20.glCompileShader (shader.id);
@@ -708,7 +708,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.copyTexImage2D (target, level, internalformat, x, y, width, height, border);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_copy_tex_image_2d (target, level, internalformat, x, y, width, height, border);
 		#elseif java
 		GL11.glCopyTexImage2D (target, level, internalformat, x, y, width, height, border);
@@ -721,7 +721,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.copyTexSubImage2D (target, level, xoffset, yoffset, x, y, width, height);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_copy_tex_sub_image_2d (target, level, xoffset, yoffset, x, y, width, height);
 		#elseif java
 		GL11.glCopyTexSubImage2D (target, level, xoffset, yoffset, x, y, width, height);
@@ -734,7 +734,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.createBuffer ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return new GLBuffer (version, lime_gl_create_buffer ());
 		#elseif java
 		//return new GLBuffer (version, GL15.glGenBuffers (1));
@@ -750,7 +750,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.createFramebuffer ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return new GLFramebuffer (version, lime_gl_create_framebuffer ());
 		#elseif java
 		//return new GLFramebuffer (version, GL30.glGenFramebuffers (1));
@@ -766,7 +766,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.createProgram ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return new GLProgram (version, lime_gl_create_program ());
 		#elseif java
 		return new GLProgram (version, GL20.glCreateProgram ());
@@ -781,7 +781,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.createRenderbuffer ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return new GLRenderbuffer (version, lime_gl_create_render_buffer ());
 		#elseif java
 		//return new GLRenderbuffer (version, GL30.glGenRenderbuffers (1));
@@ -797,7 +797,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.createShader (type);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return new GLShader (version, lime_gl_create_shader (type));
 		#elseif java
 		return new GLShader (version, GL20.glCreateShader (type));
@@ -812,7 +812,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.createTexture ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return new GLTexture (version, lime_gl_create_texture ());
 		#elseif java
 		//return new GLTexture (version, GL11.glGenTextures (1));
@@ -828,7 +828,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.cullFace (mode);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_cull_face (mode);
 		#elseif java
 		GL11.glCullFace (mode);
@@ -841,7 +841,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.deleteBuffer (buffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_delete_buffer (buffer.id);
 		buffer.invalidate ();
 		#elseif java
@@ -856,7 +856,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.deleteFramebuffer (framebuffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_delete_framebuffer (framebuffer.id);
 		framebuffer.invalidate ();
 		#elseif
@@ -871,7 +871,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.deleteProgram (program);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_delete_program (program.id);
 		program.invalidate ();
 		#elseif java
@@ -886,7 +886,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.deleteRenderbuffer (renderbuffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_delete_render_buffer (renderbuffer.id);
 		renderbuffer.invalidate ();
 		#elseif java
@@ -901,7 +901,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.deleteShader (shader);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_delete_shader (shader.id);
 		shader.invalidate ();
 		#elseif java
@@ -916,7 +916,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.deleteTexture (texture);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_delete_texture (texture.id);
 		texture.invalidate ();
 		#elseif java
@@ -931,7 +931,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.depthFunc (func);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_depth_func (func);
 		#elseif java
 		GL11.glDepthFunc (func);
@@ -944,7 +944,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.depthMask (flag);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_depth_mask (flag);
 		#elseif java
 		GL11.glDepthMask (flag);
@@ -957,7 +957,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.depthRange (zNear, zFar);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_depth_range (zNear, zFar);
 		#elseif java
 		GL11.glDepthRange (zNear, zFar);
@@ -970,7 +970,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.detachShader (program, shader);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_detach_shader (program.id, shader.id);
 		#elseif java
 		GL20.glDetachShader (program.id, shader.id);
@@ -983,7 +983,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.disable (cap);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_disable (cap);
 		#elseif java
 		GL11.glDisable (cap);
@@ -996,7 +996,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.disableVertexAttribArray (index);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_disable_vertex_attrib_array (index);
 		#elseif java
 		GL20.glDisableVertexAttribArray (index);
@@ -1009,7 +1009,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.drawArrays (mode, first, count);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_draw_arrays (mode, first, count);
 		#elseif java
 		GL11.glDrawArrays (mode, first, count);
@@ -1022,7 +1022,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.drawElements (mode, count, type, offset);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_draw_elements (mode, count, type, offset);
 		#elseif java
 		//GL11.glDrawElements (mode, count, type, offset);
@@ -1035,7 +1035,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.enable (cap);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_enable (cap);
 		#elseif java
 		GL11.glEnable (cap);
@@ -1048,7 +1048,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.enableVertexAttribArray (index);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_enable_vertex_attrib_array (index);
 		#elseif java
 		GL20.glEnableVertexAttribArray (index);
@@ -1061,7 +1061,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.finish ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_finish ();
 		#elseif java
 		GL11.glFinish ();
@@ -1074,7 +1074,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.flush ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_flush ();
 		#elseif java
 		GL11.glFlush ();
@@ -1087,7 +1087,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.framebufferRenderbuffer (target, attachment, renderbuffertarget, renderbuffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_framebuffer_renderbuffer (target, attachment, renderbuffertarget, renderbuffer.id);
 		#elseif java
 		GL30.glFramebufferRenderbuffer (target, attachment, renderbuffertarget, renderbuffer.id);
@@ -1100,7 +1100,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.framebufferTexture2D (target, attachment, textarget, texture, level);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_framebuffer_texture2D (target, attachment, textarget, texture.id, level);
 		#elseif java
 		GL30.glFramebufferTexture2D (target, attachment, textarget, texture.id, level);
@@ -1113,7 +1113,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.frontFace (mode);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_front_face (mode);
 		#elseif java
 		GL11.glFrontFace (mode);
@@ -1126,7 +1126,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.generateMipmap (target);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_generate_mipmap (target);
 		#elseif java
 		GL30.glGenerateMipmap (target);
@@ -1139,7 +1139,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getActiveAttrib (program, index);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		var result:Dynamic = lime_gl_get_active_attrib (program.id, index);
 		return result;
 		#elseif java
@@ -1156,7 +1156,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getActiveUniform (program, index);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		var result:Dynamic = lime_gl_get_active_uniform (program.id, index);
 		return result;
 		#elseif java
@@ -1173,7 +1173,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getAttachedShaders (program);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return program.getShaders ();
 		#elseif java
 		return program.getShaders ();
@@ -1188,7 +1188,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getAttribLocation (program, name);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_attrib_location (program.id, name);
 		#elseif java
 		return GL20.glGetAttribLocation (program.id, name);
@@ -1203,7 +1203,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getBufferParameter (target, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_buffer_parameter (target, pname);
 		#elseif java
 		//return GL15.glGetBufferParameter (target, pname);
@@ -1219,7 +1219,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getContextAttributes ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		var base:Dynamic = lime_gl_get_context_attributes ();
 		base.premultipliedAlpha = false;
 		base.preserveDrawingBuffer = false;
@@ -1241,7 +1241,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getError ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_error ();
 		#elseif java
 		return GL11.glGetError ();
@@ -1256,7 +1256,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getExtension (name);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_extension (name);
 		#else
 		return null;
@@ -1269,7 +1269,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getFramebufferAttachmentParameter (target, attachment, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_framebuffer_attachment_parameter (target, attachment, pname);
 		#elseif java
 		//return GL30.glGetFramebufferAttachmentParameter (target, attachment, pname);
@@ -1285,7 +1285,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getParameter (pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_parameter (pname);
 		#elseif java
 		return null;
@@ -1300,7 +1300,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getProgramInfoLog (program);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_program_info_log (program.id);
 		#elseif java
 		return GL20.glGetProgramInfoLog (program.id);
@@ -1315,7 +1315,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getProgramParameter (program, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_program_parameter (program.id, pname);
 		#elseif java
 		//return GL20.glGetProgramParameter (program.id, pname);
@@ -1331,7 +1331,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getRenderbufferParameter (target, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_render_buffer_parameter (target, pname);
 		#elseif java
 		//return GL30.glGetRenderbufferParameter (target, pname);
@@ -1347,7 +1347,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getShaderInfoLog (shader);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_shader_info_log (shader.id);
 		#elseif java
 		return GL20.glGetShaderInfoLog (shader.id);
@@ -1362,7 +1362,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getShaderParameter (shader, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_shader_parameter (shader.id, pname);
 		#elseif java
 		//return GL20.glGetShaderParameter (shader.id, pname);
@@ -1378,7 +1378,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getShaderPrecisionFormat (shadertype, precisiontype);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		var result:Dynamic = lime_gl_get_shader_precision_format (shadertype, precisiontype);
 		return result;
 		#elseif java
@@ -1395,7 +1395,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getShaderSource (shader);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_shader_source (shader.id);
 		#elseif java
 		return GL20.glGetShaderSource (shader.id);
@@ -1410,7 +1410,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getSupportedExtensions ();
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		var result = new Array<String> ();
 		lime_gl_get_supported_extensions (result);
 		return result;
@@ -1427,7 +1427,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getTexParameter (target, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_tex_parameter (target, pname);
 		#elseif java
 		//return GL11.nglGetTexParameteriv (target, pname);
@@ -1443,7 +1443,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getUniform (program, location);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_uniform (program.id, location);
 		#elseif java
 		//return GL20.glGetUniform (program.id, location);
@@ -1459,7 +1459,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getUniformLocation (program, name);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_uniform_location (program.id, name);
 		#elseif java
 		return GL20.glGetUniformLocation (program.id, name);
@@ -1474,7 +1474,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getVertexAttrib (index, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_vertex_attrib (index, pname);
 		#elseif java
 		return 0;
@@ -1489,7 +1489,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.getVertexAttribOffset (index, pname);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_get_vertex_attrib_offset (index, pname);
 		#elseif java
 		return 0;
@@ -1504,7 +1504,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.hint (target, mode);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_hint (target, mode);
 		#end
 		
@@ -1515,7 +1515,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.isBuffer (buffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return buffer != null && buffer.id > 0 && lime_gl_is_buffer (buffer.id);
 		#else
 		return false;
@@ -1539,7 +1539,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.isEnabled (cap);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return lime_gl_is_enabled (cap);
 		#else
 		return false;
@@ -1552,7 +1552,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.isFramebuffer (framebuffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return framebuffer != null && framebuffer.id > 0 && lime_gl_is_framebuffer (framebuffer.id);
 		#else
 		return false;
@@ -1565,7 +1565,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.isProgram (program);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return program != null && program.id > 0 && lime_gl_is_program (program.id);
 		#else
 		return false;
@@ -1578,7 +1578,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.isRenderbuffer (renderbuffer);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return renderbuffer != null && renderbuffer.id > 0 && lime_gl_is_renderbuffer (renderbuffer.id);
 		#else
 		return false;
@@ -1591,7 +1591,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.isShader (shader);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return shader != null && shader.id > 0 && lime_gl_is_shader (shader.id);
 		#else
 		return false;
@@ -1604,7 +1604,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		return context.isTexture (texture);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		return texture != null && texture.id > 0 && lime_gl_is_texture (texture.id);
 		#else
 		return false;
@@ -1617,7 +1617,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.lineWidth (width);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_line_width (width);
 		#end
 		
@@ -1628,7 +1628,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.linkProgram (program);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_link_program (program.id);
 		#end
 		
@@ -1639,7 +1639,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.pixelStorei (pname, param);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_pixel_storei (pname, param);
 		#end
 		
@@ -1650,7 +1650,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.polygonOffset (factor, units);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_polygon_offset (factor, units);
 		#end
 		
@@ -1675,7 +1675,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.renderbufferStorage (target, internalformat, width, height);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_renderbuffer_storage (target, internalformat, width, height);
 		#end
 		
@@ -1686,7 +1686,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.sampleCoverage (value, invert);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_sample_coverage (value, invert);
 		#end
 		
@@ -1697,7 +1697,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.scissor (x, y, width, height);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_scissor (x, y, width, height);
 		#end
 		
@@ -1708,7 +1708,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.shaderSource (shader, source);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_shader_source (shader.id, source);
 		#end
 		
@@ -1719,7 +1719,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.stencilFunc (func, ref, mask);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_stencil_func (func, ref, mask);
 		#end
 		
@@ -1730,7 +1730,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.stencilFuncSeparate (face, func, ref, mask);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_stencil_func_separate (face, func, ref, mask);
 		#end
 		
@@ -1741,7 +1741,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.stencilMask (mask);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_stencil_mask (mask);
 		#end
 		
@@ -1752,7 +1752,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.stencilMaskSeparate (face, mask);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_stencil_mask_separate (face, mask);
 		#end
 		
@@ -1763,7 +1763,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.stencilOp (fail, zfail, zpass);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_stencil_op (fail, zfail, zpass);
 		#end
 		
@@ -1774,7 +1774,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.stencilOpSeparate (face, fail, zfail, zpass);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_stencil_op_separate (face, fail, zfail, zpass);
 		#end
 		
@@ -1799,7 +1799,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.texParameterf (target, pname, param);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_tex_parameterf (target, pname, param);
 		#end
 		
@@ -1810,7 +1810,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.texParameteri (target, pname, param);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_tex_parameteri (target, pname, param);
 		#end
 		
@@ -1835,7 +1835,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform1f (location, x);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform1f (location, x);
 		#end
 		
@@ -1859,7 +1859,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform1i (location, x);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform1i (location, x);
 		#end
 		
@@ -1883,7 +1883,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform2f (location, x, y);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform2f (location, x, y);
 		#end
 		
@@ -1907,7 +1907,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform2i (location, x, y);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform2i (location, x, y);
 		#end
 		
@@ -1931,7 +1931,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform3f (location, x, y, z);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform3f (location, x, y, z);
 		#end
 		
@@ -1955,7 +1955,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform3i (location, x, y, z);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform3i (location, x, y, z);
 		#end
 		
@@ -1979,7 +1979,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform4f (location, x, y, z, w);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform4f (location, x, y, z, w);
 		#end
 		
@@ -2003,7 +2003,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.uniform4i (location, x, y, z, w);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_uniform4i (location, x, y, z, w);
 		#end
 		
@@ -2073,7 +2073,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.useProgram (program);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_use_program (program == null ? 0 : program.id);
 		#end
 		
@@ -2084,7 +2084,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.validateProgram (program);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_validate_program (program.id);
 		#end
 		
@@ -2095,7 +2095,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.vertexAttrib1f (indx, x);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_vertex_attrib1f (indx, x);
 		#end
 		
@@ -2119,7 +2119,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.vertexAttrib2f (indx, x, y);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_vertex_attrib2f (indx, x, y);
 		#end
 		
@@ -2143,7 +2143,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.vertexAttrib3f (indx, x, y, z);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_vertex_attrib3f (indx, x, y, z);
 		#end
 		
@@ -2167,7 +2167,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.vertexAttrib4f (indx, x, y, z, w);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_vertex_attrib4f (indx, x, y, z, w);
 		#end
 		
@@ -2191,7 +2191,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.vertexAttribPointer (indx, size, type, normalized, stride, offset);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_vertex_attrib_pointer (indx, size, type, normalized, stride, offset);
 		#end
 		
@@ -2202,7 +2202,7 @@ class GL {
 		
 		#if (js && html5 && !display)
 		context.viewport (x, y, width, height);
-		#elseif ((cpp || neko || nodejs) && lime_opengl && !macro)
+		#elseif (lime_native && lime_opengl && !macro)
 		lime_gl_viewport (x, y, width, height);
 		#end
 		
@@ -2212,7 +2212,7 @@ class GL {
 	private static function get_version ():Int { return 2; }
 	
 	
-	#if ((cpp || neko || nodejs) && lime_opengl && !macro)
+	#if (lime_native && lime_opengl && !macro)
 	@:cffi private static function lime_gl_active_texture (texture:Int):Void;
 	@:cffi private static function lime_gl_attach_shader (program:Int, shader:Int):Void;
 	@:cffi private static function lime_gl_bind_attrib_location (program:Int, index:Int, name:String):Void;

--- a/lime/graphics/utils/ImageCanvasUtil.hx
+++ b/lime/graphics/utils/ImageCanvasUtil.hx
@@ -11,7 +11,7 @@ import lime.math.Rectangle;
 import lime.math.Vector2;
 import lime.utils.UInt8Array;
 
-#if (js && html5)
+#if lime_html5
 import js.Browser;
 #end
 
@@ -62,7 +62,7 @@ class ImageCanvasUtil {
 	
 	public static function convertToData (image:Image):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (image.buffer.data == null) {
 			
 			convertToCanvas (image);
@@ -135,7 +135,7 @@ class ImageCanvasUtil {
 	
 	public static function createCanvas (image:Image, width:Int, height:Int):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		var buffer = image.buffer;
 		
 		if (buffer.__srcCanvas == null) {
@@ -168,7 +168,7 @@ class ImageCanvasUtil {
 	
 	public static function createImageData (image:Image):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		
 		var buffer = image.buffer;
 		
@@ -353,7 +353,7 @@ class ImageCanvasUtil {
 	
 	public static function sync (image:Image, clear:Bool):Void {
 		
-		#if (js && html5)
+		#if lime_html5
 		if (image.dirty && image.buffer.__srcImageData != null && image.type != DATA) {
 			
 			image.buffer.__srcContext.putImageData (image.buffer.__srcImageData, 0, 0);

--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -31,7 +31,7 @@ class ImageDataUtil {
 		var data = image.buffer.data;
 		if (data == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_color_transform (image, rect, colorMatrix); else
 		#end
 		{
@@ -96,7 +96,7 @@ class ImageDataUtil {
 		
 		if (srcData == null || destData == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_copy_channel (image, sourceImage, sourceRect, destPoint, srcIdx, destIdx); else
 		#end
 		{
@@ -157,7 +157,7 @@ class ImageDataUtil {
 	
 	public static function copyPixels (image:Image, sourceImage:Image, sourceRect:Rectangle, destPoint:Vector2, alphaImage:Image = null, alphaPoint:Vector2 = null, mergeAlpha:Bool = false):Void {
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_copy_pixels (image, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha); else
 		#end
 		{
@@ -322,7 +322,7 @@ class ImageDataUtil {
 		var data = image.buffer.data;
 		if (data == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_fill_rect (image, rect, (fillColor >> 16) & 0xFFFF, (fillColor) & 0xFFFF); else // TODO: Better Int32 solution
 		#end
 		{
@@ -359,7 +359,7 @@ class ImageDataUtil {
 		
 		if (format == ARGB32) color = ((color & 0xFFFFFF) << 8) | ((color >> 24) & 0xFF);
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_flood_fill (image, x, y, (color >> 16) & 0xFFFF, (color) & 0xFFFF); else // TODO: Better Int32 solution
 		#end
 		{
@@ -643,7 +643,7 @@ class ImageDataUtil {
 		var length = Std.int (rect.width * rect.height);
 		var bytes = Bytes.alloc (length * 4);
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_get_pixels (image, rect, format, bytes); else
 		#end
 		{
@@ -694,7 +694,7 @@ class ImageDataUtil {
 		
 		if (image.buffer.data == null || sourceImage.buffer.data == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_merge (image, sourceImage, sourceRect, destPoint, redMultiplier, greenMultiplier, blueMultiplier, alphaMultiplier); else
 		#end
 		{
@@ -747,7 +747,7 @@ class ImageDataUtil {
 		var data = image.buffer.data;
 		if (data == null || !image.buffer.transparent) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_multiply_alpha (image); else
 		#end
 		{
@@ -777,7 +777,7 @@ class ImageDataUtil {
 		if (buffer.width == newWidth && buffer.height == newHeight) return;
 		var newBuffer = new ImageBuffer (new UInt8Array (newWidth * newHeight * 4), newWidth, newHeight);
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_resize (image, newBuffer, newWidth, newHeight); else
 		#end
 		{
@@ -879,7 +879,7 @@ class ImageDataUtil {
 		var data = image.buffer.data;
 		if (data == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_set_format (image, format); else
 		#end
 		{
@@ -1012,7 +1012,7 @@ class ImageDataUtil {
 		
 		if (image.buffer.data == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_set_pixels (image, rect, bytes, format); else
 		#end
 		{
@@ -1104,7 +1104,7 @@ class ImageDataUtil {
 		
 		var hits = 0;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) hits = lime_image_data_util_threshold (image, sourceImage, sourceRect, destPoint, _operation, (_threshold >> 16) & 0xFFFF, (_threshold) & 0xFFFF, (_color >> 16) & 0xFFFF, (_color) & 0xFFFF, (_mask >> 16) & 0xFFFF, (_mask) & 0xFFFF, copySource); else
 		#end
 		{
@@ -1180,7 +1180,7 @@ class ImageDataUtil {
 		var data = image.buffer.data;
 		if (data == null) return;
 		
-		#if ((cpp || neko) && !disable_cffi && !macro)
+		#if (lime_image_data_cffi && !disable_cffi && !macro)
 		if (CFFI.enabled) lime_image_data_util_unmultiply_alpha (image); else
 		#end
 		{
@@ -1265,7 +1265,7 @@ class ImageDataUtil {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_image_data_util_color_transform (image:Dynamic, rect:Dynamic, colorMatrix:Dynamic):Void;
 	@:cffi private static function lime_image_data_util_copy_channel (image:Dynamic, sourceImage:Dynamic, sourceRect:Dynamic, destPoint:Dynamic, srcChannel:Int, destChannel:Int):Void;
 	@:cffi private static function lime_image_data_util_copy_pixels (image:Dynamic, sourceImage:Dynamic, sourceRect:Dynamic, destPoint:Dynamic, alphaImage:Dynamic, alphaPoint:Dynamic, mergeAlpha:Bool):Void;

--- a/lime/net/HTTPRequest.hx
+++ b/lime/net/HTTPRequest.hx
@@ -9,7 +9,7 @@ import lime.system.BackgroundWorker;
 import lime.system.CFFI;
 import lime.utils.Bytes;
 
-#if (js && html5)
+#if lime_html5
 import js.html.XMLHttpRequest;
 #end
 
@@ -40,7 +40,7 @@ class HTTPRequest {
 		
 		
 		
-		#elseif (js && html5)
+		#elseif lime_html5
 		
 		var request = new XMLHttpRequest ();
 		request.addEventListener ("progress", request_onProgress, false);

--- a/lime/net/curl/CURL.hx
+++ b/lime/net/curl/CURL.hx
@@ -19,7 +19,7 @@ abstract CURL(Float) from Float to Float {
 	
 	public static function getDate (date:String, now:Int):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return cast lime_curl_getdate (date, cast now);
 		#else
 		return 0;
@@ -30,7 +30,7 @@ abstract CURL(Float) from Float to Float {
 	
 	public static function globalCleanup ():Void {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		lime_curl_global_cleanup ();
 		#end
 		
@@ -39,7 +39,7 @@ abstract CURL(Float) from Float to Float {
 	
 	public static function globalInit (flags:Int):CURLCode {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return cast lime_curl_global_init (flags);
 		#else
 		return cast 0;
@@ -50,7 +50,7 @@ abstract CURL(Float) from Float to Float {
 	
 	public static function version ():String {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_version ();
 		#else
 		return null;
@@ -61,7 +61,7 @@ abstract CURL(Float) from Float to Float {
 	
 	public static function versionInfo (type:CURLVersion):Dynamic {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_version_info (cast (type, Int));
 		#else
 		return null;
@@ -77,7 +77,7 @@ abstract CURL(Float) from Float to Float {
 	}
 	
 	
-	#if ((cpp || neko || nodejs) && lime_curl && !macro)
+	#if (lime_native && lime_curl && !macro)
 	@:cffi private static function lime_curl_getdate (date:String, now:Float):Float;
 	@:cffi private static function lime_curl_global_cleanup ():Void;
 	@:cffi private static function lime_curl_global_init (flags:Int):Int;

--- a/lime/net/curl/CURLEasy.hx
+++ b/lime/net/curl/CURLEasy.hx
@@ -14,7 +14,7 @@ class CURLEasy {
 	
 	public static function cleanup (handle:CURL):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		lime_curl_easy_cleanup (handle);
 		#end
 		
@@ -23,7 +23,7 @@ class CURLEasy {
 	
 	public static function duphandle (handle:CURL):CURL {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_easy_duphandle (handle);
 		#else
 		return 0;
@@ -34,7 +34,7 @@ class CURLEasy {
 	
 	public static function escape (handle:CURL, url:String, length:Int):String {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_easy_escape (handle, url, length);
 		#else
 		return null;
@@ -45,7 +45,7 @@ class CURLEasy {
 	
 	public static function getinfo (handle:CURL, info:CURLInfo):Dynamic {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_easy_getinfo (handle, cast (info, Int));
 		#else
 		return null;
@@ -56,7 +56,7 @@ class CURLEasy {
 	
 	public static function init ():CURL {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_easy_init ();
 		#else
 		return 0;
@@ -67,7 +67,7 @@ class CURLEasy {
 	
 	public static function pause (handle:CURL, bitMask:Int):CURLCode {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return cast lime_curl_easy_pause (handle, bitMask);
 		#else
 		return cast 0;
@@ -78,7 +78,7 @@ class CURLEasy {
 	
 	public static function perform (handle:CURL):CURLCode {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return cast lime_curl_easy_perform (handle);
 		#else
 		return cast 0;
@@ -89,7 +89,7 @@ class CURLEasy {
 	
 	/*public static function recv (handle:Dynamic):CURLCode {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return cast lime_curl_easy_perform (handle);
 		#else
 		return cast 0;
@@ -100,7 +100,7 @@ class CURLEasy {
 	
 	public static function reset (handle:CURL):Void {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		lime_curl_easy_reset (handle);
 		#end
 		
@@ -109,7 +109,7 @@ class CURLEasy {
 	
 	/*public static function send (handle:Dynamic):CURLCode {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return cast lime_curl_easy_perform (handle);
 		#else
 		return cast 0;
@@ -120,7 +120,7 @@ class CURLEasy {
 	
 	public static function setopt (handle:CURL, option:CURLOption, parameter:Dynamic):CURLCode {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		if (option == CURLOption.WRITEFUNCTION || option == CURLOption.HEADERFUNCTION) {
 			
 			parameter = __writeCallback.bind (parameter);
@@ -136,7 +136,7 @@ class CURLEasy {
 	
 	public static function strerror (code:CURLCode):String {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_easy_strerror (cast (code, Int));
 		#else
 		return null;
@@ -147,7 +147,7 @@ class CURLEasy {
 	
 	public static function unescape (handle:CURL, url:String, inLength:Int, outLength:Int):String {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		return lime_curl_easy_unescape (handle, url, inLength, outLength);
 		#else
 		return null;
@@ -158,7 +158,7 @@ class CURLEasy {
 	
 	private static function __writeCallback (callback:Dynamic, output:Dynamic, size:Int, nmemb:Int):Int {
 		
-		#if ((cpp || neko || nodejs) && lime_curl && !macro)
+		#if (lime_native && lime_curl && !macro)
 		var bytes:Bytes = null;
 		
 		if (output != null) {
@@ -178,7 +178,7 @@ class CURLEasy {
 	}
 	
 	
-	#if ((cpp || neko || nodejs) && lime_curl && !macro)
+	#if (lime_native && lime_curl && !macro)
 	@:cffi private static function lime_curl_easy_cleanup (handle:Float):Void;
 	@:cffi private static function lime_curl_easy_duphandle (handle:Float):Float;
 	@:cffi private static function lime_curl_easy_escape (curl:Float, url:String, length:Int):Dynamic;

--- a/lime/project/WindowData.hx
+++ b/lime/project/WindowData.hx
@@ -24,7 +24,7 @@ typedef WindowData = {
 	@:optional var depthBuffer:Bool;
 	@:optional var stencilBuffer:Bool;
 	@:optional var title:String;
-	#if (js && html5)
+	#if lime_html5
 	@:optional var element:#if (haxe_ver >= "3.2") js.html.Element #else js.html.HtmlElement #end;
 	#end
 	

--- a/lime/system/CFFI.hx
+++ b/lime/system/CFFI.hx
@@ -23,7 +23,7 @@ class CFFI {
 	
 	private static function __init__ ():Void {
 		
-		#if (cpp || neko || nodejs)
+		#if lime_native
 		available = true;
 		enabled = #if disable_cffi false; #else true; #end
 		#else

--- a/lime/system/CFFIPointer.hx
+++ b/lime/system/CFFIPointer.hx
@@ -19,7 +19,7 @@ abstract CFFIPointer(Dynamic) from Dynamic to Dynamic {
 		
 		if (this != null) {
 			
-			#if ((cpp || neko || nodejs) && !macro)
+			#if (lime_native && !macro)
 			return lime_cffi_get_native_pointer (this);
 			#end
 			
@@ -51,7 +51,7 @@ abstract CFFIPointer(Dynamic) from Dynamic to Dynamic {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_cffi_get_native_pointer (ptr:Dynamic):Float;
 	#end
 	

--- a/lime/system/Clipboard.hx
+++ b/lime/system/Clipboard.hx
@@ -25,7 +25,7 @@ class Clipboard {
 	
 	private static function get_text ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_clipboard_get_text ();
 		#elseif flash
 		if (FlashClipboard.generalClipboard.hasFormat (TEXT_FORMAT)) {
@@ -42,7 +42,7 @@ class Clipboard {
 	
 	private static function set_text (value:String):String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		lime_clipboard_set_text (value);
 		return value;
 		#elseif flash
@@ -62,7 +62,7 @@ class Clipboard {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_clipboard_get_text ():Dynamic;
 	@:cffi private static function lime_clipboard_set_text (text:String):Void;
 	#end

--- a/lime/system/System.hx
+++ b/lime/system/System.hx
@@ -170,7 +170,15 @@ class System {
 				
 			}
 			
-			display.currentMode = display.supportedModes[displayInfo.currentMode];
+			if (Reflect.hasField (displayInfo, "currentMode")) {
+				
+				display.currentMode = display.supportedModes[displayInfo.currentMode];
+				
+			} else {
+				
+				display.currentMode = new DisplayMode (0, 0, 60, ARGB32);
+				
+			}
 			
 			return display;
 			

--- a/lime/system/System.hx
+++ b/lime/system/System.hx
@@ -9,7 +9,7 @@ import flash.system.Capabilities;
 import flash.Lib;
 #end
 
-#if (js && html5)
+#if lime_html5
 #if (haxe_ver >= "3.2")
 import js.html.Element;
 #else
@@ -45,7 +45,7 @@ class System {
 	public static var userDirectory (get, null):String;
 	
 	
-	#if (js && html5)
+	#if lime_html5
 	@:keep @:expose("lime.embed")
 	public static function embed (element:Dynamic, width:Null<Int> = null, height:Null<Int> = null, background:String = null, assetsPrefix:String = null) {
 		
@@ -148,7 +148,7 @@ class System {
 	
 	public static function getDisplay (id:Int):Display {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		var displayInfo:Dynamic = lime_system_get_display (id);
 		
 		if (displayInfo != null) {
@@ -193,7 +193,7 @@ class System {
 			#if flash
 			display.dpi = Capabilities.screenDPI;
 			display.currentMode = new DisplayMode (Std.int (Capabilities.screenResolutionX), Std.int (Capabilities.screenResolutionY), 60, ARGB32);
-			#else
+			#elseif lime_html5
 			display.dpi = 96; // TODO: Detect DPI on HTML5
 			display.currentMode = new DisplayMode (Browser.window.screen.width, Browser.window.screen.height, 60, ARGB32);
 			#end
@@ -216,7 +216,7 @@ class System {
 		return flash.Lib.getTimer ();
 		#elseif js
 		return cast Date.now ().getTime ();
-		#elseif (!disable_cffi && !macro)
+		#elseif (lime_native && !disable_cffi && !macro)
 		return cast lime_system_get_timer ();
 		#elseif cpp
 		return Std.int (untyped __global__.__time_stamp () * 1000);
@@ -249,7 +249,7 @@ class System {
 	
 	private static function get_allowScreenTimeout ():Bool {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_allow_screen_timeout ();
 		#else
 		return true;
@@ -260,7 +260,7 @@ class System {
 	
 	private static function set_allowScreenTimeout (value:Bool):Bool {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_set_allow_screen_timeout (value);
 		#else
 		return true;
@@ -271,7 +271,7 @@ class System {
 	
 	private static function get_applicationDirectory ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_directory (SystemDirectory.APPLICATION, null, null);
 		#elseif flash
 		if (Capabilities.playerType == "Desktop") {
@@ -311,7 +311,7 @@ class System {
 			
 		}
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_directory (SystemDirectory.APPLICATION_STORAGE, company, file);
 		#elseif flash
 		if (Capabilities.playerType == "Desktop") {
@@ -332,7 +332,7 @@ class System {
 	
 	private static function get_desktopDirectory ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_directory (SystemDirectory.DESKTOP, null, null);
 		#elseif flash
 		if (Capabilities.playerType == "Desktop") {
@@ -353,7 +353,7 @@ class System {
 	
 	private static function get_documentsDirectory ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_directory (SystemDirectory.DOCUMENTS, null, null);
 		#elseif flash
 		if (Capabilities.playerType == "Desktop") {
@@ -374,7 +374,7 @@ class System {
 	
 	private static function get_fontsDirectory ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_directory (SystemDirectory.FONTS, null, null);
 		#else
 		return null;
@@ -385,7 +385,7 @@ class System {
 	
 	private static function get_numDisplays ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_num_displays ();
 		#else
 		return 1;
@@ -396,7 +396,7 @@ class System {
 	
 	private static function get_userDirectory ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_system_get_directory (SystemDirectory.USER, null, null);
 		#elseif flash
 		if (Capabilities.playerType == "Desktop") {
@@ -435,7 +435,7 @@ class System {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_system_get_allow_screen_timeout ():Bool;
 	@:cffi private static function lime_system_set_allow_screen_timeout (value:Bool):Bool;
 	@:cffi private static function lime_system_get_directory (type:Int, company:String, title:String):Dynamic;

--- a/lime/text/Font.hx
+++ b/lime/text/Font.hx
@@ -8,12 +8,12 @@ import lime.math.Vector2;
 import lime.system.System;
 import lime.utils.UInt8Array;
 
-#if (js && html5)
+#if lime_html5
 import js.html.CanvasElement;
 import js.html.CanvasRenderingContext2D;
 #end
 
-#if ((cpp || neko || nodejs) && !macro)
+#if (lime_native && !macro)
 import haxe.io.Path;
 #end
 
@@ -42,7 +42,7 @@ class Font {
 	public var unitsPerEM (get, null):Int;
 	
 	@:noCompletion private var __fontPath:String;
-	#if (cpp || neko || nodejs)
+	#if lime_native
 	@:noCompletion private var __fontPathWithoutDirectory:String;
 	#end
 	
@@ -66,7 +66,7 @@ class Font {
 	
 	public function decompose ():NativeFontData {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		if (src == null) throw "Uninitialized font handle.";
 		var data:Dynamic = lime_font_outline_decompose (src, 1024 * 20);
@@ -86,7 +86,7 @@ class Font {
 		var font = new Font ();
 		font.__fromBytes (bytes);
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return (font.src != null) ? font : null;
 		#else
 		return font;
@@ -100,7 +100,7 @@ class Font {
 		var font = new Font ();
 		font.__fromFile (path);
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return (font.src != null) ? font : null;
 		#else
 		return font;
@@ -111,7 +111,7 @@ class Font {
 	
 	public function getGlyph (character:String):Glyph {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_glyph_index (src, character);
 		#else
 		return -1;
@@ -122,7 +122,7 @@ class Font {
 	
 	public function getGlyphs (characters:String = #if (display && haxe_ver < "3.2") "" #else "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^`'\"/\\&*()[]{}<>|:;_-+=?,. " #end):Array<Glyph> {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		var glyphs:Dynamic = lime_font_get_glyph_indices (src, characters);
 		return glyphs;
 		#else
@@ -134,7 +134,7 @@ class Font {
 	
 	public function getGlyphMetrics (glyph:Glyph):GlyphMetrics {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		var value:Dynamic = lime_font_get_glyph_metrics (src, glyph);
 		var metrics = new GlyphMetrics ();
 		
@@ -153,7 +153,7 @@ class Font {
 	
 	public function renderGlyph (glyph:Glyph, fontSize:Int):Image {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		__setSize (fontSize);
 		
@@ -191,7 +191,7 @@ class Font {
 	
 	public function renderGlyphs (glyphs:Array<Glyph>, fontSize:Int):Map<Glyph, Image> {
 		
-		//#if ((cpp || neko || nodejs) && !macro)
+		//#if (lime_native && !macro)
 		//
 		//var uniqueGlyphs = new Map<Int, Bool> ();
 		//
@@ -357,7 +357,7 @@ class Font {
 		
 		__fontPath = null;
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		__fontPathWithoutDirectory = null;
 		
@@ -378,7 +378,7 @@ class Font {
 		
 		__fontPath = path;
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		__fontPathWithoutDirectory = Path.withoutDirectory (__fontPath);
 		
@@ -397,7 +397,7 @@ class Font {
 	
 	@:noCompletion private function __setSize (size:Int):Void {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		lime_font_set_size (src, size);
 		#end
 		
@@ -413,7 +413,7 @@ class Font {
 	
 	private function get_ascender ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_ascender (src);
 		#else
 		return 0;
@@ -424,7 +424,7 @@ class Font {
 	
 	private function get_descender ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_descender (src);
 		#else
 		return 0;
@@ -435,7 +435,7 @@ class Font {
 	
 	private function get_height ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_height (src);
 		#else
 		return 0;
@@ -446,7 +446,7 @@ class Font {
 	
 	private function get_numGlyphs ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_num_glyphs (src);
 		#else
 		return 0;
@@ -457,7 +457,7 @@ class Font {
 	
 	private function get_underlinePosition ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_underline_position (src);
 		#else
 		return 0;
@@ -468,7 +468,7 @@ class Font {
 	
 	private function get_underlineThickness ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_underline_thickness (src);
 		#else
 		return 0;
@@ -479,7 +479,7 @@ class Font {
 	
 	private function get_unitsPerEM ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_font_get_units_per_em (src);
 		#else
 		return 0;
@@ -495,7 +495,7 @@ class Font {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_font_get_ascender (handle:Dynamic):Int;
 	@:cffi private static function lime_font_get_descender (handle:Dynamic):Int;
 	@:cffi private static function lime_font_get_family_name (handle:Dynamic):Dynamic;

--- a/lime/text/TextLayout.hx
+++ b/lime/text/TextLayout.hx
@@ -45,7 +45,7 @@ class TextLayout {
 		positions = [];
 		__dirty = true;
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		__handle = lime_text_layout_create (__direction, __script, __language);
 		#end
 	}
@@ -55,7 +55,7 @@ class TextLayout {
 		
 		positions = [];
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		
 		if (__handle != null && text != null && text != "" && font != null && font.src != null) {
 			
@@ -128,7 +128,7 @@ class TextLayout {
 		
 		__direction = value;
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		lime_text_layout_set_direction (__handle, value);
 		#end
 		
@@ -178,7 +178,7 @@ class TextLayout {
 		
 		__language = value;
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		lime_text_layout_set_language (__handle, value);
 		#end
 		
@@ -202,7 +202,7 @@ class TextLayout {
 		
 		__script = value;
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		lime_text_layout_set_script (__handle, value);
 		#end
 		
@@ -242,7 +242,7 @@ class TextLayout {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_text_layout_create (direction:Int, script:String, language:String):Dynamic;
 	@:cffi private static function lime_text_layout_position (textHandle:Dynamic, fontHandle:Dynamic, size:Int, textString:String, data:Dynamic):Dynamic;
 	@:cffi private static function lime_text_layout_set_direction (textHandle:Dynamic, direction:Int):Void;

--- a/lime/ui/FileDialog.hx
+++ b/lime/ui/FileDialog.hx
@@ -308,7 +308,7 @@ class FileDialog {
 	
 	
 	
-	#if (cpp || neko || nodejs)
+	#if lime_native
 	@:cffi private static function lime_file_dialog_open_directory (filter:String, defaultPath:String):Dynamic;
 	@:cffi private static function lime_file_dialog_open_file (filter:String, defaultPath:String):Dynamic;
 	@:cffi private static function lime_file_dialog_open_files (filter:String, defaultPath:String):Dynamic;

--- a/lime/ui/Gamepad.hx
+++ b/lime/ui/Gamepad.hx
@@ -36,7 +36,7 @@ class Gamepad {
 	
 	public static function addMappings (mappings:Array<String>):Void {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		lime_gamepad_add_mappings (mappings);
 		#end
 		
@@ -75,9 +75,9 @@ class Gamepad {
 	
 	@:noCompletion private inline function get_guid ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_gamepad_get_device_guid (this.id);
-		#elseif (js && html5)
+		#elseif lime_html5
 		var devices = Joystick.__getDeviceData ();
 		return devices[this.id].id;
 		#else
@@ -89,9 +89,9 @@ class Gamepad {
 	
 	@:noCompletion private inline function get_name ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_gamepad_get_device_name (this.id);
-		#elseif (js && html5)
+		#elseif lime_html5
 		var devices = Joystick.__getDeviceData ();
 		return devices[this.id].id;
 		#else
@@ -108,7 +108,7 @@ class Gamepad {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_gamepad_add_mappings (mappings:Dynamic):Void;
 	@:cffi private static function lime_gamepad_get_device_guid (id:Int):Dynamic;
 	@:cffi private static function lime_gamepad_get_device_name (id:Int):Dynamic;

--- a/lime/ui/Joystick.hx
+++ b/lime/ui/Joystick.hx
@@ -61,7 +61,7 @@ class Joystick {
 	}
 	
 	
-	#if (js && html5)
+	#if lime_html5
 	@:noCompletion private static function __getDeviceData ():Array<Dynamic> {
 		
 		return (untyped navigator.getGamepads) ? untyped navigator.getGamepads () : (untyped navigator.webkitGetGamepads) ? untyped navigator.webkitGetGamepads () : null;
@@ -79,9 +79,9 @@ class Joystick {
 	
 	@:noCompletion private inline function get_guid ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_joystick_get_device_guid (this.id);
-		#elseif (js && html5)
+		#elseif lime_html5
 		var devices = __getDeviceData ();
 		return devices[this.id].id;
 		#else
@@ -93,9 +93,9 @@ class Joystick {
 	
 	@:noCompletion private inline function get_name ():String {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_joystick_get_device_name (this.id);
-		#elseif (js && html5)
+		#elseif lime_html5
 		var devices = __getDeviceData ();
 		return devices[this.id].id;
 		#else
@@ -107,9 +107,9 @@ class Joystick {
 	
 	@:noCompletion private inline function get_numAxes ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_joystick_get_num_axes (this.id);
-		#elseif (js && html5)
+		#elseif lime_html5
 		var devices = __getDeviceData ();
 		return devices[this.id].axes.length;
 		#else
@@ -121,9 +121,9 @@ class Joystick {
 	
 	@:noCompletion private inline function get_numButtons ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_joystick_get_num_buttons (this.id);
-		#elseif (js && html5)
+		#elseif lime_html5
 		var devices = __getDeviceData ();
 		return devices[this.id].buttons.length;
 		#else
@@ -135,7 +135,7 @@ class Joystick {
 	
 	@:noCompletion private inline function get_numHats ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_joystick_get_num_hats (this.id);
 		#else
 		return 0;
@@ -146,7 +146,7 @@ class Joystick {
 	
 	@:noCompletion private inline function get_numTrackballs ():Int {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		return lime_joystick_get_num_trackballs (this.id);
 		#else
 		return 0;
@@ -162,7 +162,7 @@ class Joystick {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_joystick_get_device_guid (id:Int):Dynamic;
 	@:cffi private static function lime_joystick_get_device_name (id:Int):Dynamic;
 	@:cffi private static function lime_joystick_get_num_axes (id:Int):Int;

--- a/lime/ui/Mouse.hx
+++ b/lime/ui/Mouse.hx
@@ -69,7 +69,7 @@ class Mouse {
 
 #if flash
 @:noCompletion private typedef MouseBackend = lime._backend.flash.FlashMouse;
-#elseif (js && html5)
+#elseif lime_html5
 @:noCompletion private typedef MouseBackend = lime._backend.html5.HTML5Mouse;
 #else
 @:noCompletion private typedef MouseBackend = lime._backend.native.NativeMouse;

--- a/lime/ui/Window.hx
+++ b/lime/ui/Window.hx
@@ -497,7 +497,7 @@ class Window {
 
 #if flash
 @:noCompletion private typedef WindowBackend = lime._backend.flash.FlashWindow;
-#elseif (js && html5)
+#elseif lime_html5
 @:noCompletion private typedef WindowBackend = lime._backend.html5.HTML5Window;
 #else
 @:noCompletion private typedef WindowBackend = lime._backend.native.NativeWindow;

--- a/lime/utils/Bytes.hx
+++ b/lime/utils/Bytes.hx
@@ -67,7 +67,7 @@ class Bytes extends HaxeBytes {
 	}
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	public static function __fromNativePointer (data:Dynamic, length:Int):Bytes {
 		
 		var bytes:Dynamic = lime_bytes_from_data_pointer (data, length);

--- a/lime/utils/LZMA.hx
+++ b/lime/utils/LZMA.hx
@@ -13,7 +13,7 @@ class LZMA {
 	
 	public static function decode (bytes:Bytes):Bytes {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		var data:Dynamic = lime_lzma_decode (bytes);
 		return @:privateAccess new Bytes (data.length, data.b);
 		#else
@@ -25,7 +25,7 @@ class LZMA {
 	
 	public static function encode (bytes:Bytes):Bytes {
 		
-		#if ((cpp || neko || nodejs) && !macro)
+		#if (lime_native && !macro)
 		var data:Dynamic = lime_lzma_encode (bytes);
 		return @:privateAccess new Bytes (data.length, data.b);
 		#else
@@ -42,7 +42,7 @@ class LZMA {
 	
 	
 	
-	#if ((cpp || neko || nodejs) && !macro)
+	#if (lime_native && !macro)
 	@:cffi private static function lime_lzma_decode (data:Dynamic):Dynamic;
 	@:cffi private static function lime_lzma_encode (data:Dynamic):Dynamic;
 	#end

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -1201,7 +1201,15 @@ namespace lime {
 		if (path) {
 			
 			value _path = alloc_string (path);
-			free ((char*) path);
+			
+			if (type != 4) {
+				
+				// TODO: Make this more consistent
+				
+				free ((char*) path);
+				
+			}
+			
 			return _path;
 			
 		} else {

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -27,7 +27,7 @@ class ApplicationMain {
 		preloader.onComplete.add (start);
 		preloader.create (config);
 		
-		#if (js && html5)
+		#if lime_html5
 		var urls = [];
 		var types = [];
 		


### PR DESCRIPTION
I still think that copying and pasting ```#if (cpp || neko || nodejs)``` everywhere is bad. When we add other VMs/programming languages in the future, That expression will become like this:

```#if (cpp || neko || nodejs || java || cs || python)```

This looks too long. I tried replacing that expression with much simpler one, ```#if lime_native```, and I was able to do that without breaking document generation, though a little modification was needed in some places.