### PR TITLE
Fix android apk installation for platform tools >= 23

### DIFF
--- a/lime/tools/helpers/AndroidHelper.hx
+++ b/lime/tools/helpers/AndroidHelper.hx
@@ -113,6 +113,25 @@ class AndroidHelper {
 		
 		return 0;
 	}
+
+	public static function getPlatformToolsVersion ():String {
+
+		var propertiesPath = adbPath + "source.properties";
+		var properties = File.getContent(propertiesPath);
+		
+		for (line in properties.split ("\n")) {
+
+			if(StringTools.startsWith (line, "Pkg.Revision")) {
+
+				return line.substr (line.indexOf ("=") + 1);
+
+			}
+
+		}
+
+		return "";
+
+	}
 	
 	
 	public static function initialize (project:HXProject):Void {
@@ -228,14 +247,20 @@ class AndroidHelper {
 			
 		}
 		
-		var args = [ "install", "-r" ];
+		var args = [ "install" ];
 		
-		//if (getDeviceSDKVersion (deviceID) > 16) {
-			
-			args.push ("-d");
-			
-		//}
-		
+		var platformToolsMajorVersion = Std.parseInt(getPlatformToolsVersion ().split (".")[0]);
+
+		if (platformToolsMajorVersion >= 23) {
+
+			args.push("-rd");
+
+		} else {
+
+			args.push("-r");
+
+		}
+
 		args.push (targetPath);
 		
 		if (deviceID != null && deviceID != "") {


### PR DESCRIPTION
`-d` flag doesn't exist in android sdk platform tools before version 23. Also, versions 23 and higher accept combined flags (`-rd`) instead of individually listed flags (`-r -d`).