### PR TITLE
Fix 'lime create extension'

### DIFF
--- a/tools/utils/CreateTemplate.hx
+++ b/tools/utils/CreateTemplate.hx
@@ -38,6 +38,7 @@ class CreateTemplate {
 		context.ANDROID_MINIMUM_SDK_VERSION = "::ANDROID_MINIMUM_SDK_VERSION::";
 		context.META_BUILD_NUMBER = "::META_BUILD_NUMBER::";
 		context.META_VERSION = "::META_VERSION::";
+		context.ANDROID_GRADLE_PLUGIN = "::ANDROID_GRADLE_PLUGIN::";
 		
 		PathHelper.mkdir (title);
 		FileHelper.recursiveCopyTemplate ([ PathHelper.getHaxelib (new Haxelib ("lime"), true)  + "/templates" ], "extension", title, context);


### PR DESCRIPTION
This fixes the issue I described [here](https://github.com/openfl/lime/pull/923#issuecomment-280951576), using the first of the two solutions I mentioned. Now extensions will work again without manually editing `build.gradle`!