### PR TITLE
Fix compatibility with latest Haxe dev

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1811,6 +1811,13 @@ class CommandLineTools {
 			
 			var process = new Process ("haxe", [ "-version" ]);
 			var haxeVersion = StringTools.trim (process.stderr.readAll ().toString ());
+			
+			if (haxeVersion == "") {
+
+				haxeVersion = StringTools.trim (process.stdout.readAll ().toString ());
+
+			}
+			
 			process.close ();
 			
 			environment.set ("haxe", haxeVersion);


### PR DESCRIPTION
Haxe no longer abuses stderr and outputs to stdout, see HaxeFoundation/haxe@f6da2aa. Without this fix, this leads the the following compiler error:

>Error: Lime 5.8.2 is not compatible with Haxe 1 (version 3.2.0 or higher is required)

The fix is basically the same approach vshaxe takes for backwards compatibility: vshaxe/haxe-languageserver@e119a7e