### PR TITLE
for AIR set android and ios targetFlags into defines

### DIFF
--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -121,6 +121,8 @@ class ProjectXMLParser extends HXProject {
 			
 			defines.set ("targetType", "swf");
 			defines.set ("flash", "1");
+			if (targetFlags.exists("ios")) defines.set ("ios", "1");
+			if (targetFlags.exists("android")) defines.set ("android", "1");
 			
 		} else if (target == Platform.WINDOWS && (targetFlags.exists ("uwp") || targetFlags.exists ("winjs"))) {
 			
@@ -1055,7 +1057,7 @@ class ProjectXMLParser extends HXProject {
 	
 	
 	private function parseXML (xml:Fast, section:String, extensionPath:String = ""):Void {
-		
+
 		for (element in xml.elements) {
 			
 			var isValid = isValidElement (element, section);


### PR DESCRIPTION
on AIR, to map different certificates for android and ios, need to copy android and ios targetFlags into defines:
```
<certificate path="Assets/certificate.p12" password="test" if="android" />
<certificate path="Assets/ios_development.p12" password="test" if="ios debug" />
<certificate path="Assets/ios_distribution.p12" password="test" if="ios release" />
```