### PR TITLE
Cache loaded TEXT Assets in AssetLibrary

### DIFF
--- a/lime/utils/AssetLibrary.hx
+++ b/lime/utils/AssetLibrary.hx
@@ -569,7 +569,9 @@ class AssetLibrary {
 						
 					} else {
 						
-						return bytes.getString (0, bytes.length);
+						var text = bytes.getString (0, bytes.length);
+						cachedText.set(id, text);
+						return text;
 						
 					}
 					


### PR DESCRIPTION
We use `Assets.getText` after loading via `Assets.loadLibrary`.
This patch makes it work.