### PR TITLE
Update GameActivity.java

### DIFF
--- a/templates/android/template/app/src/main/java/org/haxe/lime/GameActivity.java
+++ b/templates/android/template/app/src/main/java/org/haxe/lime/GameActivity.java
@@ -310,6 +310,15 @@ public class GameActivity extends SDLActivity {
 	::end::
 	
 	
+	@Override public void onWindowFocusChanged(boolean hasFocus) {
+
+		super.onWindowFocusChanged(hasFocus);
+
+		updateSystemUI ();
+
+	}
+	
+	
 	public static void openFile (String path) {
 		
 		try {


### PR DESCRIPTION
Handle android onWindowFocusChanged in GameActivity.java

Fixes the issue of the System UI Bar showing up over the game screen.
http://community.openfl.org/t/android-navigation-bar-reappears-after-sleep/9617/4