### PR TITLE
should fix isLocal when using not embedded assets on html5 and cpp

### DIFF
--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -412,19 +412,18 @@ class DefaultAssetLibrary extends AssetLibrary {
 	
 	public override function isLocal (id:String, type:String):Bool {
 		
+		#if (flash || windows || mac || linux)
+			
+		return className.exists (id);
+			
+		#else
 		var requestedType = type != null ? cast (type, AssetType) : null;
-		
-		#if flash
-		
-		//if (requestedType != AssetType.MUSIC && requestedType != AssetType.SOUND) {
-			
+		if (requestedType == AssetType.FONT)
 			return className.exists (id);
-			
-		//}
+		else
+			return path.exists (id);
 		
 		#end
-		
-		return true;
 		
 	}
 	


### PR DESCRIPTION
`isLocal `returns true everytime for other target than flash
But it is wrong, if some assets are not in **project.xml**, they are obviously not embedded and you'll need to load asynchronously (so `isLocal `has to return `false`).

This PR fixed this partially.

I say 'partially" because if you add sounds in **project.xml** with `embed=false`, they will be in the variable `path` and isLocal will still return true even if you choose embed=false. I think there is a bug somewhere that consider some files to be embedded even if they are not.

Also, I think we could avoid casting 2 times `AssetType` (in Assets.hx and DefaultAssetLibrary.hx). We just need to pass AssetType as a function parameter like this instead of using String: 
`public override function isLocal (id:String, type:AssetType):Bool`