### PR TITLE
Remove @:to metadata from conversion functions to support Haxe4

### DIFF
--- a/lime/ui/KeyCode.hx
+++ b/lime/ui/KeyCode.hx
@@ -257,7 +257,7 @@ import lime._backend.native.NativeCFFI;
 		
 	}
 	
-	@:to private static function toScanCode (keyCode:KeyCode):ScanCode {
+	private static function toScanCode (keyCode:KeyCode):ScanCode {
 		
 		#if (lime_cffi && !macro)
 		var code:Int = keyCode;

--- a/lime/ui/ScanCode.hx
+++ b/lime/ui/ScanCode.hx
@@ -253,7 +253,7 @@ import lime._backend.native.NativeCFFI;
 		
 	}
 	
-	@:to private static function toKeyCode (scanCode:ScanCode):KeyCode {
+	private static function toKeyCode (scanCode:ScanCode):KeyCode {
 		
 		return KeyCode.fromScanCode (scanCode);
 		


### PR DESCRIPTION
Implicit conversion between both abstracts is still possible because both have a @:from function

see also https://github.com/HaxeFoundation/haxe/issues/6441