### PR TITLE
HTML5GLRenderContext compressedTexImage fixes

### DIFF
--- a/lime/_backend/html5/HTML5GLRenderContext.hx
+++ b/lime/_backend/html5/HTML5GLRenderContext.hx
@@ -1007,6 +1007,7 @@ class HTML5GLRenderContext {
 		if (Std.is (imageSize, Int)) {
 			
 			srcData = __prepareData (null, srcData);
+			if (srcData != null && Std.is (srcData, ArrayBuffer)) srcData = new UInt8Array (srcData);
 			
 			if (version > 1 && srcOffset != null) {
 				
@@ -1053,6 +1054,7 @@ class HTML5GLRenderContext {
 		if (Std.is (imageSize, Int)) {
 			
 			srcData = __prepareData (null, srcData);
+			if (srcData != null && Std.is (srcData, ArrayBuffer)) srcData = new UInt8Array (srcData);
 			
 			if (version > 1 && srcOffset != null) {
 				


### PR DESCRIPTION
To avoid a runtime error, I had to create an UInt8Array after the call to __prepareData

This is the same approach that is in use for the regular texImage functions (without compression)