### PR TITLE
Implement HTML5 System clipboard support

### DIFF
--- a/lime/system/Clipboard.hx
+++ b/lime/system/Clipboard.hx
@@ -3,6 +3,8 @@ package lime.system;
 
 #if flash
 import flash.desktop.Clipboard in FlashClipboard;
+#elseif js
+import js.Browser.document;
 #end
 
 #if !macro
@@ -14,6 +16,10 @@ class Clipboard {
 	
 	
 	public static var text (get, set):String;
+
+	#if js
+	private static var _text : String;
+	#end
 	
 	
 	
@@ -33,6 +39,8 @@ class Clipboard {
 			return FlashClipboard.generalClipboard.getData (TEXT_FORMAT);
 			
 		}
+		#elseif js
+		return _text;
 		#end
 		
 		return null;
@@ -45,8 +53,19 @@ class Clipboard {
 		#if (lime_cffi && !macro)
 		lime_clipboard_set_text (value);
 		return value;
+		
 		#elseif flash
 		FlashClipboard.generalClipboard.setData (TEXT_FORMAT, value);
+		return value;
+		
+		#elseif js
+		_text = value;
+		
+		#if html5
+		if (document.queryCommandEnabled("copy"))
+			document.execCommand("copy");
+		#end
+		
 		return value;
 		#end
 		


### PR DESCRIPTION
Because of various "security" related reasons, a hidden `<input>` is required, having selected text in order for Copy, and Cut events to be fired.

Only within such an event handler can the user (OpenFL) write to the system clipboard.