### PR TITLE
Makes sure extension is used when saving with FileDialog

### DIFF
--- a/lime/ui/FileDialog.hx
+++ b/lime/ui/FileDialog.hx
@@ -75,14 +75,14 @@ class FileDialog {
 					
 					var path:String = cast result;
 					
-					// Makes sure the filename ends with extension
-					if (type == SAVE && filter != null && path.indexOf (".") == -1) {
-						
-						path += "." + filter;
-						
-					}
-					
 					if (path != null) {
+						
+						// Makes sure the filename ends with extension
+						if (type == SAVE && filter != null && path.indexOf (".") == -1) {
+							
+							path += "." + filter;
+							
+						}
 						
 						onSelect.dispatch (path);
 						

--- a/lime/ui/FileDialog.hx
+++ b/lime/ui/FileDialog.hx
@@ -75,6 +75,13 @@ class FileDialog {
 					
 					var path:String = cast result;
 					
+					// Makes sure the filename ends with extension
+					if (type == SAVE && filter != null && !StringTools.endsWith (path, "." + filter) ) {
+						
+						path += "." + filter;
+						
+					}
+					
 					if (path != null) {
 						
 						onSelect.dispatch (path);

--- a/lime/ui/FileDialog.hx
+++ b/lime/ui/FileDialog.hx
@@ -76,7 +76,7 @@ class FileDialog {
 					var path:String = cast result;
 					
 					// Makes sure the filename ends with extension
-					if (type == SAVE && filter != null && !StringTools.endsWith (path, "." + filter) ) {
+					if (type == SAVE && filter != null && path.indexOf (".") == -1) {
 						
 						path += "." + filter;
 						


### PR DESCRIPTION
While testing the save functionality I found myself sometimes omitting the extension when saving.

![openfl_filedialog_type](https://cloud.githubusercontent.com/assets/77518/22857878/934d4c1e-f07c-11e6-9ac4-8d96ddd444a1.PNG)

And when I looked back at the saved file, it didn't have any extension, which felt a bit weird. Testing back in flash and in other programs, it does seems to be the general rules of thumb to always saves the file with the "filter" extension if there's one.