### PR TITLE
Add prompt for keystore password on android

### DIFF
--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -1,3 +1,8 @@
+import groovy.swing.SwingBuilder
+import java.awt.GridBagLayout;
+import java.awt.GridBagConstraints;
+import javax.swing.border.EmptyBorder;
+
 apply plugin: 'com.android.application'
 
 android {
@@ -14,6 +19,16 @@ android {
 	
 	::if KEY_STORE::
 	signingConfigs {
+        if (project.KEY_STORE_PASSWORD == 'null') {
+            def keyStoreFile = project.KEY_STORE.split('/')
+            keyStoreFile = keyStoreFile[keyStoreFile.length - 1]
+            project.KEY_STORE_PASSWORD = getPassword('\nPlease enter key password for ' + keyStoreFile + ':');
+        }
+
+        if (project.KEY_STORE_ALIAS_PASSWORD == 'null') {
+            project.KEY_STORE_ALIAS_PASSWORD = getPassword("\nPlease enter key alias password for alias " + project.KEY_STORE_ALIAS + ":")
+        }
+
 		release {
 			storeFile file(project.KEY_STORE)
 			storePassword project.KEY_STORE_PASSWORD
@@ -64,4 +79,60 @@ dependencies {
 	compile fileTree(dir: 'libs', include: ['*.jar'])
 	::if (ANDROID_LIBRARY_PROJECTS)::::foreach (ANDROID_LIBRARY_PROJECTS)::compile project(':deps:::name::')
 	::end::::end::
+}
+
+def getPassword(message) {
+    def password = '';
+    if (System.console() == null) {
+        new SwingBuilder().edt {
+            dialog(
+                title: 'Enter password',
+                alwaysOnTop: true,
+                size: [350, 150],
+                resizable: false,
+                locationRelativeTo: null,
+                pack: true,
+                modal: true,
+                show: true
+            ) {
+                lookAndFeel('system')
+
+                panel(border: new EmptyBorder(10, 10, 10, 10)) {
+                    gridBagLayout()
+                    def gbc = new GridBagConstraints();
+
+                    gbc.gridx = 0
+                    gbc.gridy = 0
+                    gbc.fill = GridBagConstraints.HORIZONTAL
+                    gbc.insets = [0, 0, 10, 0]
+                    label(
+                        text: '<html>' +
+                        '<body style="width: 350px">' +
+                        message +
+                        '</body>' +
+                        '</html>',
+                        constraints: gbc)
+
+                    gbc.gridy = 1
+                    input = passwordField(constraints: gbc)
+
+                    gbc.gridy = 2
+                    gbc.fill = GridBagConstraints.NONE
+                    gbc.insets = [0, 0, 0, 0]
+                    gbc.ipadx = 50
+                    button = button(
+                        defaultButton: true,
+                        text: 'OK',
+                        actionPerformed: {
+                            password = input.password
+                            dispose()
+                        },
+                        constraints: gbc)
+                }
+            }
+        }
+    } else {
+        password = System.console().readPassword(message)
+    }
+    return new String(password)
 }


### PR DESCRIPTION
These changes address the wishlist item here: https://trello.com/c/6W5G8ovz/62-would-be-nice-to-prompt-for-password-if-doing-an-android-release-build-and-the-password-is-not-defined

The changes use the technique described here: https://www.timroes.de/2014/01/19/using-password-prompts-with-gradle-build-files/

The changes add a prompt for a password at the console during an android build when the project.xml certificate element does not have a keystore password specified, and another prompt for an alias password if a keystore alias password is not specified. If build.gradle is run from somewhere other than the console, a small dialog pops up asking for the appropriate passwords. This only happens on release builds when the certificate element specifies a keystore file.