### PR TITLE
Fix SDL renderer scale calculation error

### DIFF
--- a/project/src/backend/sdl/SDLRenderer.cpp
+++ b/project/src/backend/sdl/SDLRenderer.cpp
@@ -139,7 +139,7 @@ namespace lime {
 		
 		SDL_GetWindowSize (sdlWindow, &width, &height);
 		
-		double scale = outputWidth / width;
+		double scale = double(outputWidth) / width;
 		return scale;
 		
 	}


### PR DESCRIPTION
This pull request fixes OpenFL 4.x [rendering problem](https://github.com/openfl/openfl/issues/1309) occurred in iPhone 6 Plus and 6s Plus.
