### PR TITLE
Make Gradle use the right APK filename.

### DIFF
--- a/lime/tools/platforms/AndroidPlatform.hx
+++ b/lime/tools/platforms/AndroidPlatform.hx
@@ -179,20 +179,17 @@ class AndroidPlatform extends PlatformTarget {
 	
 	public override function install ():Void {
 		
-		var build = "debug";
+		var build = "-debug";
 		
 		if (project.certificate != null) {
 			
-			build = "release";
+			build = "-release";
 			
 		}
 		
-		var apkPath = FileSystem.fullPath (targetDirectory) + "/bin/app/build/outputs/apk/";
-		var apkSuffix = "-" + build + ".apk";
+		var apkPath = FileSystem.fullPath (targetDirectory) + "/bin/app/build/outputs/apk/" + project.app.file + build + ".apk";
 		
-		File.copy (apkPath + "app" + apkSuffix, apkPath + project.app.file + apkSuffix);
-		
-		deviceID = AndroidHelper.install (project, apkPath + project.app.file + apkSuffix, deviceID);
+		deviceID = AndroidHelper.install (project, apkPath, deviceID);
 		
 	}
 	

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -48,6 +48,16 @@ android {
 			signingConfig signingConfigs.release
 		}
 	}
+	
+	android.applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def outputFile = output.outputFile
+			
+            if (outputFile != null && outputFile.name.endsWith('.apk')) {
+                output.outputFile = new File(outputFile.parent, "::APP_FILE::-" + variant.buildType.name + ".apk")
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Currently, Lime renames it before installing, but this can be annoying for people who only use the `build` command.