### PR TITLE
Enable OpenGL s3tc extension

### DIFF
--- a/lime/_backend/native/NativeGLRenderContext.hx
+++ b/lime/_backend/native/NativeGLRenderContext.hx
@@ -3459,6 +3459,7 @@ class NativeGLRenderContext {
 			__extensionObjectConstructors["EXT_shader_texture_lod"] = EXT_shader_texture_lod.new;
 			__extensionObjectConstructors["EXT_shadow_samplers"] = EXT_shadow_samplers.new;
 			__extensionObjectConstructors["EXT_texture_compression_dxt1"] = EXT_texture_compression_dxt1.new;
+			__extensionObjectConstructors["EXT_texture_compression_s3tc"] = EXT_texture_compression_s3tc.new;
 			__extensionObjectConstructors["EXT_texture_filter_anisotropic"] = EXT_texture_filter_anisotropic.new;
 			__extensionObjectConstructors["EXT_texture_format_BGRA8888"] = EXT_texture_format_BGRA8888.new;
 			__extensionObjectConstructors["EXT_texture_rg"] = EXT_texture_rg.new;

--- a/lime/graphics/opengl/ext/EXT_texture_compression_s3tc.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_compression_s3tc.hx
@@ -1,0 +1,20 @@
+package lime.graphics.opengl.ext;
+
+
+class EXT_texture_compression_s3tc {
+	
+	
+	public var COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83F0;
+	public var COMPRESSED_RGBA_S3TC_DXT1_EXT = 0x83F1;
+	public var COMPRESSED_RGBA_S3TC_DXT3_EXT = 0x83F2;
+	public var COMPRESSED_RGBA_S3TC_DXT5_EXT = 0x83F3;
+	
+	
+	private function new () {
+		
+		
+		
+	}
+	
+	
+}


### PR DESCRIPTION
This extension allows DXT1 & DXT5 compressed textures.

Necessary if you want to use compressed textures on Mac & Windows.