### PR TITLE
HTML5: Working clipboard menus

### DIFF
--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -24,6 +24,7 @@ import lime.ui.Window;
 
 
 @:access(lime.app.Application)
+@:access(lime.system.Clipboard)
 @:access(lime.ui.Gamepad)
 @:access(lime.ui.Joystick)
 @:access(lime.ui.Window)
@@ -295,6 +296,8 @@ class HTML5Window {
 	
 	private function handleCutOrCopyEvent (event:ClipboardEvent):Void {
 		
+		parent.onClipboard.dispatch (event.type);
+		
 		event.clipboardData.setData('text/plain', Clipboard.text);
 		event.preventDefault(); // We want our data, not data from any selection, to be written to the clipboard
 		
@@ -303,9 +306,12 @@ class HTML5Window {
 
 	private function handlePasteEvent (event:ClipboardEvent):Void {
 		
-		if(untyped event.clipboardData.types.indexOf('text/plain') > -1){
-			var text = Clipboard.text = event.clipboardData.getData('text/plain');
-			parent.onTextInput.dispatch (text);
+		if (untyped event.clipboardData.types.indexOf('text/plain') > -1) {
+			
+			// Set the internal _text value to system clipboard contents:
+			var text = Clipboard._text = event.clipboardData.getData('text/plain');
+			
+			parent.onClipboard.dispatch (event.type);
 			
 			// We are already handling the data from the clipboard, we do not want it inserted into the hidden input
 			event.preventDefault();

--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -732,23 +732,23 @@ class HTML5Window {
 	
 	public function setClipboard (value:String):Void {
 		
+		var inputEnabled = enableTextEvents;
+		
+		setEnableTextEvents (true); // create textInput if necessary
+		
+		var cacheText = textInput.value;
+		textInput.value = value;
+		textInput.select (); // text must be selected for copy command to become available
+		
 		if (Browser.document.queryCommandEnabled ("copy")) {
-			
-			var inputEnabled = enableTextEvents;
-			
-			setEnableTextEvents (true); // create textInput if necessary
-			setEnableTextEvents (false);
-			
-			var cacheText = textInput.value;
-			textInput.value = value;
 			
 			Browser.document.execCommand ("copy");
 			
-			textInput.value = cacheText;
-			
-			setEnableTextEvents (inputEnabled);
-			
 		}
+		
+		textInput.value = cacheText;
+		
+		setEnableTextEvents (inputEnabled);
 		
 	}
 	

--- a/lime/system/Clipboard.hx
+++ b/lime/system/Clipboard.hx
@@ -80,3 +80,12 @@ class Clipboard {
 	
 	
 }
+
+
+@:enum abstract ClipboardAction(String) from String {
+	
+	var COPY  = "copy";
+	var CUT   = "cut";
+	var PASTE = "paste";
+	
+}

--- a/lime/ui/Window.hx
+++ b/lime/ui/Window.hx
@@ -6,6 +6,7 @@ import lime.app.Config;
 import lime.app.Event;
 import lime.graphics.Image;
 import lime.graphics.Renderer;
+import lime.system.Clipboard;
 import lime.system.Display;
 
 #if openfl
@@ -58,6 +59,7 @@ class Window {
 	public var onRestore = new Event<Void->Void> ();
 	public var onTextEdit = new Event<String->Int->Int->Void> ();
 	public var onTextInput = new Event<String->Void> ();
+	public var onClipboard = new Event<ClipboardAction->Void> ();
 	public var renderer:Renderer;
 	public var resizable (get, set):Bool;
 	public var scale (get, null):Float;


### PR DESCRIPTION
Copy and Cut from Edit menu do not work in HTML5.

It sets clipboard data from `Clipboard.text`, but that property never gets set when selecting text … which makes sense because setting the Clipboard would immediately overwrite the system clipboard.

This patch fixes both `setClipboard` and above mentioned issue.