### PR TITLE
first time you build lime, binary is not built or in global path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Tell haxelib where your development copy of Lime is installed:
 The first time you run the "lime" command, it will attempt to build the Lime standard binary for your desktop platform as the command-line tools. To build these manually, use the following command (using "mac" or "linux" if appropriate):
 
     haxelib install format
-    lime rebuild windows
+    haxelib run lime rebuild windows
 
 You can build additional binaries, or rebuild binaries after making changes, using "lime rebuild":
 


### PR DESCRIPTION
actually, i'm not sure what to do to get lime in the global path on a fresh windows install.
i just always use `haxelib run lime ...`

but this was necessary to build on windows for me. hoping to save others time since its more likely to work than without.

```
C:\Users\Mike>lime
'lime' is not recognized as an internal or external command,
operable program or batch file.
```