### PR TITLE
Add ExtensionBGRA and ExtensionPackedDepthStencil

### DIFF
--- a/lime/graphics/opengl/ExtensionBGRA.hx
+++ b/lime/graphics/opengl/ExtensionBGRA.hx
@@ -1,0 +1,7 @@
+package lime.graphics.opengl;
+
+class ExtensionBGRA {
+	
+	public static inline var BGRA_EXT = 0x80E1;
+	
+}

--- a/lime/graphics/opengl/ExtensionPackedDepthStencil.hx
+++ b/lime/graphics/opengl/ExtensionPackedDepthStencil.hx
@@ -1,0 +1,7 @@
+package lime.graphics.opengl;
+
+class ExtensionPackedDepthStencil {
+	
+	public static inline var DEPTH24_STENCIL8_EXT = 0x88F0;
+	
+}


### PR DESCRIPTION
Instead of adding those constants to `GL` class directly, I added those to separate classes. WebGL does something like this to handle extension constants/functions.