### PR TITLE
Start HTTPRequest timeout when doWork is called

### DIFF
--- a/lime/_backend/native/NativeHTTPRequest.hx
+++ b/lime/_backend/native/NativeHTTPRequest.hx
@@ -108,6 +108,27 @@ class NativeHTTPRequest {
 		}
 		
 	}
+
+
+	private function doWork_startTimeout ():Void {
+
+		if (parent.timeout > 0) {
+			
+			timeout = Timer.delay (function () {
+				
+				if (this.promise != null && bytesLoaded == 0 && bytesTotal == 0 && !this.promise.isComplete && !this.promise.isError) {
+					
+					//cancel ();
+					
+					this.promise.error (CURL.strerror (CURLCode.OPERATION_TIMEDOUT));
+					
+				}
+				
+			}, parent.timeout);
+			
+		}
+
+	}
 	
 	
 	private function doWork_loadURL (uri:String, binary:Bool):Void {
@@ -317,22 +338,6 @@ class NativeHTTPRequest {
 		
 		canceled = false;
 		
-		if (parent.timeout > 0) {
-			
-			timeout = Timer.delay (function () {
-				
-				if (this.promise != null && bytesLoaded == 0 && bytesTotal == 0 && !this.promise.isComplete && !this.promise.isError) {
-					
-					//cancel ();
-					
-					this.promise.error (CURL.strerror (CURLCode.OPERATION_TIMEDOUT));
-					
-				}
-				
-			}, parent.timeout);
-			
-		}
-		
 		threadPool.queue ({ instance: this, uri: uri, binary: binary });
 		
 		return promise.future;
@@ -459,7 +464,8 @@ class NativeHTTPRequest {
 			instance.doWork_loadURL (uri, binary);
 			
 		}
-		
+
+		instance.doWork_startTimeout ();
 	}
 	
 	


### PR DESCRIPTION
Otherwise we get some false-positive timeout since the HTTPRequest was never actually "called" but was waiting for other request to finish in the ThreadPool.