### PR TITLE
FLASH_PLAYER_EXE typo fix (option 2)

### DIFF
--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -151,7 +151,7 @@ class ProjectXMLParser extends HXProject {
 			
 		} else if (defines.exists ("FLASH_PLAYER_EXE")) {
 			
-			environment.set ("FLASH_PLAYER_EXE", defines.get ("SWF_PLAYER"));
+			Sys.putEnv ("FLASH_PLAYER_EXE", defines.get ("FLASH_PLAYER_EXE"));
 			
 		}
 		


### PR DESCRIPTION
This code checks for the existence of `FLASH_PLAYER_EXE` but copies `SWF_PLAYER` instead. Also, fixing this typo isn't enough, since [`FlashHelper` looks in the system environment variables](https://github.com/openfl/lime/blob/develop/lime/tools/helpers/FlashHelper.hx#L959), not `project.environment`, for a value named `FLASH_PLAYER_EXE`.

I've created two pull requests for you to choose from:

1. Deletes the code. #812
2. Fixes the typo and calls `Sys.putEnv()`. #813

Personally, I suggest option 1. No one will ever need to set `FLASH_PLAYER_EXE` from project.xml, since they can get exactly the same result by setting `SWF_PLAYER`. This code is just taking up space.