### PR TITLE
Fix the IOS Accelerometer which wasn't fully linked to lime

### DIFF
--- a/project/src/backend/sdl/SDLJoystick.cpp
+++ b/project/src/backend/sdl/SDLJoystick.cpp
@@ -55,7 +55,7 @@ namespace lime {
 	
 	void SDLJoystick::Init () {
 		
-		#if defined(IOS) || defined(ANDROID) || defined(TVOS)
+		#if defined(IPHONE) || defined(ANDROID) || defined(TVOS)
 		for (int i = 0; i < SDL_NumJoysticks (); i++) {
 			
 			if (strstr (SDL_JoystickNameForIndex (i), "Accelerometer")) {


### PR DESCRIPTION
The SDL implementation of IOS Accelerometer was correct.  Wrapped around the Joystick API for commodity I guess, but working.
The problem was in fact that LIME didn't linked the joystick itself...
After few long hours, the obvious was found, the define was wrong.   IPHONE instead of IOS did fix the problem.