### PR TITLE
Fix fillRect behaviour when using alpha on neko/cpp (see #759 and #631)

### DIFF
--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -333,6 +333,7 @@ class ImageDataUtil {
 			
 			var format = image.buffer.format;
 			var premultiplied = image.buffer.premultiplied;
+			if (premultiplied) fillColor.multiplyAlpha();
 			
 			var dataView = new ImageDataView (image, rect);
 			var row;
@@ -343,7 +344,7 @@ class ImageDataUtil {
 				
 				for (x in 0...dataView.width) {
 					
-					fillColor.writeUInt8 (data, row + (x * 4), format, premultiplied);
+					fillColor.writeUInt8 (data, row + (x * 4), format, false);
 					
 				}
 				

--- a/project/src/graphics/utils/ImageDataUtil.cpp
+++ b/project/src/graphics/utils/ImageDataUtil.cpp
@@ -253,13 +253,15 @@ namespace lime {
 		int row;
 		RGBA fillColor (color);
 		
+		if (premultiplied) fillColor.MultiplyAlpha ();
+		
 		for (int y = 0; y < dataView.height; y++) {
 			
 			row = dataView.Row (y);
 			
 			for (int x = 0; x < dataView.width; x++) {
 				
-				fillColor.WriteUInt8 (data, row + (x * 4), format, premultiplied);
+				fillColor.WriteUInt8 (data, row + (x * 4), format, false);
 				
 			}
 			


### PR DESCRIPTION
Previously fillColor would get multiplied repeatedly in a loop, this PR aims to fix it by computing the premultiplied alpha value once, and using it in calls to fillColor.writeUInt8 with the premultiplied arg set to false.

See #759 and #631