### PR TITLE
Lib folder seperation for targets hosted in the same location

### DIFF
--- a/lime/tools/helpers/ModuleHelper.hx
+++ b/lime/tools/helpers/ModuleHelper.hx
@@ -39,8 +39,8 @@ class ModuleHelper {
 	
 	public static function buildModules (project:HXProject, tempDirectory:String, outputDirectory:String):Void {
 		
-		tempDirectory = PathHelper.combine (tempDirectory, "lib");
-		outputDirectory = PathHelper.combine (outputDirectory, "lib");
+		tempDirectory = PathHelper.combine (tempDirectory, "lib-" + project.target);
+		outputDirectory = PathHelper.combine (outputDirectory, "lib-" + project.target);
 		
 		PathHelper.mkdir (tempDirectory);
 		PathHelper.mkdir (outputDirectory);
@@ -215,7 +215,7 @@ class ModuleHelper {
 		
 		for (module in project.modules) {
 			
-			project.dependencies.push (new Dependency ("./lib/" + module.name + suffix, null));
+			project.dependencies.push (new Dependency ("./lib-" + project.target + "/" + module.name + suffix, null));
 			
 			excludeTypes = ArrayHelper.concatUnique (excludeTypes, module.classNames);
 			excludeTypes = ArrayHelper.concatUnique (excludeTypes, module.excludeTypes);

--- a/lime/tools/platforms/HTML5Platform.hx
+++ b/lime/tools/platforms/HTML5Platform.hx
@@ -263,8 +263,8 @@ class HTML5Platform extends PlatformTarget {
 				
 				var name = Path.withoutDirectory (dependency.path);
 				
-				context.linkedLibraries.push ("./lib/" + name);
-				FileHelper.copyIfNewer (dependency.path, PathHelper.combine (destination, PathHelper.combine ("lib", name)));
+				context.linkedLibraries.push ("./lib-html5/" + name);
+				FileHelper.copyIfNewer (dependency.path, PathHelper.combine (destination, PathHelper.combine ("lib-html5", name)));
 				
 			}
 			


### PR DESCRIPTION
When SWF assets are to be shared across targets (e.g. HTML & Flash) due to differences in the library.json file separate, target specific versions are needed. This PR along with an equivalent PR for OpenFL (https://github.com/openfl/openfl/pull/1757) changes the generated 'lib' folder to be target specific e.g. 'lib-html5' or 'lib-flash'. 

This allows the two targets to be copied to the same location without conflict and avoiding duplication of assets.

NOTE: This is to be merged along with the equivalent OpenFL PR (https://github.com/openfl/openfl/pull/1757)