### PR TITLE
fixed: default fonts STILL didn't work on some iOS versions

### DIFF
--- a/legacy/project/src/common/FreeType.cpp
+++ b/legacy/project/src/common/FreeType.cpp
@@ -385,6 +385,7 @@ bool FindFile(const std::string& inName, const std::string& inPath, int inMaxDep
             if (file)
             {
                outPath = path;
+               fclose(file);
                closedir(d);
                return true;
             }


### PR DESCRIPTION
apple can’t decide on directory locations between devices and versions, so we’ll just recursively search /Library/Fonts instead