### PR TITLE
Fix to audio looping/Neko OpenAL support.

### DIFF
--- a/lime/audio/AudioSource.hx
+++ b/lime/audio/AudioSource.hx
@@ -138,7 +138,7 @@ class AudioSource {
 				}
 				
 				id = al.genSource ();
-				al.sourcei (id, al.BUFFER, buffer.id);
+				al.sourcei (id, al.BUFFER, 0);
 			
 			default:
 			
@@ -181,6 +181,15 @@ class AudioSource {
 		if (playing || id == 0) {
 			
 			return;
+			
+		}
+		
+		var buffersQueued = AL.getSourcei(id, AL.BUFFERS_QUEUED);
+		var buffersWanted = (loops < 2) ? (loops + 1) : 3;
+		
+		for (i in buffersQueued...buffersWanted) {
+			
+			AL.sourceQueueBuffer(id, buffer.id);
 			
 		}
 		
@@ -363,16 +372,22 @@ class AudioSource {
 		
 		#if (!flash && !html5)
 		
-		playing = false;
 		
 		if (loops > 0) {
 			
 			loops--;
-			currentTime = 0;
-			play ();
+			
+			if (loops > 1) {
+				
+				AL.sourceQueueBuffer(id, buffer.id);
+				
+			}
+			
 			return;
 			
 		} else {
+			
+			playing = false;
 			
 			AL.sourceStop (id);
 			timer.stop ();

--- a/lime/audio/openal/AL.hx
+++ b/lime/audio/openal/AL.hx
@@ -846,7 +846,8 @@ class AL {
 	public static function sourceQueueBuffer (source:Int, buffer:Int):Void {
 		
 		#if ((cpp || neko || nodejs) && lime_openal && !macro)
-		lime_al_source_queue_buffers (source, 1, [ buffer ]);
+		var buffers:Array<Int> = [ buffer ];
+		lime_al_source_queue_buffers (source, 1, buffers);
 		#end
 		
 	}

--- a/project/src/audio/openal/OpenALBindings.cpp
+++ b/project/src/audio/openal/OpenALBindings.cpp
@@ -46,11 +46,20 @@ namespace lime {
 	
 	void lime_al_bufferfv (int buffer, int param, value values) {
 		
-		float* data = val_array_float (values);
-		
-		if (data) {
+		if (val_is_null (values) == false) {
+			
+			int size = val_array_size (values);
+			ALfloat *data = new ALfloat[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALfloat)val_float( val_array_i (values, i) );
+				
+			}
 			
 			alBufferfv (buffer, param, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -66,11 +75,20 @@ namespace lime {
 	
 	void lime_al_bufferiv (int buffer, int param, value values) {
 		
-		int* data = val_array_int (values);
-		
-		if (data) {
+		if (val_is_null (values) == false) {
+			
+			int size = val_array_size (values);
+			ALint* data = new ALint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALint)val_int( val_array_i (values, i) );
+				
+			}
 			
 			alBufferiv (buffer, param, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -109,11 +127,20 @@ namespace lime {
 	
 	void lime_al_delete_buffers (int n, value buffers) {
 		
-		int* data = val_array_int (buffers);
-		
-		if (data) {
+		if (val_is_null (buffers) == false) {
 			
-			alDeleteBuffers (n, (ALuint*)data);
+			int size = val_array_size (buffers);
+			ALuint* data = new ALuint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALuint)val_int( val_array_i (buffers, i) );
+				
+			}
+			
+			alDeleteBuffers (n, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -130,11 +157,20 @@ namespace lime {
 	
 	void lime_al_delete_sources (int n, value sources) {
 		
-		int* data = val_array_int (sources);
-		
-		if (data) {
+		if (val_is_null (sources) == false) {
 			
-			alDeleteSources (n, (ALuint*)data);
+			int size = val_array_size (sources);
+			ALuint* data = new ALuint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALuint)val_int( val_array_i (sources, i) );
+				
+			}
+			
+			alDeleteSources (n, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -674,11 +710,20 @@ namespace lime {
 	
 	void lime_al_listenerfv (int param, value values) {
 		
-		float* data = val_array_float (values);
-		
-		if (data) {
+		if (val_is_null (values) == false) {
 			
-			alListenerfv (param, data);
+			int size = val_array_size (values);
+			ALfloat *data = new ALfloat[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALfloat)val_float( val_array_i (values, i) );
+				
+			}
+			
+			alListenerfv(param, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -694,11 +739,20 @@ namespace lime {
 	
 	void lime_al_listeneriv (int param, value values) {
 		
-		int* data = val_array_int (values);
-		
-		if (data) {
+		if (val_is_null (values) == false) {
+			
+			int size = val_array_size (values);
+			ALint* data = new ALint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALint)val_int( val_array_i (values, i) );
+				
+			}
 			
 			alListeneriv (param, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -714,14 +768,22 @@ namespace lime {
 	
 	void lime_al_source_pausev (int n, value sources) {
 		
-		int* data = val_array_int (sources);
-		
-		if (data) {
+		if (val_is_null (sources) == false) {
 			
-			alSourcePausev (n, (ALuint*)data);
+			int size = val_array_size (sources);
+			ALuint* data = new ALuint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALuint)val_int( val_array_i (sources, i) );
+				
+			}
+			
+			alSourcePausev (n, data);
+			
+			delete[] data;
 			
 		}
-		
 	}
 	
 	
@@ -734,11 +796,20 @@ namespace lime {
 	
 	void lime_al_source_playv (int n, value sources) {
 		
-		int* data = val_array_int (sources);
-		
-		if (data) {
+		if (val_is_null (sources) == false) {
 			
-			alSourcePlayv (n, (ALuint*)data);
+			int size = val_array_size (sources);
+			ALuint* data = new ALuint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALuint)val_int( val_array_i (sources, i) );
+				
+			}
+			
+			alSourcePlayv (n, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -747,11 +818,20 @@ namespace lime {
 	
 	void lime_al_source_queue_buffers (int source, int nb, value buffers) {
 		
-		int* data = val_array_int (buffers);
-		
-		if (data) {
+		if (val_is_null (buffers) == false) {
 			
-			alSourceQueueBuffers (source, nb, (ALuint*)data);
+			int size = val_array_size (buffers);
+			ALuint* data = new ALuint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALuint)val_int( val_array_i (buffers, i) );
+				
+			}
+			
+			alSourceQueueBuffers (source, nb, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -767,11 +847,20 @@ namespace lime {
 	
 	void lime_al_source_rewindv (int n, value sources) {
 		
-		int* data = val_array_int (sources);
-		
-		if (data) {
+		if (val_is_null (sources) == false) {
 			
-			alSourceRewindv (n, (ALuint*)data);
+			int size = val_array_size (sources);
+			ALuint* data = new ALuint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALuint)val_int( val_array_i (sources, i) );
+				
+			}
+			
+			alSourceRewindv (n, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -787,11 +876,20 @@ namespace lime {
 	
 	void lime_al_source_stopv (int n, value sources) {
 		
-		int* data = val_array_int (sources);
-		
-		if (data) {
+		if (val_is_null (sources) == false) {
 			
-			alSourceStopv (n, (ALuint*)data);
+			int size = val_array_size (sources);
+			ALuint* data = new ALuint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALuint)val_int( val_array_i (sources, i) );
+				
+			}
+			
+			alSourceStopv (n, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -840,11 +938,20 @@ namespace lime {
 	
 	void lime_al_sourcefv (int source, int param, value values) {
 		
-		float* data = val_array_float (values);
-		
-		if (data) {
+		if (val_is_null (values) == false) {
+			
+			int size = val_array_size (values);
+			ALfloat *data = new ALfloat[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALfloat)val_float( val_array_i (values, i) );
+				
+			}
 			
 			alSourcefv (source, param, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -860,11 +967,20 @@ namespace lime {
 	
 	void lime_al_sourceiv (int source, int param, value values) {
 		
-		int* data = val_array_int (values);
-		
-		if (data) {
+		if (val_is_null (values) == false) {
+			
+			int size = val_array_size (values);
+			ALint* data = new ALint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				
+				data[i] = (ALint)val_int( val_array_i (values, i) );
+				
+			}
 			
 			alSourceiv (source, param, data);
+			
+			delete[] data;
 			
 		}
 		
@@ -889,9 +1005,26 @@ namespace lime {
 	value lime_alc_create_context (value device, value attrlist) {
 		
 		ALCdevice* alcDevice = (ALCdevice*)val_data (device);
-		int* list = val_array_int (attrlist);
+		
+		ALCint* list = NULL;
+		
+		if (val_is_null (attrlist) == false) {
+			
+			int size = val_array_size (attrlist);
+			list = new ALCint[size];
+			
+			for (int i = 0; i < size; ++i) {
+				list[i] = (ALCint)val_int( val_array_i (attrlist, i) );
+			}
+			
+		}
 		
 		ALCcontext* alcContext = alcCreateContext (alcDevice, list);
+		
+		if (list != NULL) {
+			delete[] list;
+		}
+		
 		return CFFIPointer (alcContext);
 		
 	}


### PR DESCRIPTION
Two changes in this PR:
- Looping buffers in an AudioSource is now handled by queueing them, instead of a timer. This creates sample-accurate looping. Limited numbers of buffers are used to allow for absurd loop values with no cost.
- Changes val_array_int and val_array_float references in OpenALBindings.cpp to temporary buffers, to fix compatibility with neko.
  - Possible improvement, if more annoying to maintain: Keep the original val_array_* code around and only use these as a fallback for when they fail.

Some other things noted:
- This change breaks the starting offset on loop, and will always reset to the start of the buffer. OpenAL does not support looping offsets, to my knowledge.
  - Suggestion: When buffer streaming gets added, allow streaming to be done on a 'view' of an existing AudioBuffer.
- AudioSource's looping timer does not work correctly if the current playback time is set to a non-zero value.
  - Suggestion: This could be fixed by forcing it to restart the timer on a loop. Did not perform this change, but I can on request.
