### PR TITLE
Fixes for tvOS.

### DIFF
--- a/lime/tools/helpers/TVOSHelper.hx
+++ b/lime/tools/helpers/TVOSHelper.hx
@@ -42,7 +42,7 @@ class TVOSHelper {
 		if (project.targetFlags.exists("simulator")) {
 			
 			commands.push ("-arch");
-			commands.push ("i386");
+			commands.push ("x86_64");
 			
 		}
 		
@@ -101,7 +101,6 @@ class TVOSHelper {
 				var best = "";
 				var files = FileSystem.readDirectory (dev_path);
 				var extract_version = ~/^AppleTVOS(.*).sdk$/;
-				
 				for (file in files) {
 					if (extract_version.match (file)) {
 						var ver = extract_version.matched (1);
@@ -110,6 +109,7 @@ class TVOSHelper {
 					}
 				}
 				
+
 				if (best != "")
 					project.environment.set ("TVOS_VER", best);
 			}
@@ -201,9 +201,9 @@ class TVOSHelper {
 			Sys.command ("chmod", [ "+x", launcher ]);
 
             // device config
-            var defaultDevice = "appletv";
-            var devices:Array<String> = ["appletv", "iphone-4s", "iphone-5", "iphone-5s", "iphone-6-plus", "iphone-6", "ipad-2", "ipad-retina", "ipad-air"];
-            var oldDevices:Map<String, String> = ["iphone" => "iphone-6", "ipad" => "ipad-air"];
+            var defaultDevice = "apple-tv-1080p";
+            var devices:Array<String> = ["apple-tv-1080p"];
+            var oldDevices:Map<String, String> = ["appletv" => "apple-tv-1080p"];
 
             var deviceFlag:String = null;
             var deviceTypeID = null;

--- a/templates/tvos/PROJ/haxe/Build.hxml
+++ b/templates/tvos/PROJ/haxe/Build.hxml
@@ -1,5 +1,5 @@
 -main ApplicationMain ::HAXE_FLAGS::
 -D tvos
--D appletvos
+-D appletv
 --macro keep("::APP_MAIN::")
 -D no-compilation

--- a/templates/tvos/PROJ/haxe/makefile
+++ b/templates/tvos/PROJ/haxe/makefile
@@ -1,6 +1,6 @@
 
 ifeq ("$(ARCHS)","normal")
-	ARCHS = arm64 i386
+	ARCHS = arm64
 endif
 
 HAXE_BUILDS := $(ARCHS:%=build-haxe-%)
@@ -44,13 +44,6 @@ debug_print:
 
 LIB_BASE := build/$(CONFIG)/::CPP_LIBPREFIX::ApplicationMain$(DEBUG)
 LIB_DEST := $(DEBUG)/libApplicationMain.a
-
-build-haxe-i386:
-	@echo "Haxe simulator build: $(CONFIG)"
-	haxe Build.hxml -D simulator -cpp build/$(CONFIG) $(DEBUG)
-	cd build/$(CONFIG); export HXCPP_NO_COLOR=1; haxelib run ::CPP_BUILD_LIBRARY:: Build.xml -Dtvos -Dsimulator -DHXCPP_CPP11 $(DEF_DEBUG) $(HXCPP_CLANG) `cat Options.txt | while read LINE; do printf " -D$$LINE"; done`
-	cp build/$(CONFIG)/::CPP_LIBPREFIX::ApplicationMain$(DEBUG).appletvsim.a ../lib/i386$(LIB_DEST)
-	touch ../Classes/Main.mm
 
 build-haxe-x86_64:
 	@echo "Haxe simulator build: $(CONFIG)-64"


### PR DESCRIPTION
Forces the architecture to be 64 bit only when using the simulator.
Also fixes an issue where it was being set the wrong define thus not allowing to build for the simulator as expected.