### PR TITLE
Implement virtual destructors in some C++ classes

### DIFF
--- a/project/include/app/Application.h
+++ b/project/include/app/Application.h
@@ -13,6 +13,8 @@ namespace lime {
 		
 		public:
 			
+			virtual ~Application () {};
+			
 			static AutoGCRoot* callback;
 			
 			virtual int Exec () = 0;

--- a/project/include/graphics/Renderer.h
+++ b/project/include/graphics/Renderer.h
@@ -16,6 +16,8 @@ namespace lime {
 		
 		public:
 			
+			virtual ~Renderer() {};
+			
 			virtual void Flip () = 0;
 			virtual void* GetContext () = 0;
 			virtual double GetScale () = 0;

--- a/project/include/graphics/Renderer.h
+++ b/project/include/graphics/Renderer.h
@@ -16,7 +16,7 @@ namespace lime {
 		
 		public:
 			
-			virtual ~Renderer() {};
+			virtual ~Renderer () {};
 			
 			virtual void Flip () = 0;
 			virtual void* GetContext () = 0;

--- a/project/include/ui/Window.h
+++ b/project/include/ui/Window.h
@@ -19,7 +19,7 @@ namespace lime {
 		
 		public:
 			
-			virtual ~Window() {};
+			virtual ~Window () {};
 			
 			virtual void Alert (const char* message, const char* title) = 0;
 			virtual void Close () = 0;

--- a/project/include/ui/Window.h
+++ b/project/include/ui/Window.h
@@ -19,6 +19,8 @@ namespace lime {
 		
 		public:
 			
+			virtual ~Window() {};
+			
 			virtual void Alert (const char* message, const char* title) = 0;
 			virtual void Close () = 0;
 			virtual void Focus () = 0;


### PR DESCRIPTION
Not defining virtual destructors in these classes will cause memory leaks in subclasses, since destructors of subclasses are not called if it's not declared as virtual in base class.

https://github.com/openfl/lime/blob/b3164fa16143dc0dcc97fecf6cc2a1f7c43a79df/project/src/ExternalInterface.cpp#L92-L93

This will only call `Window`'s destructor if it's not virtual. To fix memory leaks, you need to cast window instance to SDLWindow, or define virtual destructor in base class. I think there is no reason to do former though.