### PR TITLE
Added <window httpReqTimeout= > attribute to project.xml

### DIFF
--- a/lime/app/Application.hx
+++ b/lime/app/Application.hx
@@ -43,6 +43,8 @@ class Application extends Module {
 	 * A list of currently attached Module instances
 	**/
 	public var modules (default, null):Array<IModule>;
+
+	public var httpReqTimeout (default, null):Int;
 	
 	/**
 	 * The Preloader for the current Application
@@ -182,6 +184,12 @@ class Application extends Module {
 				
 			}
 			
+			if (Reflect.hasField (config, "httpReqTimeout")) {
+				
+				httpReqTimeout = config.httpReqTimeout;
+				
+			}
+
 			if (Reflect.hasField (config, "windows")) {
 				
 				for (windowConfig in config.windows) {

--- a/lime/app/Config.hx
+++ b/lime/app/Config.hx
@@ -48,6 +48,8 @@ typedef Config = {
 	 * corresponds to the `<meta title="" />` attribute in XML
 	**/
 	@:optional var name:String;
+
+	@:optional var httpReqTimeout:Int;
 	
 	/**
 	 * An application orientation

--- a/lime/net/HTTPRequest.hx
+++ b/lime/net/HTTPRequest.hx
@@ -2,6 +2,7 @@ package lime.net;
 
 
 import haxe.io.Bytes;
+import lime.app.Application;
 import lime.app.Event;
 import lime.app.Future;
 import lime.app.Promise;
@@ -57,7 +58,7 @@ private class AbstractHTTPRequest<T> implements _IHTTPRequest {
 		formData = new Map ();
 		headers = [];
 		method = GET;
-		timeout = 30000;
+		timeout = (Application.current.config != null && Reflect.hasField (Application.current.config, "httpReqTimeout")) ? Reflect.field (Application.current.config, "httpReqTimeout") : 30000;
 		withCredentials = false;
 		
 		#if !display

--- a/lime/project/HXProject.hx
+++ b/lime/project/HXProject.hx
@@ -136,7 +136,7 @@ class HXProject {
 		
 		defaultMeta = { title: "MyApplication", description: "", packageName: "com.example.myapp", version: "1.0.0", company: "", companyUrl: "", buildNumber: null, companyId: "" }
 		defaultApp = { main: "Main", file: "MyApplication", path: "bin", preloader: "", swfVersion: 17, url: "", init: null }
-		defaultWindow = { width: 800, height: 600, parameters: "{}", background: 0xFFFFFF, fps: 30, hardware: true, display: 0, resizable: true, borderless: false, orientation: Orientation.AUTO, vsync: false, fullscreen: false, allowHighDPI: true, alwaysOnTop: false, antialiasing: 0, allowShaders: true, requireShaders: false, depthBuffer: false, stencilBuffer: false, colorDepth: 16, maximized: false, minimized: false, hidden: false }
+		defaultWindow = { width: 800, height: 600, parameters: "{}", background: 0xFFFFFF, fps: 30, httpReqTimeout: 30000, hardware: true, display: 0, resizable: true, borderless: false, orientation: Orientation.AUTO, vsync: false, fullscreen: false, allowHighDPI: true, alwaysOnTop: false, antialiasing: 0, allowShaders: true, requireShaders: false, depthBuffer: false, stencilBuffer: false, colorDepth: 16, maximized: false, minimized: false, hidden: false }
 		
 		platformType = PlatformType.DESKTOP;
 		architectures = [];

--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -2119,7 +2119,7 @@ class ProjectXMLParser extends HXProject {
 						
 					}
 				
-				case "height", "width", "fps", "antialiasing":
+				case "height", "width", "fps", "antialiasing", "httpReqTimeout":
 					
 					if (Reflect.hasField (windows[id], name)) {
 						

--- a/lime/project/WindowData.hx
+++ b/lime/project/WindowData.hx
@@ -11,6 +11,7 @@ typedef WindowData = {
 	@:optional var parameters:String;
 	@:optional var fps:Int;
 	@:optional var hardware:Bool;
+	@:optional var httpReqTimeout:Int;
 	@:optional var display:Int;
 	@:optional var resizable:Bool;
 	@:optional var borderless:Bool;

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -18,6 +18,7 @@ package;
 			company: "::meta.company::",
 			file: "::APP_FILE::",
 			fps: ::WIN_FPS::,
+			httpReqTimeout: ::WIN_HTTP_REQ_TIMEOUT::,
 			name: "::meta.title::",
 			orientation: "::WIN_ORIENTATION::",
 			packageName: "::meta.packageName::",


### PR DESCRIPTION
Allows the 'httpReqTimeout=' to be added as an attribute to the <window> element overriding the default 30000 ms for the HttpRequest timeout. 

e.g. <window httpReqTimeout="180000" if="html5"/>