### PR TITLE
Ability to define build modules from project.hxp

### DIFF
--- a/lime/tools/helpers/StringHelper.hx
+++ b/lime/tools/helpers/StringHelper.hx
@@ -271,6 +271,61 @@ class StringHelper {
 		return string + "\n" + StringTools.lpad ("", character, string.length);
 		
 	}
-	
+
+	public static function filter (text:String, include:Array<String> = null, exclude:Array<String> = null):Bool {
+
+		if (include == null) {
+
+			include = [ "*" ];
+
+		}
+
+		if (exclude == null) {
+
+			exclude = [];
+
+		}
+
+		for (filter in exclude) {
+
+			if (filter != "") {
+
+				filter = StringTools.replace (filter, ".", "\\.");
+				filter = StringTools.replace (filter, "*", ".*");
+
+				var regexp = new EReg ("^" + filter + "$", "i");
+
+				if (regexp.match (text)) {
+
+					return false;
+
+				}
+
+			}
+
+		}
+
+		for (filter in include) {
+
+			if (filter != "") {
+
+				filter = StringTools.replace (filter, ".", "\\.");
+				filter = StringTools.replace (filter, "*", ".*");
+
+				var regexp = new EReg ("^" + filter, "i");
+
+				if (regexp.match (text)) {
+
+					return true;
+
+				}
+
+			}
+
+		}
+
+		return false;
+
+	}
 	
 }


### PR DESCRIPTION
Moves module processing into ModuleHelper so it can be accessed from places other than ProjectXMLParser, such as a Project.hxp file.