### PR TITLE
fixes for testing AIR iphone simulator

### DIFF
--- a/lime/tools/helpers/AIRHelper.hx
+++ b/lime/tools/helpers/AIRHelper.hx
@@ -234,12 +234,20 @@ class AIRHelper {
 				
 			}
 			
-			ProcessHelper.runCommand (workingDirectory, project.defines.get ("AIR_SDK") + "/bin/adt", [ "-uninstallApp" ].concat (args).concat ([ "-appid", project.meta.packageName ]));
+			ProcessHelper.runCommand (workingDirectory, project.defines.get ("AIR_SDK") + "/bin/adt", [ "-uninstallApp" ].concat (args).concat ([ "-appid", project.meta.packageName ]), true, true);
 			ProcessHelper.runCommand (workingDirectory, project.defines.get ("AIR_SDK") + "/bin/adt", [ "-installApp" ].concat (args).concat ([ "-package", FileSystem.fullPath (workingDirectory) + "/" + (rootDirectory != null ? rootDirectory + "/" : "") + project.app.file + ".ipa" ]));
 			
 			if (project.targetFlags.exists ("simulator")) {
-				
-				ProcessHelper.runCommand ("", "open", [ "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app/" ]);
+
+				var simulatorAppPath:String = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app/";
+
+				if (!FileSystem.exists(simulatorAppPath)) {
+
+					simulatorAppPath = "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/";
+
+				}
+
+				ProcessHelper.runCommand ("", "open", [ simulatorAppPath ]);
 				
 			}
 			


### PR DESCRIPTION
- ignore errors when running uninstallApp (we don't want to exit if the app is not already installed)
- check which simulator app path to use