### PR TITLE
Fix DCE breaking GL extensions

### DIFF
--- a/lime/graphics/opengl/ext/AMD_compressed_3DC_texture.hx
+++ b/lime/graphics/opengl/ext/AMD_compressed_3DC_texture.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class AMD_compressed_3DC_texture {
 	
 	

--- a/lime/graphics/opengl/ext/AMD_compressed_ATC_texture.hx
+++ b/lime/graphics/opengl/ext/AMD_compressed_ATC_texture.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class AMD_compressed_ATC_texture {
 	
 	

--- a/lime/graphics/opengl/ext/AMD_performance_monitor.hx
+++ b/lime/graphics/opengl/ext/AMD_performance_monitor.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class AMD_performance_monitor {
 	
 	

--- a/lime/graphics/opengl/ext/AMD_program_binary_Z400.hx
+++ b/lime/graphics/opengl/ext/AMD_program_binary_Z400.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class AMD_program_binary_Z400 {
 	
 	

--- a/lime/graphics/opengl/ext/ANGLE_framebuffer_blit.hx
+++ b/lime/graphics/opengl/ext/ANGLE_framebuffer_blit.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ANGLE_framebuffer_blit {
 	
 	

--- a/lime/graphics/opengl/ext/ANGLE_framebuffer_multisample.hx
+++ b/lime/graphics/opengl/ext/ANGLE_framebuffer_multisample.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ANGLE_framebuffer_multisample {
 	
 	

--- a/lime/graphics/opengl/ext/ANGLE_instanced_arrays.hx
+++ b/lime/graphics/opengl/ext/ANGLE_instanced_arrays.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/ANGLE_pack_reverse_row_order.hx
+++ b/lime/graphics/opengl/ext/ANGLE_pack_reverse_row_order.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ANGLE_pack_reverse_row_order {
 	
 	

--- a/lime/graphics/opengl/ext/ANGLE_texture_compression_dxt3.hx
+++ b/lime/graphics/opengl/ext/ANGLE_texture_compression_dxt3.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ANGLE_texture_compression_dxt3 {
 	
 	

--- a/lime/graphics/opengl/ext/ANGLE_texture_compression_dxt5.hx
+++ b/lime/graphics/opengl/ext/ANGLE_texture_compression_dxt5.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ANGLE_texture_compression_dxt5 {
 	
 	

--- a/lime/graphics/opengl/ext/ANGLE_texture_usage.hx
+++ b/lime/graphics/opengl/ext/ANGLE_texture_usage.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ANGLE_texture_usage {
 	
 	

--- a/lime/graphics/opengl/ext/ANGLE_translated_shader_source.hx
+++ b/lime/graphics/opengl/ext/ANGLE_translated_shader_source.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ANGLE_translated_shader_source {
 	
 	

--- a/lime/graphics/opengl/ext/APPLE_framebuffer_multisample.hx
+++ b/lime/graphics/opengl/ext/APPLE_framebuffer_multisample.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class APPLE_framebuffer_multisample {
 	
 	

--- a/lime/graphics/opengl/ext/APPLE_rgb_422.hx
+++ b/lime/graphics/opengl/ext/APPLE_rgb_422.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class APPLE_rgb_422 {
 	
 	

--- a/lime/graphics/opengl/ext/APPLE_sync.hx
+++ b/lime/graphics/opengl/ext/APPLE_sync.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class APPLE_sync {
 	
 	

--- a/lime/graphics/opengl/ext/APPLE_texture_format_BGRA8888.hx
+++ b/lime/graphics/opengl/ext/APPLE_texture_format_BGRA8888.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class APPLE_texture_format_BGRA8888 {
 	
 	

--- a/lime/graphics/opengl/ext/APPLE_texture_max_level.hx
+++ b/lime/graphics/opengl/ext/APPLE_texture_max_level.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class APPLE_texture_max_level {
 	
 	

--- a/lime/graphics/opengl/ext/ARM_mali_program_binary.hx
+++ b/lime/graphics/opengl/ext/ARM_mali_program_binary.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ARM_mali_program_binary {
 	
 	

--- a/lime/graphics/opengl/ext/ARM_mali_shader_binary.hx
+++ b/lime/graphics/opengl/ext/ARM_mali_shader_binary.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class ARM_mali_shader_binary {
 	
 	

--- a/lime/graphics/opengl/ext/DMP_shader_binary.hx
+++ b/lime/graphics/opengl/ext/DMP_shader_binary.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class DMP_shader_binary {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_bgra.hx
+++ b/lime/graphics/opengl/ext/EXT_bgra.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_bgra {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_blend_minmax.hx
+++ b/lime/graphics/opengl/ext/EXT_blend_minmax.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/EXT_color_buffer_half_float.hx
+++ b/lime/graphics/opengl/ext/EXT_color_buffer_half_float.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/EXT_debug_label.hx
+++ b/lime/graphics/opengl/ext/EXT_debug_label.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_debug_label {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_discard_framebuffer.hx
+++ b/lime/graphics/opengl/ext/EXT_discard_framebuffer.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_discard_framebuffer {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_disjoint_timer_query.hx
+++ b/lime/graphics/opengl/ext/EXT_disjoint_timer_query.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
 @:native("EXT_disjoint_timer_query")
 extern class EXT_disjoint_timer_query {
 	

--- a/lime/graphics/opengl/ext/EXT_map_buffer_range.hx
+++ b/lime/graphics/opengl/ext/EXT_map_buffer_range.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_map_buffer_range {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_multisampled_render_to_texture.hx
+++ b/lime/graphics/opengl/ext/EXT_multisampled_render_to_texture.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_multisampled_render_to_texture {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_multiview_draw_buffers.hx
+++ b/lime/graphics/opengl/ext/EXT_multiview_draw_buffers.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_multiview_draw_buffers {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_occlusion_query_boolean.hx
+++ b/lime/graphics/opengl/ext/EXT_occlusion_query_boolean.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_occlusion_query_boolean {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_packed_depth_stencil.hx
+++ b/lime/graphics/opengl/ext/EXT_packed_depth_stencil.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_packed_depth_stencil {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_read_format_bgra.hx
+++ b/lime/graphics/opengl/ext/EXT_read_format_bgra.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_read_format_bgra {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_robustness.hx
+++ b/lime/graphics/opengl/ext/EXT_robustness.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_robustness {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_sRGB.hx
+++ b/lime/graphics/opengl/ext/EXT_sRGB.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/EXT_separate_shader_objects.hx
+++ b/lime/graphics/opengl/ext/EXT_separate_shader_objects.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_separate_shader_objects {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_shader_framebuffer_fetch.hx
+++ b/lime/graphics/opengl/ext/EXT_shader_framebuffer_fetch.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_shader_framebuffer_fetch {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_shader_texture_lod.hx
+++ b/lime/graphics/opengl/ext/EXT_shader_texture_lod.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/EXT_shadow_samplers.hx
+++ b/lime/graphics/opengl/ext/EXT_shadow_samplers.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_shadow_samplers {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_texture_compression_dxt1.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_compression_dxt1.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_texture_compression_dxt1 {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_texture_compression_s3tc.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_compression_s3tc.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_texture_compression_s3tc {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_texture_filter_anisotropic.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_filter_anisotropic.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/EXT_texture_format_BGRA8888.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_format_BGRA8888.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_texture_format_BGRA8888 {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_texture_rg.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_rg.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_texture_rg {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_texture_storage.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_storage.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_texture_storage {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_texture_type_2_10_10_10_REV.hx
+++ b/lime/graphics/opengl/ext/EXT_texture_type_2_10_10_10_REV.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_texture_type_2_10_10_10_REV {
 	
 	

--- a/lime/graphics/opengl/ext/EXT_unpack_subimage.hx
+++ b/lime/graphics/opengl/ext/EXT_unpack_subimage.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class EXT_unpack_subimage {
 	
 	

--- a/lime/graphics/opengl/ext/FJ_shader_binary_GCCSO.hx
+++ b/lime/graphics/opengl/ext/FJ_shader_binary_GCCSO.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class FJ_shader_binary_GCCSO {
 	
 	

--- a/lime/graphics/opengl/ext/IMG_multisampled_render_to_texture.hx
+++ b/lime/graphics/opengl/ext/IMG_multisampled_render_to_texture.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class IMG_multisampled_render_to_texture {
 	
 	

--- a/lime/graphics/opengl/ext/IMG_program_binary.hx
+++ b/lime/graphics/opengl/ext/IMG_program_binary.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class IMG_program_binary {
 	
 	

--- a/lime/graphics/opengl/ext/IMG_read_format.hx
+++ b/lime/graphics/opengl/ext/IMG_read_format.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class IMG_read_format {
 	
 	

--- a/lime/graphics/opengl/ext/IMG_shader_binary.hx
+++ b/lime/graphics/opengl/ext/IMG_shader_binary.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class IMG_shader_binary {
 	
 	

--- a/lime/graphics/opengl/ext/IMG_texture_compression_pvrtc.hx
+++ b/lime/graphics/opengl/ext/IMG_texture_compression_pvrtc.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class IMG_texture_compression_pvrtc {
 	
 	

--- a/lime/graphics/opengl/ext/KHR_debug.hx
+++ b/lime/graphics/opengl/ext/KHR_debug.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class KHR_debug {
 	
 	

--- a/lime/graphics/opengl/ext/KHR_texture_compression_astc_ldr.hx
+++ b/lime/graphics/opengl/ext/KHR_texture_compression_astc_ldr.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class KHR_texture_compression_astc_ldr {
 	
 	

--- a/lime/graphics/opengl/ext/NV_coverage_sample.hx
+++ b/lime/graphics/opengl/ext/NV_coverage_sample.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class NV_coverage_sample {
 	
 	

--- a/lime/graphics/opengl/ext/NV_depth_nonlinear.hx
+++ b/lime/graphics/opengl/ext/NV_depth_nonlinear.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class NV_depth_nonlinear {
 	
 	

--- a/lime/graphics/opengl/ext/NV_draw_buffers.hx
+++ b/lime/graphics/opengl/ext/NV_draw_buffers.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class NV_draw_buffers {
 	
 	

--- a/lime/graphics/opengl/ext/NV_fbo_color_attachments.hx
+++ b/lime/graphics/opengl/ext/NV_fbo_color_attachments.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class NV_fbo_color_attachments {
 	
 	

--- a/lime/graphics/opengl/ext/NV_fence.hx
+++ b/lime/graphics/opengl/ext/NV_fence.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class NV_fence {
 	
 	

--- a/lime/graphics/opengl/ext/NV_read_buffer.hx
+++ b/lime/graphics/opengl/ext/NV_read_buffer.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class NV_read_buffer {
 	
 	

--- a/lime/graphics/opengl/ext/OES_EGL_image_external.hx
+++ b/lime/graphics/opengl/ext/OES_EGL_image_external.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_EGL_image_external {
 	
 	

--- a/lime/graphics/opengl/ext/OES_compressed_ETC1_RGB8_texture.hx
+++ b/lime/graphics/opengl/ext/OES_compressed_ETC1_RGB8_texture.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_compressed_ETC1_RGB8_texture {
 	
 	

--- a/lime/graphics/opengl/ext/OES_compressed_paletted_texture.hx
+++ b/lime/graphics/opengl/ext/OES_compressed_paletted_texture.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_compressed_paletted_texture {
 	
 	

--- a/lime/graphics/opengl/ext/OES_depth24.hx
+++ b/lime/graphics/opengl/ext/OES_depth24.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_depth24 {
 	
 	

--- a/lime/graphics/opengl/ext/OES_depth32.hx
+++ b/lime/graphics/opengl/ext/OES_depth32.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_depth32 {
 	
 	

--- a/lime/graphics/opengl/ext/OES_element_index_uint.hx
+++ b/lime/graphics/opengl/ext/OES_element_index_uint.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/OES_get_program_binary.hx
+++ b/lime/graphics/opengl/ext/OES_get_program_binary.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_get_program_binary {
 	
 	

--- a/lime/graphics/opengl/ext/OES_mapbuffer.hx
+++ b/lime/graphics/opengl/ext/OES_mapbuffer.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_mapbuffer {
 	
 	

--- a/lime/graphics/opengl/ext/OES_packed_depth_stencil.hx
+++ b/lime/graphics/opengl/ext/OES_packed_depth_stencil.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_packed_depth_stencil {
 	
 	

--- a/lime/graphics/opengl/ext/OES_required_internalformat.hx
+++ b/lime/graphics/opengl/ext/OES_required_internalformat.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_required_internalformat {
 	
 	

--- a/lime/graphics/opengl/ext/OES_rgb8_rgba8.hx
+++ b/lime/graphics/opengl/ext/OES_rgb8_rgba8.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 class OES_rgb8_rgba8 {
 	
 	

--- a/lime/graphics/opengl/ext/OES_standard_derivatives.hx
+++ b/lime/graphics/opengl/ext/OES_standard_derivatives.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/OES_stencil1.hx
+++ b/lime/graphics/opengl/ext/OES_stencil1.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_stencil1 {
 	
 	

--- a/lime/graphics/opengl/ext/OES_stencil4.hx
+++ b/lime/graphics/opengl/ext/OES_stencil4.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_stencil4 {
 	
 	

--- a/lime/graphics/opengl/ext/OES_surfaceless_context.hx
+++ b/lime/graphics/opengl/ext/OES_surfaceless_context.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_surfaceless_context {
 	
 	

--- a/lime/graphics/opengl/ext/OES_texture_3D.hx
+++ b/lime/graphics/opengl/ext/OES_texture_3D.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_texture_3D {
 	
 	

--- a/lime/graphics/opengl/ext/OES_texture_half_float.hx
+++ b/lime/graphics/opengl/ext/OES_texture_half_float.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/OES_vertex_array_object.hx
+++ b/lime/graphics/opengl/ext/OES_vertex_array_object.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
+
 #if (!js || !html5 || display)
 
 

--- a/lime/graphics/opengl/ext/OES_vertex_half_float.hx
+++ b/lime/graphics/opengl/ext/OES_vertex_half_float.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_vertex_half_float {
 	
 	

--- a/lime/graphics/opengl/ext/OES_vertex_type_10_10_10_2.hx
+++ b/lime/graphics/opengl/ext/OES_vertex_type_10_10_10_2.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class OES_vertex_type_10_10_10_2 {
 	
 	

--- a/lime/graphics/opengl/ext/QCOM_alpha_test.hx
+++ b/lime/graphics/opengl/ext/QCOM_alpha_test.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class QCOM_alpha_test {
 	
 	

--- a/lime/graphics/opengl/ext/QCOM_binning_control.hx
+++ b/lime/graphics/opengl/ext/QCOM_binning_control.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class QCOM_binning_control {
 	
 	

--- a/lime/graphics/opengl/ext/QCOM_extended_get.hx
+++ b/lime/graphics/opengl/ext/QCOM_extended_get.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class QCOM_extended_get {
 	
 	

--- a/lime/graphics/opengl/ext/QCOM_perfmon_global_mode.hx
+++ b/lime/graphics/opengl/ext/QCOM_perfmon_global_mode.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class QCOM_perfmon_global_mode {
 	
 	

--- a/lime/graphics/opengl/ext/QCOM_tiled_rendering.hx
+++ b/lime/graphics/opengl/ext/QCOM_tiled_rendering.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class QCOM_tiled_rendering {
 	
 	

--- a/lime/graphics/opengl/ext/QCOM_writeonly_rendering.hx
+++ b/lime/graphics/opengl/ext/QCOM_writeonly_rendering.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class QCOM_writeonly_rendering {
 	
 	

--- a/lime/graphics/opengl/ext/VIV_shader_binary.hx
+++ b/lime/graphics/opengl/ext/VIV_shader_binary.hx
@@ -1,6 +1,8 @@
 package lime.graphics.opengl.ext;
 
 
+@:keep
+
 class VIV_shader_binary {
 	
 	

--- a/lime/graphics/opengl/ext/WEBGL_color_buffer_float.hx
+++ b/lime/graphics/opengl/ext/WEBGL_color_buffer_float.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_color_buffer_float")
 extern class WEBGL_color_buffer_float {
 	

--- a/lime/graphics/opengl/ext/WEBGL_compressed_texture_atc.hx
+++ b/lime/graphics/opengl/ext/WEBGL_compressed_texture_atc.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_compressed_texture_atc")
 extern class WEBGL_compressed_texture_atc {
 	

--- a/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc.hx
+++ b/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_compressed_texture_etc")
 extern class WEBGL_compressed_texture_etc {
 	

--- a/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc1.hx
+++ b/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc1.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_compressed_texture_etc1")
 extern class WEBGL_compressed_texture_etc1 {
 	

--- a/lime/graphics/opengl/ext/WEBGL_compressed_texture_pvrtc.hx
+++ b/lime/graphics/opengl/ext/WEBGL_compressed_texture_pvrtc.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_compressed_texture_pvrtc")
 extern class WEBGL_compressed_texture_pvrtc {
 	

--- a/lime/graphics/opengl/ext/WEBGL_compressed_texture_s3tc.hx
+++ b/lime/graphics/opengl/ext/WEBGL_compressed_texture_s3tc.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_compressed_texture_s3tc")
 extern class WEBGL_compressed_texture_s3tc {
 	

--- a/lime/graphics/opengl/ext/WEBGL_debug_renderer_info.hx
+++ b/lime/graphics/opengl/ext/WEBGL_debug_renderer_info.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_debug_renderer_info")
 extern class WEBGL_debug_renderer_info {
 	

--- a/lime/graphics/opengl/ext/WEBGL_debug_shaders.hx
+++ b/lime/graphics/opengl/ext/WEBGL_debug_shaders.hx
@@ -4,6 +4,8 @@ package lime.graphics.opengl.ext; #if (js && html5)
 import lime.graphics.opengl.GLShader;
 
 
+@:keep
+
 @:native("WEBGL_debug_shaders")
 extern class WEBGL_debug_shaders {
 	

--- a/lime/graphics/opengl/ext/WEBGL_depth_texture.hx
+++ b/lime/graphics/opengl/ext/WEBGL_depth_texture.hx
@@ -4,6 +4,8 @@ package lime.graphics.opengl.ext; #if (js && html5)
 import lime.graphics.opengl.GLShader;
 
 
+@:keep
+
 @:native("WEBGL_depth_texture")
 extern class WEBGL_depth_texture {
 	

--- a/lime/graphics/opengl/ext/WEBGL_draw_buffers.hx
+++ b/lime/graphics/opengl/ext/WEBGL_draw_buffers.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_draw_buffers")
 extern class WEBGL_draw_buffers {
 	

--- a/lime/graphics/opengl/ext/WEBGL_lose_context.hx
+++ b/lime/graphics/opengl/ext/WEBGL_lose_context.hx
@@ -1,6 +1,9 @@
 package lime.graphics.opengl.ext; #if (js && html5)
 
 
+@:keep
+
+
 @:native("WEBGL_lose_context")
 extern class WEBGL_lose_context {
 	


### PR DESCRIPTION
With dce=full, GL returns extension objects with null attributes. The new openfl Context3D sets some constants from them and so even basic GPU functionality breaks with DCE. I added "@:keep" before every class with 1+ fields in lime.graphics.opengl.ext and it fixed my problems.
```
var bgraExtension = lime.graphics.opengl.GL.getExtension("EXT_bgra");  
trace(bgraExtension.BGRA_EXT);
```
This would trace null now.