### PR TITLE
Make XMLHttpRequest work on Internet Explorer 11 also.

### DIFF
--- a/lime/_backend/html5/HTML5HTTPRequest.hx
+++ b/lime/_backend/html5/HTML5HTTPRequest.hx
@@ -50,12 +50,6 @@ class HTML5HTTPRequest {
 		request.addEventListener ("progress", progress, false);
 		request.onreadystatechange = readyStateChange;
 		
-		if (parent.timeout > 0) {
-			
-			request.timeout = parent.timeout;
-			
-		}
-		
 		var query = "";
 		
 		if (parent.data == null) {
@@ -86,6 +80,9 @@ class HTML5HTTPRequest {
 		}
 		
 		request.open (Std.string (parent.method), uri, true);
+		if (parent.timeout > 0) {
+			request.timeout = parent.timeout;
+		}
 		
 		if (binary) {
 			


### PR DESCRIPTION
This pull request makes sure that using XmlHttpRequest in Internet explorer, does not give an excection.