### PR TITLE
Let architecture be specified for simulator builds

### DIFF
--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -41,9 +41,17 @@ class IOSHelper {
 		
 		if (project.targetFlags.exists ("simulator")) {
 			
-			commands.push ("-arch");
-			//commands.push ("i386");
-			commands.push ("x86_64");
+			if (project.targetFlags.exists ("i386")) {
+				
+				commands.push ("-arch");
+				commands.push ("i386");
+				
+			} else {
+				
+				commands.push ("-arch");
+				commands.push ("x86_64");
+			
+			}
 			
 		} else if (project.targetFlags.exists ("armv7")) {
 			


### PR DESCRIPTION
x86_64 can be the default simulator architecture, but i386 is still necessary for older devices.