### PR TITLE
Build directory

### DIFF
--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -1573,6 +1573,10 @@ class ProjectXMLParser extends HXProject {
 									
 									config.set ("android.gradle-version", value);
 								
+								case "gradle-build-directory":
+									
+									config.set ("android.gradle-build-directory", value);
+								
 								default:
 									
 									name = formatAttributeName (attribute);

--- a/lime/tools/platforms/AndroidPlatform.hx
+++ b/lime/tools/platforms/AndroidPlatform.hx
@@ -187,7 +187,8 @@ class AndroidPlatform extends PlatformTarget {
 			
 		}
 		
-		var apkPath = FileSystem.fullPath (targetDirectory) + "/bin/app/build/outputs/apk/";
+		var apkPath = FileSystem.fullPath (targetDirectory) + "/bin/app/build";
+		apkPath = project.config.getString ("android.gradle-build-directory", apkPath) + "/outputs/apk/";
 		var apkSuffix = "-" + build + ".apk";
 		
 		File.copy (apkPath + "app" + apkSuffix, apkPath + project.app.file + apkSuffix);
@@ -311,6 +312,7 @@ class AndroidPlatform extends PlatformTarget {
 		context.ANDROID_EXTENSIONS = project.config.getArrayString ("android.extension");
 		context.ANDROID_PERMISSIONS = project.config.getArrayString ("android.permission", [ "android.permission.WAKE_LOCK", "android.permission.INTERNET", "android.permission.VIBRATE", "android.permission.ACCESS_NETWORK_STATE" ]);
 		context.ANDROID_GRADLE_VERSION = project.config.getString ("android.gradle-version", "2.10");
+		if (project.config.exists ("android.gradle-build-directory")) context.ANDROID_GRADLE_BUILD_DIRECTORY = project.config.getString ("android.gradle-build-directory");
 		context.ANDROID_LIBRARY_PROJECTS = [];
 		
 		var escaped = ~/([ #!=\\:])/g;

--- a/lime/tools/platforms/AndroidPlatform.hx
+++ b/lime/tools/platforms/AndroidPlatform.hx
@@ -187,8 +187,18 @@ class AndroidPlatform extends PlatformTarget {
 			
 		}
 		
-		var apkPath = FileSystem.fullPath (targetDirectory) + "/bin/app/build";
-		apkPath = project.config.getString ("android.gradle-build-directory", apkPath) + "/outputs/apk/";
+		var apkPath:String;
+		
+		if (project.config.exists ("android.gradle-build-directory")) {
+			
+			apkPath = project.config.getString ("android.gradle-build-directory") + "/" + project.meta.title + "/app/outputs/apk/";
+			
+		} else {
+			
+			apkPath = FileSystem.fullPath (targetDirectory) + "/bin/app/build/outputs/apk/";
+			
+		}
+		
 		var apkSuffix = "-" + build + ".apk";
 		
 		File.copy (apkPath + "app" + apkSuffix, apkPath + project.app.file + apkSuffix);

--- a/lime/tools/platforms/AndroidPlatform.hx
+++ b/lime/tools/platforms/AndroidPlatform.hx
@@ -191,7 +191,7 @@ class AndroidPlatform extends PlatformTarget {
 		
 		if (project.config.exists ("android.gradle-build-directory")) {
 			
-			apkPath = project.config.getString ("android.gradle-build-directory") + "/" + project.meta.title + "/app/outputs/apk/";
+			apkPath = project.config.getString ("android.gradle-build-directory") + "/" + project.app.file + "/app/outputs/apk/";
 			
 		} else {
 			

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 		}
 	}
 	::if ANDROID_GRADLE_BUILD_DIRECTORY::
-	buildDir = "::ANDROID_GRADLE_BUILD_DIRECTORY::/::APP_TITLE::/${project.name}"::end::
+	buildDir = "::ANDROID_GRADLE_BUILD_DIRECTORY::/::APP_FILE::/${project.name}"::end::
 }
 
 task clean(type: Delete) {

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -20,6 +20,8 @@ allprojects {
 			url "http://jcenter.bintray.com/"
 		}
 	}
+	::if ANDROID_GRADLE_BUILD_DIRECTORY::
+	buildDir = "::ANDROID_GRADLE_BUILD_DIRECTORY::/::APP_TITLE::/${project.name}"::end::
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
Windows has a hard limit (240 characters) on the length of a file path. Gradle uses deeply nested files, and some libraries (looking at you, Google Play Game Services!) include extremely long file names.

Gradle's paths are still under the limit, but Lime's directory structure `Export/android/release/bin` is enough to push it over in some cases.

Fortunately, Gradle lets you put its build folders somewhere else; ideally somewhere with a very short filepath. For instance, by setting `<android gradle-build-directory="C:/Build" />`, you'll dramatically reduce your file path length without having to move your project. (If you don't set `gradle-build-directory`, everything works exactly as before.)
