### PR TITLE
Fix for #919 - Add Filter to FileDialog save (Windows only)

### DIFF
--- a/project/src/ui/FileDialog.cpp
+++ b/project/src/ui/FileDialog.cpp
@@ -165,8 +165,8 @@ namespace lime {
 		
 		#ifdef HX_WINDOWS
 		
-		std::wstring temp(L"*.");
-		const wchar_t* filters[] = {filter ? (temp + *filter).c_str() : NULL};
+		std::wstring temp (L"*.");
+		const wchar_t* filters[] = {filter ? (temp + *filter).c_str () : NULL};
 
 		const wchar_t* path = tinyfd_saveFileDialogW (L"", defaultPath ? defaultPath->c_str () : 0, filter ? 1 : 0, filter ? filters : NULL, NULL);
 		

--- a/project/src/ui/FileDialog.cpp
+++ b/project/src/ui/FileDialog.cpp
@@ -163,11 +163,12 @@ namespace lime {
 	
 	std::wstring* FileDialog::SaveFile (std::wstring* filter, std::wstring* defaultPath) {
 		
-		// TODO: Filters
-		
 		#ifdef HX_WINDOWS
 		
-		const wchar_t* path = tinyfd_saveFileDialogW (L"", defaultPath ? defaultPath->c_str () : 0, 0, NULL, NULL);
+		std::wstring temp(L"*.");
+		const wchar_t* filters[] = {filter ? (temp + *filter).c_str() : NULL};
+
+		const wchar_t* path = tinyfd_saveFileDialogW (L"", defaultPath ? defaultPath->c_str () : 0, filter ? 1 : 0, filter ? filters : NULL, NULL);
 		
 		if (path) {
 			
@@ -177,6 +178,8 @@ namespace lime {
 		}
 		
 		#else
+		
+		// TODO: Filters
 		
 		char* _defaultPath = 0;
 		


### PR DESCRIPTION
Simply add "*." to the filter (which is the extension of the default filename) and add it as a parameter to the tinyfd function.

Not sure how to properly concatenate wstring so I hope the code is clean.

Didn't do other platforms since I can only test windows atm.

Would be usefull to add to the "open" functions as well.