### PR TITLE
Allow to include TBD dependencies in XML

### DIFF
--- a/lime/tools/platforms/IOSPlatform.hx
+++ b/lime/tools/platforms/IOSPlatform.hx
@@ -132,7 +132,7 @@ class IOSPlatform extends PlatformTarget {
 		
 		for (dependency in project.dependencies) {
 			
-			if (!StringTools.endsWith (dependency.name, ".framework") && !StringTools.endsWith (dependency.path, ".framework")) {
+			if (!StringTools.endsWith (dependency.name, ".framework") && !StringTools.endsWith (dependency.name, ".tbd") && !StringTools.endsWith (dependency.path, ".framework")) {
 				
 				if (dependency.path != "") {
 					
@@ -270,16 +270,25 @@ class IOSPlatform extends PlatformTarget {
 			
 			var name = null;
 			var path = null;
+			var fileType = null;
 			
 			if (Path.extension (dependency.name) == "framework") {
 				
 				name = dependency.name;
 				path = "/System/Library/Frameworks/" + dependency.name;
+				fileType = "wrapper.framework";
 				
+			} else if (Path.extension (dependency.name) == "tbd") {
+				
+				name = dependency.name;
+				path = "usr/lib/" + dependency.name;
+				fileType = "sourcecode.text-based-dylib-definition";
+
 			} else if (Path.extension (dependency.path) == "framework") {
 				
 				name = Path.withoutDirectory (dependency.path);
 				path = PathHelper.tryFullPath (dependency.path);
+				fileType = "wrapper.framework";
 				
 			}
 			
@@ -291,7 +300,7 @@ class IOSPlatform extends PlatformTarget {
 				ArrayHelper.addUnique (context.frameworkSearchPaths, Path.directory (path));
 				
 				context.ADDL_PBX_BUILD_FILE += "		" + frameworkID + " /* " + name + " in Frameworks */ = {isa = PBXBuildFile; fileRef = " + fileID + " /* " + name + " */; };\n";
-				context.ADDL_PBX_FILE_REFERENCE += "		" + fileID + " /* " + name + " */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = \"" + name + "\"; path = \"" + path + "\"; sourceTree = SDKROOT; };\n";
+				context.ADDL_PBX_FILE_REFERENCE += "		" + fileID + " /* " + name + " */ = {isa = PBXFileReference; lastKnownFileType = \"" + fileType + "\"; name = \"" + name + "\"; path = \"" + path + "\"; sourceTree = SDKROOT; };\n";
 				context.ADDL_PBX_FRAMEWORKS_BUILD_PHASE += "				" + frameworkID + " /* " + name + " in Frameworks */,\n";
 				context.ADDL_PBX_FRAMEWORK_GROUP += "				" + fileID + " /* " + name + " */,\n";
 				


### PR DESCRIPTION
This allows lime extensions to add things like:
<dependency name="libz.tbd" />

This is the only missing extension, since dylib packages are deprecated and replaced by TBD on xcode 7+