### PR TITLE
Request Permission result for Android.

### DIFF
--- a/dependencies/extension-api/src/main/java/org/haxe/extension/Extension.java
+++ b/dependencies/extension-api/src/main/java/org/haxe/extension/Extension.java
@@ -31,6 +31,12 @@ public class Extension {
 		return true;
 		
 	}
+
+	public boolean onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+
+		return true;
+
+	}
 	
 	
 	public boolean onBackPressed () {

--- a/templates/android/template/app/src/main/java/org/haxe/lime/GameActivity.java
+++ b/templates/android/template/app/src/main/java/org/haxe/lime/GameActivity.java
@@ -1,9 +1,9 @@
 package org.haxe.lime;
 
 
-import android.content.res.AssetManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -11,16 +11,16 @@ import android.os.Handler;
 import android.os.Vibrator;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.MimeTypeMap;
+import org.haxe.extension.Extension;
+import org.libsdl.app.SDLActivity;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.haxe.extension.Extension;
-import org.libsdl.app.SDLActivity;
 
 
 public class GameActivity extends SDLActivity {
@@ -71,6 +71,23 @@ public class GameActivity extends SDLActivity {
 		
 		super.onActivityResult (requestCode, resultCode, data);
 		
+	}
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+
+		for (Extension extension : extensions) {
+
+			if (!extension.onRequestPermissionsResult (requestCode, permissions, grantResults)) {
+
+				return;
+
+			}
+
+		}
+
+		super.onRequestPermissionsResult (requestCode, permissions, grantResults);
+
 	}
 	
 	

--- a/templates/extension/dependencies/android/src/main/java/org/haxe/extension/Extension.java
+++ b/templates/extension/dependencies/android/src/main/java/org/haxe/extension/Extension.java
@@ -56,6 +56,15 @@ public class ::className:: extends Extension {
 		return true;
 		
 	}
+
+	/**
+	 * Called when the activity receives th results for permission requests.
+	 */
+	public boolean onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+
+		return true;
+
+	}
 	
 	
 	/**


### PR DESCRIPTION
From Android 6.0, if you target sdk with 23 or greater, you need to request the permissions in runtime.

This PR implements the onRequestPermissionsResult in the Extension class. It is required for request in custom extensions.

More info here: https://developer.android.com/training/permissions/requesting.html