### PR TITLE
Avoid howlerjs exception when seeking files that are being played.

### DIFF
--- a/lime/_backend/html5/HTML5AudioSource.hx
+++ b/lime/_backend/html5/HTML5AudioSource.hx
@@ -165,7 +165,9 @@ class HTML5AudioSource {
 		if (parent.buffer != null) {
 			
 			//if (playing) buffer.__srcHowl.play (id);
-			parent.buffer.__srcHowl.seek ((value + parent.offset) / 1000, id);
+			var pos = (value + parent.offset) / 1000;
+			if ( pos < 0 ) pos = 0;
+			parent.buffer.__srcHowl.seek (pos, id);
 			
 		}
 		


### PR DESCRIPTION
On some cases, it ended up sending negative positions crashing the game.