### PR TITLE
Fix HXP projects.

### DIFF
--- a/lime/project/HXProject.hx
+++ b/lime/project/HXProject.hx
@@ -108,7 +108,7 @@ class HXProject {
 		serializer.useCache = true;
 		serializer.serialize (instance);
 		
-		File.saveContent (args[7], serializer.toString ());
+		File.saveContent (args[args.length - 1], serializer.toString ());
 		
 	}
 	


### PR DESCRIPTION
When Lime finds a project.hxp file, it runs `HXProject.fromFile()` to parse it. This function runs these two lines:

```haxe
ProcessHelper.runCommand ("", "haxe", [ name, "-main", "lime.project.HXProject", "-cp", tempDirectory, "-neko", nekoOutput, "-cp", PathHelper.combine (PathHelper.getHaxelib (new Haxelib ("lime")), "tools"), "-lib", "lime", "-D", "lime-curl", "-D", "native", "-D", "lime-native", "-D", "lime-cffi" ]);
ProcessHelper.runCommand ("", "neko", [ FileSystem.fullPath (nekoOutput), HXProject._command, name, Std.string (HXProject._target), Std.string (HXProject._debug), Serializer.run (HXProject._targetFlags), Serializer.run (HXProject._templatePaths), Serializer.run (HXProject._userDefines), Serializer.run (HXProject._environment), temporaryFile ]);
```

The first line compiles HXProject.hx, and the second runs it, meaning that it runs `HXProject.main()` with the arguments specified by the second line. Here they are, arranged for readability:

```haxe
HXProject._command, //0
name, //1
Std.string (HXProject._target), //2
Std.string (HXProject._debug), //3
Serializer.run (HXProject._targetFlags), //4
Serializer.run (HXProject._templatePaths), //5
Serializer.run (HXProject._userDefines), //6
Serializer.run (HXProject._environment), //7
temporaryFile //8
```

Now let's look at `main()`:

```haxe
HXProject._command = args[0]; //HXProject._command
HXProject._target = cast args[2]; //HXProject._target
HXProject._debug = (args[3] == "true"); //HXProject._debug
HXProject._targetFlags = Unserializer.run (args[4]); //HXProject._targetFlags
HXProject._templatePaths = Unserializer.run (args[5]); //HXProject._templatePaths
if (args.length > 6) HXProject._userDefines = Unserializer.run (args[6]); //HXProject._userDefines
if (args.length > 7) HXProject._environment = Unserializer.run (args[7]); //HXProject._environment

//...

var classRef = Type.resolveClass (args[1]); //name

//...

File.saveContent (args[7], serializer.toString ()); //HXProject._environment
```

Everything is correct except that final line, which attempts to use the entire environment as a file path, causing the build process to crash and burn.

The intended path is stored in `args[8]`, at least in this case. Since `args` varies in length, I implemented it as `args[args.length - 1]`.