### PR TITLE
Allow setting a different Gradle PLUGIN version.

### DIFF
--- a/dependencies/extension-api/build.gradle
+++ b/dependencies/extension-api/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 	}
 	
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.1.0'
+		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
 	}
 }
 

--- a/dependencies/extension-api/build.gradle
+++ b/dependencies/extension-api/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 	}
 	
 	dependencies {
-		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_VERSION::'
+		classpath 'com.android.tools.build:gradle:2.1.0'
 	}
 }
 

--- a/lime/tools/platforms/AndroidPlatform.hx
+++ b/lime/tools/platforms/AndroidPlatform.hx
@@ -313,6 +313,7 @@ class AndroidPlatform extends PlatformTarget {
 		context.ANDROID_EXTENSIONS = project.config.getArrayString ("android.extension");
 		context.ANDROID_PERMISSIONS = project.config.getArrayString ("android.permission", [ "android.permission.WAKE_LOCK", "android.permission.INTERNET", "android.permission.VIBRATE", "android.permission.ACCESS_NETWORK_STATE" ]);
 		context.ANDROID_GRADLE_VERSION = project.config.getString ("android.gradle-version", "2.10");
+		context.ANDROID_GRADLE_PLUGIN = project.config.getString ("android.gradle-plugin", "2.1.0");
 		context.ANDROID_LIBRARY_PROJECTS = [];
 		
 		var escaped = ~/([ #!=\\:])/g;

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.1.0'
+		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
 		
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files
@@ -39,7 +39,7 @@ configure(subprojects.findAll {!it.file('build.gradle').exists() && it.file('bui
 		}
 		
 		dependencies {
-			classpath 'com.android.tools.build:gradle:2.1.0'
+			classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
 		}
 	}
 	

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_VERSION::'
+		classpath 'com.android.tools.build:gradle:2.1.0'
 		
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files
@@ -39,7 +39,7 @@ configure(subprojects.findAll {!it.file('build.gradle').exists() && it.file('bui
 		}
 		
 		dependencies {
-			classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_VERSION::'
+			classpath 'com.android.tools.build:gradle:2.1.0'
 		}
 	}
 	

--- a/templates/extension/dependencies/android/build.gradle
+++ b/templates/extension/dependencies/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 	}
 	
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.1.0'
+		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
 	}
 }
 

--- a/templates/extension/dependencies/android/build.gradle
+++ b/templates/extension/dependencies/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 	}
 	
 	dependencies {
-		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_VERSION::'
+		classpath 'com.android.tools.build:gradle:2.1.0'
 	}
 }
 


### PR DESCRIPTION
The [Android plugin for Gradle](https://developer.android.com/studio/releases/gradle-plugin.html) uses numbers that look suspiciously similar to Gradle's numbers, but they aren't the same.

I failed to notice the extra period, so my previous pull request (#922) overwrote "`2.1.0`" with "`2.10`," thereby breaking Android builds. This request fixes it and adds an option to change the two values separately.