### PR TITLE
Add upload progress event for HTML5HTTPRequest

### DIFF
--- a/lime/_backend/html5/HTML5HTTPRequest.hx
+++ b/lime/_backend/html5/HTML5HTTPRequest.hx
@@ -63,7 +63,11 @@ class HTML5HTTPRequest {
 	private function load (uri:String, progress:Dynamic, readyStateChange:Dynamic):Void {
 		
 		request = new XMLHttpRequest ();
-		request.addEventListener ("progress", progress, false);
+		if(parent.method == POST) {
+			request.upload.addEventListener ("progress", progress, false);
+		} else {
+			request.addEventListener ("progress", progress, false);
+		}
 		request.onreadystatechange = readyStateChange;
 		
 		var query = "";


### PR DESCRIPTION
Check if the method is POST then use request.upload.onprogress otherwise use default request.onprogress
Previously when uploading data via URLLoader in openfl the progress was fired once with value of 200