### PR TITLE
Initialize premultiplied in ImageBuffer's constructor

### DIFF
--- a/lime/graphics/ImageBuffer.hx
+++ b/lime/graphics/ImageBuffer.hx
@@ -48,6 +48,7 @@ class ImageBuffer {
 		this.height = height;
 		this.bitsPerPixel = bitsPerPixel;
 		this.format = (format == null ? RGBA32 : format);
+		premultiplied = false;
 		transparent = true;
 		
 	}


### PR DESCRIPTION
If you don't initialize Bool field in constructor, it will become undefined on dynamic targets. Undefined and false are not the same thing, so it may cause issues.