### PR TITLE
 added ANE support for AIR Debug Launcher (ADL)

### DIFF
--- a/lime/tools/helpers/AIRHelper.hx
+++ b/lime/tools/helpers/AIRHelper.hx
@@ -263,6 +263,12 @@ class AIRHelper {
 
 				for (extDir in extDirs) {
 
+					if (!FileSystem.exists(extDir + "/adl")) {
+
+						LogHelper.error("Create " + extDir + "/adl directory, and extract your ANE files to .ane directories.");
+
+					}
+
 					args.push(extDir + "/adl");
 
 				}

--- a/lime/tools/helpers/AIRHelper.hx
+++ b/lime/tools/helpers/AIRHelper.hx
@@ -164,17 +164,7 @@ class AIRHelper {
 		
 		args = args.concat (files);
 
-		var extDirs:Array<String> = [];
-
-		for (dependency in project.dependencies) {
-
-			if (StringTools.endsWith (dependency.path, ".ane") && extDirs.indexOf(dependency.path) == -1) {
-
-				extDirs.push(FileSystem.fullPath(Path.directory(dependency.path)));
-
-			}
-
-		}
+		var extDirs:Array<String> = getExtDirs(project);
 
 		if (extDirs.length > 0) {
 
@@ -197,6 +187,27 @@ class AIRHelper {
 		
 		return targetPath + extension;
 		
+	}
+
+
+	public static function getExtDirs(project:HXProject):Array<String> {
+
+		var extDirs:Array<String> = [];
+
+		for (dependency in project.dependencies) {
+
+			var extDir:String = FileSystem.fullPath(Path.directory(dependency.path));
+
+			if (StringTools.endsWith (dependency.path, ".ane") && extDirs.indexOf(extDir) == -1) {
+
+				extDirs.push(extDir);
+
+			}
+
+		}
+
+		return extDirs;
+
 	}
 	
 	
@@ -233,13 +244,28 @@ class AIRHelper {
 			}
 			
 		} else {
+
+			var extDirs:Array<String> = getExtDirs(project);
+
+			var profile:String = extDirs.length > 0 ? "extendedDesktop" : "desktop";
 			
-			var args = [ "-profile", "desktop" ];
+			var args = [ "-profile", profile ];
 			
 			if (!project.debug) {
 				
 				args.push ("-nodebug");
 				
+			}
+
+			if (extDirs.length > 0) {
+
+				args.push("-extdir");
+
+				for (extDir in extDirs) {
+
+					args.push(extDir + "/adl");
+
+				}
 			}
 			
 			args.push (applicationXML);


### PR DESCRIPTION
For ADL, ANE files need to be extracted to directories. This change will check for an "adl" directory to be created inside extension directory, where the ANE files can be extracted.
The difference of "-extdir" for ADT and ADL is described here: https://help.adobe.com/en_US/air/build/WSfffb011ac560372f-6fa6d7e0128cca93d31-8000.html