### PR TITLE
Add possibility to build source map file for minified JS file

### DIFF
--- a/lime/tools/helpers/HTML5Helper.hx
+++ b/lime/tools/helpers/HTML5Helper.hx
@@ -191,6 +191,20 @@ class HTML5Helper {
 					
 				}
 				
+				if (project.targetFlags.exists ("source-map")) {
+					
+					args.push ("--create_source_map");
+					args.push (tempFile + ".map");
+					
+					if (FileSystem.exists(sourceFile + ".map")) {
+						
+						args.push ("--source_map_input");
+						args.push (sourceFile + "|" + sourceFile + ".map");
+						
+					}
+				
+				}
+				
 				if (!LogHelper.verbose) {
 					
 					args.push ("--jscomp_off=uselessCode");
@@ -198,6 +212,13 @@ class HTML5Helper {
 				}
 				
 				ProcessHelper.runCommand ("", "java", args);
+				
+				if (project.targetFlags.exists ("source-map")) {
+					
+					File.copy (tempFile + ".map", sourceFile + ".map");
+					FileSystem.deleteFile (tempFile + ".map");
+					
+				}
 				
 			}
 			


### PR DESCRIPTION
As lime supports the google closure compiler to minify assets it would be great to build source map file for this minified JS version as well to have improved debugging experiences in the production version as well. (only if -source-map flag was passed).
