### PR TITLE
1. More precise preloader for html5; 2. Fix font preloading in Safari.

### DIFF
--- a/lime/app/Preloader.hx
+++ b/lime/app/Preloader.hx
@@ -38,6 +38,8 @@ class Preloader #if flash extends Sprite #end {
 	private var loadedLibraries:Int;
 	private var loadedStage:Bool;
 	
+	private var itemsProgressLoaded:Int;
+	private var itemsProgressTotal:Int;
 	
 	public function new () {
 		
@@ -75,14 +77,31 @@ class Preloader #if flash extends Sprite #end {
 	
 	public function load ():Void {
 		
+		itemsProgressLoaded = 0;
+		itemsProgressTotal = 0;
+		
+		for (library in libraries) {
+			
+			itemsProgressTotal += library.computeProgressTotal ();
+			
+		}
+		
 		loadedLibraries = -1;
 		
 		for (library in libraries) {
 			
-			library.load ().onComplete (function (_) {
+			library.load ().onProgress (function (_, _) {
+				
+				updateItemsProgress();
+				
+			}).onComplete (function (_) {
 				
 				loadedLibraries++;
 				updateProgress ();
+				
+			}).onError (function (e) {
+				
+				trace(e);
 				
 			});
 			
@@ -120,7 +139,8 @@ class Preloader #if flash extends Sprite #end {
 	
 	private function updateProgress ():Void {
 		
-		update (loadedLibraries, libraries.length);
+		update (itemsProgressLoaded, itemsProgressTotal);
+		// update (loadedLibraries, libraries.length);
 		
 		if (#if flash loadedStage && #end loadedLibraries == libraries.length) {
 			
@@ -130,6 +150,12 @@ class Preloader #if flash extends Sprite #end {
 		
 	}
 	
+	private function updateItemsProgress ():Void {
+		
+		itemsProgressLoaded++;
+		updateProgress();
+		
+	}
 	
 	#if flash
 	private function current_onEnter (event:flash.events.Event):Void {

--- a/lime/text/Font.hx
+++ b/lime/text/Font.hx
@@ -446,8 +446,15 @@ class Font {
 		
 		this.name = name;
 		var font = name;
+		var ua = Browser.navigator.userAgent.toLowerCase();
 		
-		if (untyped (Browser.document).fonts && untyped (Browser.document).fonts.load) {
+		// When Safari reports that font is loaded, actually font IS NOT loaded.
+		// If you try to use this font immediately after preloader completes,
+		// default font will be used instead.
+		//
+		// We detect Safari, and use old font loading for it.
+		
+		if (!(ua.indexOf(" safari/") >= 0 && ua.indexOf(" chrome/") < 0) && untyped (Browser.document).fonts && untyped (Browser.document).fonts.load) {
 			
 			untyped (Browser.document).fonts.load ("1em '" + font + "'").then (function (_) {
 				

--- a/lime/utils/AssetLibrary.hx
+++ b/lime/utils/AssetLibrary.hx
@@ -373,6 +373,27 @@ class AssetLibrary {
 		
 	}
 	
+	public function computeProgressTotal ():Int {
+		
+		var result = 1;
+		
+			for (id in preload.keys ()) {
+				
+				switch (types.get (id)) {
+					
+					case BINARY, FONT, IMAGE, MUSIC, SOUND, TEXT:
+						
+						result++;
+					
+					default:
+					
+				}
+				
+			}
+		
+		return result;
+		
+	}
 	
 	public function load ():Future<AssetLibrary> {
 		
@@ -575,6 +596,7 @@ class AssetLibrary {
 	private function updateProgressLoaded ():Void {
 		
 		progressLoaded++;
+		promise.progress(progressLoaded, progressTotal);
 		
 		if (progressLoaded == progressTotal) {
 			


### PR DESCRIPTION
## More precise preloader for html5

In latest OpenFL / Lime version preloader din't work as earlier. This PR tries to fix it.

Additionally it adds trace of error, because without it is very difficult to guess why game is not loading (usually this is related because howler can't load .wav or .ogg sound; interestingly, it was working earlier with soundjs, but this is another story...)

## Fix font preloading in Safari

It seems that Safari reports that font loaded while font **IS NOT** actually loaded. There are 2 identical `TextView`'s, first is added immediately, second after some timeout:

![screen shot 2016-12-20 at 13 19 26](https://cloud.githubusercontent.com/assets/85473/21347031/00f3bcd8-c6b8-11e6-8d69-99c94710cfff.png)

This is reproduced with last OpenFL / Lime version, this **IS NOT** related to font preloading issue fixed in https://github.com/openfl/lime/commit/4e8bc030f6f15fed7d0f095ba323990658ca66bf. This happens only in Safari.

Demo: http://pub.zame-dev.org/openfl-safari-font-preloader/canvas/
Full source: http://pub.zame-dev.org/openfl-safari-font-preloader/project.zip

```haxe App.hx
class App extends Sprite {
    public function new() {
        super();

        addTextField(50);

        Timer.delay(function() : Void {
            addTextField(100);
        }, 1000);
    }

    private function addTextField(y : Float) : Void {
        var textField = new TextField();
        textField.borderColor = 0x800000;
        textField.border = true;
        textField.selectable = false;
        textField.wordWrap = false;
        textField.autoSize = TextFieldAutoSize.LEFT;
        textField.x = 50;
        textField.y = y;

        addChild(textField);

        var textFormat = new TextFormat();
        textFormat.font = Assets.getFont("assets/font/MyriadProCond.ttf").fontName;
        textFormat.color = 0xffffff;
        textFormat.size = 24;

        textField.defaultTextFormat = textFormat;
        textField.setTextFormat(textFormat);

        textField.text = "THIS IS THE TEST";

        var width = textField.textWidth + 4;
        var height = textField.textHeight + 4;

        textField.autoSize = TextFieldAutoSize.NONE;
        textField.width = width;
        textField.height = height;
    }
}
```