### PR TITLE
Updating android ndk version

### DIFF
--- a/tools/utils/PlatformSetup.hx
+++ b/tools/utils/PlatformSetup.hx
@@ -25,11 +25,11 @@ class PlatformSetup {
 	
 	private static var airMacPath = "http://airdownload.adobe.com/air/mac/download/latest/AdobeAIRSDK.tbz2";
 	private static var airWindowsPath = "http://airdownload.adobe.com/air/win/download/latest/AdobeAIRSDK.zip";
-	private static var androidLinuxNDKPath = "http://dl.google.com/android/ndk/android-ndk-r8b-linux-x86.tar.bz2";
+	private static var androidLinuxNDKPath = "http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip";
 	private static var androidLinuxSDKPath = "http://dl.google.com/android/android-sdk_r22.0.5-linux.tgz";
-	private static var androidMacNDKPath = "http://dl.google.com/android/ndk/android-ndk-r8b-darwin-x86.tar.bz2";
+	private static var androidMacNDKPath = "http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip";
 	private static var androidMacSDKPath = "http://dl.google.com/android/android-sdk_r22.0.5-macosx.zip";
-	private static var androidWindowsNDKPath = "http://dl.google.com/android/ndk/android-ndk-r8b-windows.zip";
+	private static var androidWindowsNDKPath = "http://dl.google.com/android/repository/android-ndk-r11c-windows-x86_64.zip";
 	private static var androidWindowsSDKPath = "http://dl.google.com/android/android-sdk_r22.0.5-windows.zip";
 	private static var apacheAntUnixPath = "http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.2-bin.tar.gz";
 	private static var apacheAntWindowsPath = "http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.2-bin.zip";


### PR DESCRIPTION
Newer hxcpp require a newer ndk (see http://community.openfl.org/t/lime-rebuil-android/7273/5),
using it on linux without issue.

Might want to update the sdk too, I think the update procedure does that too anyway,
but haven't tested it so I left it for now.