### PR TITLE
[DONT MERGE] Fix openURL on linux

### DIFF
--- a/lime/tools/helpers/ProcessHelper.hx
+++ b/lime/tools/helpers/ProcessHelper.hx
@@ -100,7 +100,7 @@ class ProcessHelper {
 			
 		} else {
 			
-			runCommand ("", "/usr/bin/xdg-open", [ url, "&" ]);
+			runCommand ("", "/usr/bin/xdg-open", [ url ]);
 			
 		}
 		


### PR DESCRIPTION
This isn't needed, the command returns immediately,
and keeping it does:
```
xdg-open: unexpected argument '&'
Try 'xdg-open --help' for more information.
```