### PR TITLE
iOS, tvOS IPA generation via deploy command

### DIFF
--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -12,414 +12,422 @@ import sys.FileSystem;
 
 
 class IOSHelper {
-	
-	
+
+
 	private static var initialized = false;
-	
-	
+
+
 	public static function build (project:HXProject, workingDirectory:String, additionalArguments:Array<String> = null):Void {
-		
+
 		initialize (project);
-		
+
 		var platformName = "iphoneos";
-		
+
 		if (project.targetFlags.exists ("simulator")) {
-			
+
 			platformName = "iphonesimulator";
-			
+
 		}
-		
+
 		var configuration = "Release";
-		
+
 		if (project.debug) {
-			
+
 			configuration = "Debug";
-			
+
 		}
-		
+
 		var iphoneVersion = project.environment.get ("IPHONE_VER");
-		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion ];
-		
+		var commands = [ "build", "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion ];
+
 		if (project.targetFlags.exists ("simulator")) {
-			
+
 			if (project.targetFlags.exists ("i386")) {
-				
+
 				commands.push ("-arch");
 				commands.push ("i386");
-				
+
 			} else {
-				
+
 				commands.push ("-arch");
 				commands.push ("x86_64");
-			
+
 			}
-			
+
 		} else if (project.targetFlags.exists ("armv7")) {
-			
+
 			commands.push ("-arch");
 			commands.push ("armv7");
-			
+
 		} else if (project.targetFlags.exists ("armv7s")) {
-			
+
 			commands.push ("-arch");
 			commands.push ("armv7s");
-			
+
 		} else if (project.targetFlags.exists ("arm64")) {
-			
+
 			commands.push ("-arch");
 			commands.push ("arm64");
-			
+
 		}
-		
+
 		commands.push ("-project");
 		commands.push (project.app.file + ".xcodeproj");
-		
+
+		if (project.targetFlags.exists("archive")) {
+			commands.push ("archive");
+			commands.push ("-scheme");
+			commands.push (project.app.file);
+			commands.push ("-archivePath");
+			commands.push (PathHelper.combine("build", PathHelper.combine(configuration + "-" + platformName, project.app.file)));
+		}
+
 		if (additionalArguments != null) {
-			
+
 			commands = commands.concat (additionalArguments);
-			
+
 		}
-		
+
 		ProcessHelper.runCommand (workingDirectory, "xcodebuild", commands);
-		
+
 	}
-	
-	
+
+
 	public static function getSDKDirectory (project:HXProject):String {
-		
+
 		initialize (project);
-		
+
 		var platformName = "iPhoneOS";
-		
+
 		if (project.targetFlags.exists ("simulator")) {
-			
+
 			platformName = "iPhoneSimulator";
-			
+
 		}
-		
+
 		var process = new Process ("xcode-select", [ "--print-path" ]);
 		var directory = process.stdout.readLine ();
 		process.close ();
-		
+
 		if (directory == "" || directory.indexOf ("Run xcode-select") > -1) {
-			
+
 			directory = "/Applications/Xcode.app/Contents/Developer";
-			
+
 		}
-		
+
 		directory += "/Platforms/" + platformName + ".platform/Developer/SDKs/" + platformName + project.environment.get ("IPHONE_VER") + ".sdk";
 		return directory;
-		
+
 	}
-	
-	
+
+
 	public static function getIOSVersion (project:HXProject):Void {
-		
+
 		if (!project.environment.exists ("IPHONE_VER") || project.environment.get ("IPHONE_VER") == "4.2") {
-			
+
 			if (!project.environment.exists ("DEVELOPER_DIR") && PlatformHelper.hostPlatform == MAC) {
-				
+
 				var process = new Process ("xcode-select", [ "--print-path" ]);
 				var developerDir = process.stdout.readLine ();
 				process.close ();
-				
+
 				project.environment.set ("DEVELOPER_DIR", developerDir);
-				
+
 			}
-			
+
 			var devPath = project.environment.get ("DEVELOPER_DIR") + "/Platforms/iPhoneOS.platform/Developer/SDKs";
-			
+
 			if (FileSystem.exists (devPath)) {
-				
+
 				var files = FileSystem.readDirectory (devPath);
 				var extractVersion = ~/^iPhoneOS(.*).sdk$/;
 				var best = "0", version;
-				
+
 				for (file in files) {
-					
+
 					if (extractVersion.match (file)) {
-						
+
 						version = extractVersion.matched (1);
-						
+
 						if (Std.parseFloat (version) > Std.parseFloat (best)) {
-							
+
 							best = version;
-							
+
 						}
-						
+
 					}
-					
+
 				}
-				
+
 				if (best != "") {
-					
+
 					project.environment.set ("IPHONE_VER", best);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	private static function getOSXVersion ():String {
-		
+
 		var output = ProcessHelper.runProcess ("", "sw_vers", [ "-productVersion" ]);
-		
+
 		return StringTools.trim (output);
-		
+
 	}
-	
-	
+
+
 	public static function getProvisioningFile (project:HXProject = null):String {
-		
+
 		if (project != null && project.config.exists ("ios.provisioning-profile")) {
-			
+
 			return PathHelper.tryFullPath (project.config.getString ("ios.provisioning-profile"));
-			
+
 		} else if (PlatformHelper.hostPlatform == Platform.MAC) {
-			
+
 			var path = PathHelper.expand ("~/Library/MobileDevice/Provisioning Profiles");
 			var files = FileSystem.readDirectory (path);
-			
+
 			for (file in files) {
-				
+
 				if (Path.extension (file) == "mobileprovision") {
-					
+
 					return path + "/" + file;
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		return "";
-		
+
 	}
-	
-	
+
+
 	private static function getXcodeVersion ():String {
-		
+
 		var output = ProcessHelper.runProcess ("", "xcodebuild", [ "-version" ]);
 		var firstLine = output.split ("\n").shift ();
-		
+
 		return StringTools.trim (firstLine.substring ("Xcode".length, firstLine.length));
-		
+
 	}
-	
-	
+
+
 	private static function initialize (project:HXProject):Void {
-		
+
 		if (!initialized) {
-			
+
 			getIOSVersion (project);
-			
+
 			initialized = true;
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public static function launch (project:HXProject, workingDirectory:String):Void {
-		
+
 		initialize (project);
-		
+
 		var configuration = "Release";
-			
+
 		if (project.debug) {
-			
+
 			configuration = "Debug";
-			
+
 		}
-		
+
 		if (project.targetFlags.exists ("simulator")) {
-			
+
 			var applicationPath = "";
-			
+
 			if (Path.extension (workingDirectory) == "app" || Path.extension (workingDirectory) == "ipa") {
-				
+
 				applicationPath = workingDirectory;
-				
+
 			} else {
-				
+
 				applicationPath = workingDirectory + "/build/" + configuration + "-iphonesimulator/" + project.app.file + ".app";
-				
+
 			}
-			
+
 			var templatePaths = [ PathHelper.combine (PathHelper.getHaxelib (new Haxelib ("lime")), "templates") ].concat (project.templatePaths);
-			
+
 			var output = ProcessHelper.runProcess ("", "xcrun", [ "simctl", "list", "devices" ]);
 			var lines = output.split ("\n");
 			var foundSection = false;
-			
+
 			var device, deviceID;
 			var devices = new Map<String, String> ();
-			
+
 			var currentDeviceID = null;
-			
+
 			for (line in lines) {
-				
+
 				if (StringTools.startsWith (line, "--")) {
-					
+
 					if (line.indexOf ("iOS") > -1) {
-						
+
 						foundSection = true;
-						
+
 					} else if (foundSection) {
-						
+
 						break;
-						
+
 					}
-					
+
 				} else if (foundSection) {
-					
+
 					device = StringTools.trim (line);
 					device = device.substring (0, device.indexOf ("(") - 1);
 					device = device.toLowerCase ();
 					device = StringTools.replace (device, " ", "-");
-					
+
 					deviceID = line.substring (line.indexOf ("(") + 1, line.indexOf (")"));
-					
+
 					if (deviceID.indexOf ("inch") > -1) {
-						
+
 						var startIndex = line.indexOf (")") + 2;
 						deviceID = line.substring (line.indexOf ("(", startIndex) + 1, line.indexOf (")", startIndex));
-						
+
 					}
-					
+
 					devices.set (device, deviceID);
-					
+
 					if (project.targetFlags.exists (device)) {
-						
+
 						currentDeviceID = deviceID;
 						break;
-						
+
 					}
-					
+
 				}
-				
+
 			}
-			
+
 			if (currentDeviceID == null) {
-				
+
 				if (project.targetFlags.exists ("ipad")) {
-					
+
 					currentDeviceID = devices.get ("ipad-air");
-					
+
 				} else {
-					
+
 					currentDeviceID = devices.get ("iphone-6");
-					
+
 				}
-				
+
 			}
-			
+
 			try {
-				
+
 				ProcessHelper.runProcess ("", "open", [ "-Ra", "iOS Simulator" ], true, false);
 				ProcessHelper.runCommand ("", "open", [ "-a", "iOS Simulator", "--args", "-CurrentDeviceUDID", currentDeviceID ]);
-				
+
 			} catch (e:Dynamic) {
-				
+
 				ProcessHelper.runCommand ("", "open", [ "-a", "Simulator", "--args", "-CurrentDeviceUDID", currentDeviceID ]);
-				
+
 			}
-			
+
 			waitForDeviceState ("xcrun", [ "simctl", "uninstall", currentDeviceID, project.meta.packageName ]);
-			waitForDeviceState ("xcrun", [ "simctl", "install", currentDeviceID, applicationPath ]);			
+			waitForDeviceState ("xcrun", [ "simctl", "install", currentDeviceID, applicationPath ]);
 			waitForDeviceState ("xcrun", [ "simctl", "launch", currentDeviceID, project.meta.packageName ]);
-			
+
 			ProcessHelper.runCommand ("", "tail", [ "-F", "~/Library/Logs/CoreSimulator/" + currentDeviceID + "/system.log"]);
-			
+
 		} else {
-			
+
 			var applicationPath = "";
-			
+
 			if (Path.extension (workingDirectory) == "app" || Path.extension (workingDirectory) == "ipa") {
-				
+
 				applicationPath = workingDirectory;
-				
+
 			} else {
-				
+
 				applicationPath = workingDirectory + "/build/" + configuration + "-iphoneos/" + project.app.file + ".app";
-				
+
 			}
-			
+
 			var templatePaths = [ PathHelper.combine (PathHelper.getHaxelib (new Haxelib ("lime")), "templates") ].concat (project.templatePaths);
 			var launcher = PathHelper.findTemplate (templatePaths, "bin/ios-deploy");
 			Sys.command ("chmod", [ "+x", launcher ]);
-			
+
 			var xcodeVersion = getXcodeVersion ();
-			
+
 			ProcessHelper.runCommand ("", launcher, [ "install", "--noninteractive", "--debug", "--bundle", FileSystem.fullPath (applicationPath) ]);
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public static function sign (project:HXProject, workingDirectory:String, entitlementsPath:String):Void {
-		
+
 		initialize (project);
-		
+
 		var configuration = "Release";
-		
+
 		if (project.debug) {
-			
+
 			configuration = "Debug";
-			
+
 		}
-		
+
 		var identity = project.config.getString ("ios.identity", "iPhone Developer");
-		
+
 		var commands = [ "-s", identity, "CODE_SIGN_IDENTITY=" + identity ];
-		
+
 		if (entitlementsPath != null) {
-			
+
 			commands.push ("--entitlements");
 			commands.push (entitlementsPath);
-			
+
 		}
-		
+
 		if (project.config.exists ("ios.provisioning-profile")) {
-			
+
 			commands.push ("PROVISIONING_PROFILE=" + project.config.getString ("ios.provisioning-profile"));
-			
+
 		}
-		
+
 		var applicationPath = "build/" + configuration + "-iphoneos/" + project.app.file + ".app";
 		commands.push (applicationPath);
-		
+
 		ProcessHelper.runCommand (workingDirectory, "codesign", commands, true, true);
-		
+
 	}
-	
-	
+
+
 	private static function waitForDeviceState (command:String, args:Array<String>):Void {
-		
+
 		var output;
-		
+
 		while (true) {
-			
+
 			output = ProcessHelper.runProcess ("", command, args, true, true, true);
-			
+
 			if (output != null && output.toLowerCase ().indexOf ("invalid device state") > -1) {
-				
+
 				Sys.sleep (3);
-				
+
 			} else {
-				
+
 				break;
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 }

--- a/lime/tools/helpers/TVOSHelper.hx
+++ b/lime/tools/helpers/TVOSHelper.hx
@@ -11,364 +11,427 @@ import sys.FileSystem;
 
 
 class TVOSHelper {
-	
-	
+
+
 	private static var initialized = false;
-	
-	
+
+
 	public static function build (project:HXProject, workingDirectory:String, additionalArguments:Array<String> = null):Void {
-		
+
 		initialize (project);
-		
-		var platformName = "appletvos";
-		
-		if (project.targetFlags.exists ("simulator")) {
-			
-			platformName = "appletvsimulator";
-			
-		}
-		
-		var configuration = "Release";
-		
-		if (project.debug) {
-			
-			configuration = "Debug";
-			
-		}
-			
-		var iphoneVersion = project.environment.get ("TVOS_VER");
-		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion ];
-			
-		if (project.targetFlags.exists("simulator")) {
-			
-			commands.push ("-arch");
-			commands.push ("x86_64");
-			
-		}
+
+		var commands = getXCodeArgs(project);
 
 		if (project.targetFlags.exists("archive")) {
+
+			var configuration = project.environment.get ("CONFIGURATION");
+			var platformName = project.environment.get ("PLATFORM_NAME");
+
 			commands.push ("archive");
 			commands.push ("-scheme");
 			commands.push (project.app.file);
 			commands.push ("-archivePath");
 			commands.push (PathHelper.combine("build", PathHelper.combine(configuration + "-" + platformName, project.app.file)));
 		}
-		
+
 		if (additionalArguments != null) {
-			
+
 			commands = commands.concat (additionalArguments);
-			
+
 		}
-		
+
 		ProcessHelper.runCommand (workingDirectory, "xcodebuild", commands);
-		
+
 	}
-	
-	
+
+	public static function deploy (project:HXProject, workingDirectory:String):Void {
+		initialize(project);
+
+		var commands = getXCodeArgs(project);
+
+		var archiveCommands = commands.concat([]);
+
+		// generate xcarchive
+		var configuration = project.environment.get ("CONFIGURATION");
+		var platformName = project.environment.get ("PLATFORM_NAME");
+
+		archiveCommands.push ("archive");
+		archiveCommands.push ("-scheme");
+		archiveCommands.push (project.app.file);
+		archiveCommands.push ("-archivePath");
+		archiveCommands.push (PathHelper.combine("build", PathHelper.combine(configuration + "-" + platformName, project.app.file)));
+
+		ProcessHelper.runCommand (workingDirectory, "xcodebuild", archiveCommands);
+
+		// generate IPA from xcarchive
+		var exportCommands = commands.concat([]);
+
+		var exportMethod = project.targetFlags.exists("adhoc") ? "adhoc"
+		: project.targetFlags.exists("development") ? "development"
+		: project.targetFlags.exists("enterprise") ? "enterprise"
+		: "appstore";
+
+		exportCommands.push ("-exportArchive");
+		exportCommands.push ("-archivePath");
+		exportCommands.push (PathHelper.combine("build", PathHelper.combine(configuration + "-" + platformName, project.app.file + ".xcarchive")));
+		exportCommands.push ("-exportOptionsPlist");
+		exportCommands.push (PathHelper.combine(project.app.file, "exportOptions-" + exportMethod + ".plist"));
+		exportCommands.push ("-exportPath");
+		exportCommands.push (PathHelper.combine ("dist", exportMethod));
+
+		ProcessHelper.runCommand (workingDirectory, "xcodebuild", exportCommands);
+	}
+
+	private static function getXCodeArgs(project:HXProject):Array<String> {
+		var platformName = "appletvos";
+
+		if (project.targetFlags.exists ("simulator")) {
+
+			platformName = "appletvsimulator";
+
+		}
+
+		var configuration = "Release";
+
+		if (project.debug) {
+
+			configuration = "Debug";
+
+		}
+
+		var iphoneVersion = project.environment.get ("TVOS_VER");
+		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion ];
+
+		if (project.targetFlags.exists("simulator")) {
+
+			commands.push ("-arch");
+			commands.push ("x86_64");
+
+		}
+
+		project.setenv ("PLATFORM_NAME", platformName);
+		project.setenv ("CONFIGURATION", configuration);
+
+		// setting CONFIGURATION and PLATFORM_NAME in project.environment doesn't set them for xcodebuild so also pass via command line
+		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion ];
+
+		if (project.targetFlags.exists("simulator")) {
+
+			commands.push ("-arch");
+			commands.push ("x86_64");
+
+		}
+
+		commands.push ("-project");
+		commands.push (project.app.file + ".xcodeproj");
+
+		return commands;
+	}
+
 	private static function getIOSVersion (project:HXProject):Void {
-		
+
 		if (!project.environment.exists("TVOS_VER")) {
-			
+
 			if (!project.environment.exists("DEVELOPER_DIR")) {
-				
+
 				var proc = new Process ("xcode-select", ["--print-path"]);
 				var developer_dir = proc.stdout.readLine ();
 				proc.close ();
 				project.environment.set ("DEVELOPER_DIR", developer_dir);
-				
+
 			}
-			
+
 			var dev_path = project.environment.get ("DEVELOPER_DIR") + "/Platforms/AppleTVOS.platform/Developer/SDKs";
-			
+
 			if (FileSystem.exists (dev_path)) {
-				
+
 				var best = "";
 				var files = FileSystem.readDirectory (dev_path);
 				var extract_version = ~/^AppleTVOS(.*).sdk$/;
-				
+
 				for (file in files) {
-					
+
 					if (extract_version.match (file)) {
-						
+
 						var ver = extract_version.matched (1);
-						
+
 						if (ver > best) {
-							
+
 							best = ver;
-							
+
 						}
-						
+
 					}
-					
+
 				}
-				
+
 				if (best != "") {
-					
+
 					project.environment.set ("TVOS_VER", best);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	private static function getOSXVersion ():String {
-		
+
 		var output = ProcessHelper.runProcess ("", "sw_vers", [ "-productVersion" ]);
 		return StringTools.trim (output);
-		
+
 	}
-	
-	
+
+
 	public static function getProvisioningFile ():String {
-		
+
 		var path = PathHelper.expand ("~/Library/MobileDevice/Provisioning Profiles");
 		var files = FileSystem.readDirectory (path);
-		
+
 		for (file in files) {
-			
+
 			if (Path.extension (file) == "mobileprovision") {
-				
+
 				return path + "/" + file;
-				
+
 			}
-			
+
 		}
-		
+
 		return "";
-		
+
 	}
-	
-	
+
+
 	public static function getSDKDirectory (project:HXProject):String {
-		
+
 		initialize (project);
-		
+
 		var platformName = "AppleTVOS";
-		
+
 		if (project.targetFlags.exists ("simulator")) {
-			
+
 			platformName = "AppleTVSimulator";
-			
+
 		}
-		
+
 		var process = new Process ("xcode-select", [ "--print-path" ]);
 		var directory = process.stdout.readLine ();
 		process.close ();
-		
+
 		if (directory == "" || directory.indexOf ("Run xcode-select") > -1) {
-			
+
 			directory = "/Applications/Xcode.app/Contents/Developer";
-			
+
 		}
-		
+
 		directory += "/Platforms/" + platformName + ".platform/Developer/SDKs/" + platformName + project.environment.get ("TVOS_VER") + ".sdk";
 		LogHelper.info(directory);
 		return directory;
-		
+
 	}
-	
-	
+
+
 	private static function getXcodeVersion ():String {
-		
+
 		var output = ProcessHelper.runProcess ("", "xcodebuild", [ "-version" ]);
 		var firstLine = output.split ("\n").shift ();
-		
+
 		return StringTools.trim (firstLine.substring ("Xcode".length, firstLine.length));
-		
+
 	}
-	
-	
+
+
 	private static function initialize (project:HXProject):Void {
-		
+
 		if (!initialized) {
-			
+
 			getIOSVersion (project);
-			
+
 			initialized = true;
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public static function launch (project:HXProject, workingDirectory:String):Void {
-		
+
 		initialize (project);
-		
+
 		var configuration = "Release";
-			
+
 		if (project.debug) {
-			
+
 			configuration = "Debug";
-			
+
 		}
-		
+
 		if (project.targetFlags.exists ("simulator")) {
-			
+
 			var applicationPath = "";
-			
+
 			if (Path.extension (workingDirectory) == "app" || Path.extension (workingDirectory) == "ipa") {
-				
+
 				applicationPath = workingDirectory;
-				
+
 			} else {
-				
+
 				applicationPath = workingDirectory + "/build/" + configuration + "-appletvsimulator/" + project.app.file + ".app";
-				
+
 			}
-			
+
 			var templatePaths = [ PathHelper.combine (PathHelper.getHaxelib (new Haxelib ("lime")), "templates") ].concat (project.templatePaths);
 			var launcher = PathHelper.findTemplate (templatePaths, "bin/ios-sim");
 			Sys.command ("chmod", [ "+x", launcher ]);
-			
+
 			// device config
 			var defaultDevice = "apple-tv-1080p";
 			var devices:Array<String> = ["apple-tv-1080p"];
 			var oldDevices:Map<String, String> = ["appletv" => "apple-tv-1080p"];
-			
+
 			var deviceFlag:String = null;
 			var deviceTypeID = null;
-			
+
 			// check if old device flag and convert to current
 			for (key in oldDevices.keys ()) {
-				
+
 				if (project.targetFlags.exists (key)) {
-					
+
 					deviceFlag = oldDevices[key];
 					break;
-					
+
 				}
-				
+
 			}
-			
+
 			// check known device in command line args
 			if (deviceFlag == null) {
-				
+
 				for (i in 0...devices.length) {
-					
+
 					if (project.targetFlags.exists (devices[i])) {
-						
+
 						deviceFlag = devices[i];
 						break;
-						
+
 					}
-					
+
 				}
-				
+
 			}
-			
+
 			// default to iphone 6
 			if (deviceFlag == null) {
-				
+
 				deviceFlag = defaultDevice;
-				
+
 			}
-			
+
 			// check if device is available
 			// $ ios-sim showdevicetypes
 			var devicesOutput:String = ProcessHelper.runProcess ("", launcher, [ "showdevicetypes" ]);
 			var deviceTypeList:Array<String> = devicesOutput.split ("\n");
-			
+
 			for (i in 0...deviceTypeList.length) {
-				
+
 				var r = new EReg (deviceFlag + ",", "i");
-				
+
 				if (r.match (deviceTypeList[i])) {
-					
+
 					deviceTypeID = deviceTypeList[i];
 					break;
-					
+
 				}
-				
+
 			}
-			
+
 			if (deviceTypeID == null) {
-				
+
 				LogHelper.warn("Device \"" + deviceFlag + "\" was not found");
-				
+
 			} else {
-				
+
 				LogHelper.info("Launch app on \"" + deviceTypeID + "\"");
-				
+
 			}
-			
+
 			// run command with --devicetypeid if exists
 			if (deviceTypeID != null) {
-				
+
 				ProcessHelper.runCommand ("", launcher, [ "launch", FileSystem.fullPath (applicationPath), /*"--sdk", project.environment.get ("IPHONE_VER"),*/ "--devicetypeid", deviceTypeID, "--timeout", "60" ]);
-				
+
 			} else {
-				
+
 				ProcessHelper.runCommand ("", launcher, [ "launch", FileSystem.fullPath (applicationPath), /*"--sdk", project.environment.get ("IPHONE_VER"), "--devicetypeid", deviceTypeID,*/ "--timeout", "60" ]);
-				
+
 			}
-			
+
 		} else {
-			
+
 			var applicationPath = "";
-			
+
 			if (Path.extension (workingDirectory) == "app" || Path.extension (workingDirectory) == "ipa") {
-				
+
 				applicationPath = workingDirectory;
-				
+
 			} else {
-				
+
 				applicationPath = workingDirectory + "/build/" + configuration + "-appletvos/" + project.app.file + ".app";
-				
+
 			}
-			
+
 			var templatePaths = [ PathHelper.combine (PathHelper.getHaxelib (new Haxelib ("lime")), "templates") ].concat (project.templatePaths);
 			var launcher = PathHelper.findTemplate (templatePaths, "bin/ios-deploy");
 			Sys.command ("chmod", [ "+x", launcher ]);
-			
+
 			var xcodeVersion = getXcodeVersion ();
-			
+
 			ProcessHelper.runCommand ("", launcher, [ "install", "--noninteractive", "--debug", "--timeout", "5", "--bundle", FileSystem.fullPath (applicationPath) ]);
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public static function sign (project:HXProject, workingDirectory:String, entitlementsPath:String):Void {
-		
+
 		initialize (project);
-		
+
 		var configuration = "Release";
-		
+
 		if (project.debug) {
-			
+
 			configuration = "Debug";
-			
+
 		}
-		
+
 		var identity = project.config.getString ("tvos.identity", "tvOS Developer");
-		
+
 		var commands = [ "-s", identity, "CODE_SIGN_IDENTITY=" + identity ];
-		
+
 		if (entitlementsPath != null) {
-			
+
 			commands.push ("--entitlements");
 			commands.push (entitlementsPath);
-			
+
 		}
-		
+
 		if (project.config.exists ("tvos.provisioning-profile")) {
-			
+
 			commands.push ("PROVISIONING_PROFILE=" + project.config.getString ("tvos.provisioning-profile"));
-			
+
 		}
-		
+
 		var applicationPath = "build/" + configuration + "-appletvos/" + project.app.file + ".app";
 		commands.push (applicationPath);
-		
+
 		ProcessHelper.runCommand (workingDirectory, "codesign", commands, true, true);
-		
+
 	}
-	
-	
+
+
 }

--- a/lime/tools/helpers/TVOSHelper.hx
+++ b/lime/tools/helpers/TVOSHelper.hx
@@ -45,6 +45,14 @@ class TVOSHelper {
 			commands.push ("x86_64");
 			
 		}
+
+		if (project.targetFlags.exists("archive")) {
+			commands.push ("archive");
+			commands.push ("-scheme");
+			commands.push (project.app.file);
+			commands.push ("-archivePath");
+			commands.push (PathHelper.combine("build", PathHelper.combine(configuration + "-" + platformName, project.app.file)));
+		}
 		
 		if (additionalArguments != null) {
 			

--- a/lime/tools/platforms/IOSPlatform.hx
+++ b/lime/tools/platforms/IOSPlatform.hx
@@ -32,227 +32,225 @@ import sys.FileSystem;
 
 
 class IOSPlatform extends PlatformTarget {
-	
-	
+
+
 	public function new (command:String, _project:HXProject, targetFlags:Map<String, String> ) {
-		
+
 		super (command, _project, targetFlags);
-		
+
 		targetDirectory = PathHelper.combine (project.app.path, project.config.getString ("ios.output-directory", "ios"));
-		
+
 	}
-	
-	
+
+
 	public override function build ():Void {
-		
+
 		if (project.targetFlags.exists ("xcode") && PlatformHelper.hostPlatform == Platform.MAC) {
-			
+
 			ProcessHelper.runCommand ("", "open", [ targetDirectory + "/" + project.app.file + ".xcodeproj" ] );
-			
+
 		} else {
-			
+
 			IOSHelper.build (project, targetDirectory);
-			
+
 			if (noOutput) return;
-			
+
 			if (!project.targetFlags.exists ("simulator")) {
-				
+
 				var entitlements = targetDirectory + "/" + project.app.file + "/" + project.app.file + "-Entitlements.plist";
 				IOSHelper.sign (project, targetDirectory + "/bin", entitlements);
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public override function clean ():Void {
-		
+
 		if (FileSystem.exists (targetDirectory)) {
-			
+
 			PathHelper.removeDirectory (targetDirectory);
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public override function deploy ():Void {
-		
-		DeploymentHelper.deploy (project, targetFlags, targetDirectory, "iOS");
-		
+		IOSHelper.deploy(project, targetDirectory);
 	}
-	
-	
+
+
 	public override function display ():Void {
-		
+
 		var hxml = PathHelper.findTemplate (project.templatePaths, "iphone/PROJ/haxe/Build.hxml", false);
 		if (hxml == null) hxml = PathHelper.findTemplate (project.templatePaths, "iphone/template/{{app.file}}/Build.hxml", true);
 		var template = new Template (File.getContent (hxml));
-		
+
 		project = project.clone ();
 		var context = generateContext ();
 		context.OUTPUT_DIR = targetDirectory;
-		
+
 		Sys.println (template.execute (context));
 		Sys.println ("-D display");
-		
+
 	}
-	
-	
+
+
 	private function generateContext ():Dynamic {
-		
+
 		//project = project.clone ();
-		
+
 		project.sources.unshift ("");
 		project.sources = PathHelper.relocatePaths (project.sources, PathHelper.combine (targetDirectory, project.app.file + "/haxe"));
 		//project.dependencies.push ("stdc++");
-		
+
 		if (project.targetFlags.exists ("xml")) {
-			
+
 			project.haxeflags.push ("-xml " + targetDirectory + "/types.xml");
-			
+
 		}
-		
+
 		if (project.targetFlags.exists ("final")) {
-			
+
 			project.haxedefs.set ("final", "");
-			
+
 		}
-		
+
 		if (!project.config.exists ("ios.identity")) {
-			
+
 			project.config.set ("ios.identity", "iPhone Developer");
-			
+
 		}
-		
+
 		IOSHelper.getIOSVersion (project);
 		project.haxedefs.set ("IPHONE_VER", project.environment.get ("IPHONE_VER"));
-		
+
 		project.haxedefs.set ("HXCPP_CPP11", "1");
-		
+
 		if (project.config.getString ("ios.compiler") == "llvm" || project.config.getString ("ios.compiler", "clang") == "clang") {
-			
+
 			project.haxedefs.set ("HXCPP_CLANG", "1");
 			project.haxedefs.set ("OBJC_ARC", "1");
-			
+
 		}
-		
+
 		var context = project.templateContext;
-		
+
 		context.HAS_ICON = false;
 		context.HAS_LAUNCH_IMAGE = false;
 		context.OBJC_ARC = false;
 		context.KEY_STORE_IDENTITY = project.config.getString ("ios.identity");
-		
+
 		if (project.config.exists ("ios.provisioning-profile")) {
-			
+
 			context.IOS_PROVISIONING_PROFILE = PathHelper.tryFullPath (project.config.getString ("ios.provisioning-profile"));
-			
+
 		}
-		
+
 		if (project.config.exists ("ios.team-id")) {
-			
+
 			context.DEVELOPMENT_TEAM_ID = project.config.getString ("ios.team-id");
-			
+
 		}
-		
+
 		context.linkedLibraries = [];
-		
+
 		for (dependency in project.dependencies) {
-			
+
 			if (!StringTools.endsWith (dependency.name, ".framework") && !StringTools.endsWith (dependency.name, ".tbd") && !StringTools.endsWith (dependency.path, ".framework")) {
-				
+
 				if (dependency.path != "") {
-					
+
 					var name = Path.withoutDirectory (Path.withoutExtension (dependency.path));
-					
+
 					if (dependency.forceLoad) {
-						
+
 						project.config.push ("ios.linker-flags", "-force_load $SRCROOT/$PRODUCT_NAME/lib/$CURRENT_ARCH/" + Path.withoutDirectory (dependency.path));
-						
+
 					}
-					
+
 					if (StringTools.startsWith (name, "lib")) {
-						
+
 						name = name.substring (3, name.length);
-						
+
 					}
-					
+
 					context.linkedLibraries.push (name);
-					
+
 				} else if (dependency.name != "") {
-					
+
 					context.linkedLibraries.push (dependency.name);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		var valid_archs = new Array<String> ();
 		var armv6 = false;
 		var armv7 = false;
 		var armv7s = false;
 		var arm64 = false;
 		var architectures = project.architectures;
-		
+
 		if (architectures == null || architectures.length == 0) {
-			
+
 			architectures = [ Architecture.ARMV7, Architecture.ARM64 ];
-			
+
 		}
-		
+
 		if (project.config.getString ("ios.device", "universal") == "universal" || project.config.getString ("ios.device") == "iphone") {
-			
+
 			if (project.config.getFloat ("ios.deployment", 8) < 5) {
-				
+
 				ArrayHelper.addUnique (architectures, Architecture.ARMV6);
-				
+
 			}
-			
+
 		}
-		
+
 		for (architecture in project.architectures) {
-			
+
 			switch (architecture) {
-				
+
 				case ARMV6: valid_archs.push ("armv6"); armv6 = true;
 				case ARMV7: valid_archs.push ("armv7"); armv7 = true;
 				case ARMV7S: valid_archs.push ("armv7s"); armv7s = true;
 				case ARM64: valid_archs.push ("arm64"); arm64 = true;
 				default:
-				
+
 			}
-			
+
 		}
-		
+
 		context.CURRENT_ARCHS = "( " + valid_archs.join(",") + ") ";
-		
+
 		valid_archs.push ("x86_64");
 		valid_archs.push ("i386");
-		
+
 		context.VALID_ARCHS = valid_archs.join(" ");
 		context.THUMB_SUPPORT = armv6 ? "GCC_THUMB_SUPPORT = NO;" : "";
-		
+
 		var requiredCapabilities = [];
-		
+
 		if (!armv6 && armv7) {
-			
+
 			requiredCapabilities.push ({ name: "armv7", value: true });
-			
+
 		} else if (!armv6 && !armv7 && armv7s) {
-			
+
 			requiredCapabilities.push ({ name: "armv7s", value: true });
-			
+
 		} else if (!armv6 && !armv7 && !armv7s && arm64) {
-			
+
 			requiredCapabilities.push ({ name: "arm64", value: true });
-			
+
 		}
-		
+
 		context.REQUIRED_CAPABILITY = requiredCapabilities;
 		context.ARMV6 = armv6;
 		context.ARMV7 = armv7;
@@ -260,35 +258,35 @@ class IOSPlatform extends PlatformTarget {
 		context.ARM64 = arm64;
 		context.TARGET_DEVICES = switch (project.config.getString ("ios.device", "universal")) { case "iphone": "1"; case "ipad": "2"; default: "1,2";  }
 		context.DEPLOYMENT = project.config.getString ("ios.deployment", "8.0");
-		
+
 		if (project.config.getString ("ios.compiler") == "llvm" || project.config.getString ("ios.compiler", "clang") == "clang") {
-			
+
 			context.OBJC_ARC = true;
-			
+
 		}
-		
+
 		//context.ENABLE_BITCODE = (project.config.getFloat ("ios.deployment", 8) >= 6);
 		context.ENABLE_BITCODE = project.config.getBool ("ios.enable-bitcode", false);
 		context.IOS_COMPILER = project.config.getString ("ios.compiler", "clang");
 		context.CPP_BUILD_LIBRARY = project.config.getString ("cpp.buildLibrary", "hxcpp");
-		
+
 		var json = Json.parse (File.getContent (PathHelper.getHaxelib (new Haxelib ("hxcpp"), true) + "/haxelib.json"));
-		
+
 		if (Std.parseFloat (json.version) > 3.1) {
-			
+
 			context.CPP_LIBPREFIX = "lib";
-			
+
 		} else {
-			
+
 			context.CPP_LIBPREFIX = "";
-			
+
 		}
-		
+
 		context.IOS_LINKER_FLAGS = ["-stdlib=libc++"].concat (project.config.getArrayString ("ios.linker-flags"));
 		context.IOS_NON_EXEMPT_ENCRYPTION = project.config.getBool ("ios.non-exempt-encryption", true);
-		
+
 		switch (project.window.orientation) {
-			
+
 			case PORTRAIT:
 				context.IOS_APP_ORIENTATION = "<array><string>UIInterfaceOrientationPortrait</string><string>UIInterfaceOrientationPortraitUpsideDown</string></array>";
 			case LANDSCAPE:
@@ -299,188 +297,188 @@ class IOSPlatform extends PlatformTarget {
 				//context.IOS_APP_ORIENTATION = "<array><string>UIInterfaceOrientationLandscapeLeft</string><string>UIInterfaceOrientationLandscapeRight</string><string>UIInterfaceOrientationPortrait</string></array>";
 			default:
 				context.IOS_APP_ORIENTATION = "<array><string>UIInterfaceOrientationLandscapeLeft</string><string>UIInterfaceOrientationLandscapeRight</string><string>UIInterfaceOrientationPortrait</string><string>UIInterfaceOrientationPortraitUpsideDown</string></array>";
-			
+
 		}
-		
+
 		context.ADDL_PBX_BUILD_FILE = "";
 		context.ADDL_PBX_FILE_REFERENCE = "";
 		context.ADDL_PBX_FRAMEWORKS_BUILD_PHASE = "";
 		context.ADDL_PBX_FRAMEWORK_GROUP = "";
-		
+
 		context.frameworkSearchPaths = [];
-		
+
 		for (dependency in project.dependencies) {
-			
+
 			var name = null;
 			var path = null;
 			var fileType = null;
-			
+
 			if (Path.extension (dependency.name) == "framework") {
-				
+
 				name = dependency.name;
 				path = "/System/Library/Frameworks/" + dependency.name;
 				fileType = "wrapper.framework";
-				
+
 			} else if (Path.extension (dependency.name) == "tbd") {
-				
+
 				name = dependency.name;
 				path = "/usr/lib/" + dependency.name;
 				fileType = "sourcecode.text-based-dylib-definition";
-				
+
 			} else if (Path.extension (dependency.path) == "framework") {
-				
+
 				name = Path.withoutDirectory (dependency.path);
 				path = PathHelper.tryFullPath (dependency.path);
 				fileType = "wrapper.framework";
-				
+
 			}
-			
+
 			if (name != null) {
-				
+
 				var frameworkID = "11C0000000000018" + StringHelper.getUniqueID ();
 				var fileID = "11C0000000000018" + StringHelper.getUniqueID ();
-				
+
 				ArrayHelper.addUnique (context.frameworkSearchPaths, Path.directory (path));
-				
+
 				context.ADDL_PBX_BUILD_FILE += "		" + frameworkID + " /* " + name + " in Frameworks */ = {isa = PBXBuildFile; fileRef = " + fileID + " /* " + name + " */; };\n";
 				context.ADDL_PBX_FILE_REFERENCE += "		" + fileID + " /* " + name + " */ = {isa = PBXFileReference; lastKnownFileType = \"" + fileType + "\"; name = \"" + name + "\"; path = \"" + path + "\"; sourceTree = SDKROOT; };\n";
 				context.ADDL_PBX_FRAMEWORKS_BUILD_PHASE += "				" + frameworkID + " /* " + name + " in Frameworks */,\n";
 				context.ADDL_PBX_FRAMEWORK_GROUP += "				" + fileID + " /* " + name + " */,\n";
-				
+
 			}
-			
+
 		}
-		
+
 		context.HXML_PATH = PathHelper.findTemplate (project.templatePaths, "iphone/PROJ/haxe/Build.hxml", false);
 		if (context.HXML_PATH == null) context.HXML_PATH = PathHelper.findTemplate (project.templatePaths, "iphone/template/{{app.file}}/haxe/Build.hxml");
 		context.PRERENDERED_ICON = project.config.getBool ("ios.prerenderedIcon", false);
-		
+
 		var allowInsecureHTTP = project.config.getString ("ios.allow-insecure-http", "*");
-		
+
 		if (allowInsecureHTTP != "*" && allowInsecureHTTP != "true") {
-			
+
 			var sites = [];
-			
+
 			if (allowInsecureHTTP != "false") {
-				
+
 				var domains = project.config.getArrayString ("ios.allow-insecure-http");
-				
+
 				for (domain in domains) {
-					
+
 					sites.push ({ domain: domain });
-					
+
 				}
-				
+
 			}
-			
+
 			context.IOS_ALLOW_INSECURE_HTTP = sites;
-			
+
 		}
-		
+
 		var haxelibPath = project.environment.get ("HAXELIB_PATH");
-		
+
 		if (haxelibPath != null) {
-			
+
 			context.HAXELIB_PATH = 'export HAXELIB_PATH=$haxelibPath;';
-			
+
 		} else {
-			
+
 			context.HAXELIB_PATH = '';
-			
+
 		}
-		
+
 		return context;
-		
+
 	}
-	
-	
+
+
 	public override function rebuild ():Void {
-		
+
 		var armv6 = (project.architectures.indexOf (Architecture.ARMV6) > -1 && !project.targetFlags.exists ("simulator"));
 		var armv7 = (command == "rebuild" || (project.architectures.indexOf (Architecture.ARMV7) > -1 && !project.targetFlags.exists ("simulator")));
 		var armv7s = (project.architectures.indexOf (Architecture.ARMV7S) > -1 && !project.targetFlags.exists ("simulator"));
 		var arm64 = (command == "rebuild" || (project.architectures.indexOf (Architecture.ARM64) > -1 && !project.targetFlags.exists ("simulator")));
 		var i386 = (command == "rebuild" || project.targetFlags.exists ("simulator"));
 		var x86_64 = (command == "rebuild" || project.targetFlags.exists ("simulator"));
-		
+
 		var arc = (project.targetFlags.exists ("arc"));
-		
+
 		var commands = [];
-		
+
 		if (armv6) commands.push ([ "-Dios", "-DHXCPP_CPP11" ]);
 		if (armv7) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARMV7" ]);
 		if (armv7s) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARMV7S" ]);
 		if (arm64) commands.push ([ "-Dios", "-DHXCPP_CPP11", "-DHXCPP_ARM64" ]);
 		if (i386) commands.push ([ "-Dios", "-Dsimulator", "-DHXCPP_CPP11" ]);
 		if (x86_64) commands.push ([ "-Dios", "-Dsimulator", "-DHXCPP_M64", "-DHXCPP_CPP11" ]);
-		
+
 		if (arc) {
-			
+
 			for (command in commands) {
-				
+
 				command.push ("-DOBJC_ARC");
-				
+
 			}
-			
+
 		}
-		
+
 		IOSHelper.getIOSVersion (project);
 		var iphoneVer = project.environment.get ("IPHONE_VER");
-		
+
 		for (command in commands) {
-			
+
 			command.push ("-DIPHONE_VER=" + iphoneVer);
-			
+
 		}
-		
+
 		CPPHelper.rebuild (project, commands);
-		
+
 	}
-	
-	
+
+
 	public override function run ():Void {
-		
+
 		if (project.targetFlags.exists ("xcode")) return;
-		
+
 		IOSHelper.launch (project, targetDirectory);
-		
+
 	}
-	
-	
+
+
 	public override function update ():Void {
-		
+
 		project = project.clone ();
-		
+
 		for (asset in project.assets) {
-			
+
 			if (asset.embed && asset.sourcePath == "") {
-				
+
 				var path = PathHelper.combine (targetDirectory + "/" + project.app.file + "/obj/tmp", asset.targetPath);
 				PathHelper.mkdir (Path.directory (path));
 				FileHelper.copyAsset (asset, path);
 				asset.sourcePath = path;
-				
+
 			}
-			
+
 		}
-		
+
 		//var manifest = new Asset ();
 		//manifest.id = "__manifest__";
 		//manifest.data = AssetHelper.createManifest (project).serialize ();
 		//manifest.resourceName = manifest.flatName = manifest.targetPath = "manifest";
 		//manifest.type = AssetType.TEXT;
 		//project.assets.push (manifest);
-		
+
 		var context = generateContext ();
 		context.OUTPUT_DIR = targetDirectory;
-		
+
 		var projectDirectory = targetDirectory + "/" + project.app.file + "/";
-		
+
 		PathHelper.mkdir (targetDirectory);
 		PathHelper.mkdir (projectDirectory);
 		PathHelper.mkdir (projectDirectory + "/haxe");
 		PathHelper.mkdir (projectDirectory + "/haxe/lime/installer");
-		
+
 		var iconSizes:Array<IconSize> = [
 			{ name: "Icon-Small.png", size: 29 },
 			{ name: "Icon-Small-40.png", size: 40 },
@@ -499,30 +497,30 @@ class IOSPlatform extends PlatformTarget {
 			{ name: "Icon-60@3x.png", size: 180 },
 			{ name: "Icon-Marketing.png", size: 1024 }
 		];
-		
+
 		context.HAS_ICON = true;
-		
+
 		var iconPath = PathHelper.combine (projectDirectory, "Images.xcassets/AppIcon.appiconset");
 		PathHelper.mkdir (iconPath);
-		
+
 		var icons = project.icons;
-		
+
 		if (icons.length == 0) {
-			
+
 			icons = [ new Icon (PathHelper.findTemplate (project.templatePaths, "default/icon.svg")) ];
-			
+
 		}
-		
+
 		for (iconSize in iconSizes) {
-			
+
 			if (!IconHelper.createIcon (icons, iconSize.size, iconSize.size, PathHelper.combine (iconPath, iconSize.name))) {
-				
+
 				context.HAS_ICON = false;
-				
+
 			}
-			
+
 		}
-		
+
 		var splashSizes:Array<SplashSize> = [
 			{ name: "Default.png", w: 320, h: 480 }, // iPhone, portrait
 			{ name: "Default@2x.png", w: 640, h: 960 }, // iPhone Retina, portrait
@@ -539,59 +537,59 @@ class IOSPlatform extends PlatformTarget {
 			{ name: "Default-1100-Portrait-2436h@3x.png", w: 1100, h: 2436 }, // iPhone X, portrait
 			{ name: "Default-1100-Landscape-2436h@3x.png", w: 2435, h: 1100 } // iPhone X, landscape
 		];
-		
+
 		var splashScreenPath = PathHelper.combine (projectDirectory, "Images.xcassets/LaunchImage.launchimage");
 		PathHelper.mkdir (splashScreenPath);
-		
+
 		for (size in splashSizes) {
-			
+
 			var match = false;
-			
+
 			for (splashScreen in project.splashScreens) {
-				
+
 				if (splashScreen.width == size.w && splashScreen.height == size.h && Path.extension (splashScreen.path) == "png") {
-					
+
 					FileHelper.copyFile (splashScreen.path, PathHelper.combine (splashScreenPath, size.name));
 					match = true;
-					
+
 				}
-				
+
 			}
-			
+
 			if (!match) {
-				
+
 				var imagePath = PathHelper.combine (splashScreenPath, size.name);
-				
+
 				if (!FileSystem.exists (imagePath)) {
-					
+
 					LogHelper.info ("", " - \x1b[1mGenerating image:\x1b[0m " + imagePath);
-					
+
 					var image = new Image (null, 0, 0, size.w, size.h, (0xFF << 24) | (project.window.background & 0xFFFFFF));
 					var bytes = image.encode ("png");
-					
+
 					File.saveBytes (imagePath, bytes);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		context.HAS_LAUNCH_IMAGE = true;
-		
+
 		PathHelper.mkdir (projectDirectory + "/resources");
 		PathHelper.mkdir (projectDirectory + "/haxe/build");
-		
+
 		// Long deprecated template path
-		
+
 		FileHelper.recursiveSmartCopyTemplate (project, "iphone/resources", projectDirectory + "/resources", context, true, false);
-		
+
 		// New template path
-		
+
 		FileHelper.recursiveSmartCopyTemplate (project, "ios/template", targetDirectory, context);
-		
+
 		// Recently deprecated template paths
-		
+
 		FileHelper.recursiveSmartCopyTemplate (project, "iphone/PROJ/haxe", projectDirectory + "/haxe", context, true, false);
 		FileHelper.recursiveSmartCopyTemplate (project, "haxe", projectDirectory + "/haxe", context, true, false);
 		FileHelper.recursiveSmartCopyTemplate (project, "iphone/PROJ/Classes", projectDirectory + "/Classes", context, true, false);
@@ -600,159 +598,159 @@ class IOSPlatform extends PlatformTarget {
 		FileHelper.copyFileTemplate (project.templatePaths, "iphone/PROJ/PROJ-Info.plist", projectDirectory + "/" + project.app.file + "-Info.plist", context, true, false);
 		FileHelper.copyFileTemplate (project.templatePaths, "iphone/PROJ/PROJ-Prefix.pch", projectDirectory + "/" + project.app.file + "-Prefix.pch", context, true, false);
 		FileHelper.recursiveSmartCopyTemplate (project, "iphone/PROJ.xcodeproj", targetDirectory + "/" + project.app.file + ".xcodeproj", context, true, false);
-		
+
 		PathHelper.mkdir (projectDirectory + "/lib");
-		
+
 		for (archID in 0...6) {
-			
+
 			var arch = [ "armv6", "armv7", "armv7s", "arm64", "i386", "x86_64" ][archID];
-			
+
 			if (arch == "armv6" && !context.ARMV6)
 				continue;
-			
+
 			if (arch == "armv7" && !context.ARMV7)
 				continue;
-			
+
 			if (arch == "armv7s" && !context.ARMV7S)
 				continue;
-			
+
 			if (arch == "arm64" && !context.ARM64)
 				continue;
-			
+
 			var libExt = [ ".iphoneos.a", ".iphoneos-v7.a", ".iphoneos-v7s.a", ".iphoneos-64.a", ".iphonesim.a", ".iphonesim-64.a" ][archID];
-			
+
 			PathHelper.mkdir (projectDirectory + "/lib/" + arch);
 			PathHelper.mkdir (projectDirectory + "/lib/" + arch + "-debug");
-			
+
 			for (ndll in project.ndlls) {
-				
+
 				//if (ndll.haxelib != null) {
-					
+
 					var releaseLib = PathHelper.getLibraryPath (ndll, "iPhone", "lib", libExt);
 					var debugLib = PathHelper.getLibraryPath (ndll, "iPhone", "lib", libExt, true);
 					var releaseDest = projectDirectory + "/lib/" + arch + "/lib" + ndll.name + ".a";
 					var debugDest = projectDirectory + "/lib/" + arch + "-debug/lib" + ndll.name + ".a";
-					
+
 					if (!FileSystem.exists (releaseLib)) {
-						
+
 						releaseLib = PathHelper.getLibraryPath (ndll, "iPhone", "lib", ".iphoneos.a");
 						debugLib = PathHelper.getLibraryPath (ndll, "iPhone", "lib", ".iphoneos.a", true);
-						
+
 					}
-					
+
 					FileHelper.copyIfNewer (releaseLib, releaseDest);
-					
+
 					if (FileSystem.exists (debugLib) && debugLib != releaseLib) {
-						
+
 						FileHelper.copyIfNewer (debugLib, debugDest);
-						
+
 					} else if (FileSystem.exists (debugDest)) {
-						
+
 						FileSystem.deleteFile (debugDest);
-						
+
 					}
-					
+
 				//}
-				
+
 			}
-			
+
 			for (dependency in project.dependencies) {
-				
+
 				if (StringTools.endsWith (dependency.path, ".a")) {
-					
+
 					var fileName = Path.withoutDirectory (dependency.path);
-					
+
 					if (!StringTools.startsWith (fileName, "lib")) {
-						
+
 						fileName = "lib" + fileName;
-						
+
 					}
-					
+
 					FileHelper.copyIfNewer (dependency.path, projectDirectory + "/lib/" + arch + "/" + fileName);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		PathHelper.mkdir (projectDirectory + "/assets");
-		
+
 		for (asset in project.assets) {
-			
+
 			if (asset.type != AssetType.TEMPLATE) {
-				
+
 				var targetPath = PathHelper.combine (projectDirectory + "/assets/", asset.resourceName);
-				
+
 				//var sourceAssetPath:String = projectDirectory + "haxe/" + asset.sourcePath;
-				
+
 				PathHelper.mkdir (Path.directory (targetPath));
 				FileHelper.copyAssetIfNewer (asset, targetPath);
-				
+
 				//PathHelper.mkdir (Path.directory (sourceAssetPath));
 				//FileHelper.linkFile (flatAssetPath, sourceAssetPath, true, true);
-				
+
 			} else {
-				
+
 				var targetPath = PathHelper.combine (projectDirectory, asset.targetPath);
-				
+
 				PathHelper.mkdir (Path.directory (targetPath));
 				FileHelper.copyAsset (asset, targetPath, context);
-				
+
 			}
-			
+
 		}
-		
+
 		if (project.targetFlags.exists ("xcode") && PlatformHelper.hostPlatform == Platform.MAC && command == "update") {
-			
+
 			ProcessHelper.runCommand ("", "open", [ targetDirectory + "/" + project.app.file + ".xcodeproj" ] );
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	/*private function updateLaunchImage () {
-		
+
 		var destination = buildDirectory + "/ios";
 		PathHelper.mkdir (destination);
-		
+
 		var has_launch_image = false;
 		if (launchImages.length > 0) has_launch_image = true;
-		
+
 		for (launchImage in launchImages) {
-			
+
 			var splitPath = launchImage.name.split ("/");
 			var path = destination + "/" + splitPath[splitPath.length - 1];
 			FileHelper.copyFile (launchImage.name, path, context, false);
-			
+
 		}
-		
+
 		context.HAS_LAUNCH_IMAGE = has_launch_image;
-		
+
 	}*/
-	
-	
+
+
 	@ignore public override function install ():Void {}
 	@ignore public override function trace ():Void {}
 	@ignore public override function uninstall ():Void {}
-	
-	
+
+
 }
 
 
 private typedef IconSize = {
-	
+
 	name:String,
 	size:Int,
-	
+
 }
 
 
 private typedef SplashSize = {
-	
+
 	name:String,
 	w:Int,
 	h:Int,
-	
+
 }

--- a/lime/tools/platforms/TVOSPlatform.hx
+++ b/lime/tools/platforms/TVOSPlatform.hx
@@ -32,209 +32,209 @@ import sys.FileSystem;
 
 
 class TVOSPlatform extends PlatformTarget {
-	
-	
+
+
 	public function new (command:String, _project:HXProject, targetFlags:Map<String, String> ) {
-		
+
 		super (command, _project, targetFlags);
-		
+
 		targetDirectory = PathHelper.combine (project.app.path, project.config.getString ("tvos.output-directory", "tvos"));
-		
+
 	}
-	
-	
+
+
 	public override function build ():Void {
-		
+
 		if (project.targetFlags.exists ("xcode") && PlatformHelper.hostPlatform == Platform.MAC) {
-			
+
 			ProcessHelper.runCommand ("", "open", [ targetDirectory + "/" + project.app.file + ".xcodeproj" ] );
-			
+
 		} else {
-			
+
 			TVOSHelper.build (project, targetDirectory);
-			
+
 			if (noOutput) return;
-			
+
 			if (!project.targetFlags.exists ("simulator")) {
-				
+
 				var entitlements = targetDirectory + "/" + project.app.file + "/" + project.app.file + "-Entitlements.plist";
 				TVOSHelper.sign (project, targetDirectory + "/bin", entitlements);
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public override function clean ():Void {
-		
+
 		if (FileSystem.exists (targetDirectory)) {
-			
+
 			PathHelper.removeDirectory (targetDirectory);
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public override function deploy ():Void {
-		
-		DeploymentHelper.deploy (project, targetFlags, targetDirectory, "tvOS");
-		
+
+		TVOSHelper.deploy(project, targetDirectory);
+
 	}
-	
-	
+
+
 	public override function display ():Void {
-		
+
 		var hxml = PathHelper.findTemplate (project.templatePaths, "tvos/PROJ/haxe/Build.hxml");
 		var template = new Template (File.getContent (hxml));
-		
+
 		var context = generateContext ();
 		context.OUTPUT_DIR = targetDirectory;
-		
+
 		Sys.println (template.execute (context));
 		Sys.println ("-D display");
-		
+
 	}
-	
-	
+
+
 	private function generateContext ():Dynamic {
-		
+
 		project = project.clone ();
-		
+
 		project.sources.unshift ("");
 		project.sources = PathHelper.relocatePaths (project.sources, PathHelper.combine (targetDirectory, project.app.file + "/haxe"));
 		//project.dependencies.push ("stdc++");
-		
+
 		if (project.targetFlags.exists ("xml")) {
-			
+
 			project.haxeflags.push ("-xml " + targetDirectory + "/types.xml");
-			
+
 		}
-		
+
 		if (project.targetFlags.exists ("final")) {
-			
+
 			project.haxedefs.set ("final", "");
-			
+
 		}
-		
+
 		if (!project.config.exists ("tvos.identity")) {
-			
+
 			project.config.set ("tvos.identity", "tvOS Developer");
-			
+
 		}
-		
+
 		var context = project.templateContext;
-		
+
 		context.HAS_ICON = false;
 		context.HAS_LAUNCH_IMAGE = false;
 		context.OBJC_ARC = false;
 		context.KEY_STORE_IDENTITY = project.config.getString ("tvos.identity");
-		
+
 		context.linkedLibraries = [];
-		
+
 		for (dependency in project.dependencies) {
-			
+
 			if (!StringTools.endsWith (dependency.name, ".framework") && !StringTools.endsWith (dependency.name, ".tbd") && !StringTools.endsWith (dependency.path, ".framework")) {
-				
+
 				if (dependency.path != "") {
-					
+
 					var name = Path.withoutDirectory (Path.withoutExtension (dependency.path));
-					
+
 					project.config.push ("tvos.linker-flags", "-force_load $SRCROOT/$PRODUCT_NAME/lib/$CURRENT_ARCH/" + Path.withoutDirectory (dependency.path));
-					
+
 					if (StringTools.startsWith (name, "lib")) {
-						
+
 						name = name.substring (3, name.length);
-						
+
 					}
-					
+
 					context.linkedLibraries.push (name);
-					
+
 				} else if (dependency.name != "") {
-					
+
 					context.linkedLibraries.push (dependency.name);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		var valid_archs = new Array<String> ();
 		var arm64 = false;
 		var architectures = project.architectures;
-		
+
 		if (architectures == null || architectures.length == 0) {
-			
+
 			architectures = [ Architecture.ARM64 ];
-			
+
 		}
-		
+
 		/*if (project.config.getString ("ios.device", "universal") == "universal" || project.config.getString ("ios.device") == "iphone") {
-			
+
 			if (project.config.getFloat ("ios.deployment", 5.1) < 5) {
-				
+
 				ArrayHelper.addUnique (architectures, Architecture.ARMV6);
-				
+
 			}
-			
+
 		}*/
-		
+
 		for (architecture in project.architectures) {
-			
+
 			switch (architecture) {
-				
+
 				case ARM64: valid_archs.push ("arm64"); arm64 = true;
 				default:
-				
+
 			}
-			
+
 		}
-		
+
 		context.CURRENT_ARCHS = "( " + valid_archs.join(",") + ") ";
-		
+
 		valid_archs.push ("i386");
-		
+
 		context.VALID_ARCHS = valid_archs.join(" ");
 		context.THUMB_SUPPORT = "";
-		
+
 		var requiredCapabilities = [];
-		
+
 		requiredCapabilities.push( { name: "arm64", value: true } );
-		
+
 		context.REQUIRED_CAPABILITY = requiredCapabilities;
 		context.ARM64 = arm64;
 		context.TARGET_DEVICES = switch (project.config.getString ("tvos.device", "appletv")) { case "appletv": "3"; default: "3";  }
 		context.DEPLOYMENT = project.config.getString ("tvos.deployment", "9.0");
-		
+
 		if (project.config.getString ("tvos.compiler") == "llvm" || project.config.getString ("tvos.compiler", "clang") == "clang") {
-			
+
 			context.OBJC_ARC = true;
-			
+
 		}
-		
+
 		context.IOS_COMPILER = project.config.getString ("tvos.compiler", "clang");
 		context.CPP_BUILD_LIBRARY = project.config.getString ("cpp.buildLibrary", "hxcpp");
-		
+
 		var json = Json.parse (File.getContent (PathHelper.getHaxelib (new Haxelib ("hxcpp"), true) + "/haxelib.json"));
-		
+
 		if (Std.parseFloat (json.version) > 3.1) {
-			
+
 			context.CPP_LIBPREFIX = "lib";
-			
+
 		} else {
-			
+
 			context.CPP_LIBPREFIX = "";
-			
+
 		}
-		
+
 		context.IOS_LINKER_FLAGS = ["-stdlib=libc++"].concat (project.config.getArrayString ("tvos.linker-flags"));
 		context.IOS_NON_EXEMPT_ENCRYPTION = project.config.getBool ("tvos.non-exempt-encryption", true);
-		
+
 		switch (project.window.orientation) {
-			
+
 			case PORTRAIT:
 				context.IOS_APP_ORIENTATION = "<array><string>UIInterfaceOrientationPortrait</string><string>UIInterfaceOrientationPortraitUpsideDown</string></array>";
 			case LANDSCAPE:
@@ -245,138 +245,138 @@ class TVOSPlatform extends PlatformTarget {
 				//context.IOS_APP_ORIENTATION = "<array><string>UIInterfaceOrientationLandscapeLeft</string><string>UIInterfaceOrientationLandscapeRight</string><string>UIInterfaceOrientationPortrait</string></array>";
 			default:
 				context.IOS_APP_ORIENTATION = "<array><string>UIInterfaceOrientationLandscapeLeft</string><string>UIInterfaceOrientationLandscapeRight</string><string>UIInterfaceOrientationPortrait</string><string>UIInterfaceOrientationPortraitUpsideDown</string></array>";
-			
+
 		}
-		
+
 		context.ADDL_PBX_BUILD_FILE = "";
 		context.ADDL_PBX_FILE_REFERENCE = "";
 		context.ADDL_PBX_FRAMEWORKS_BUILD_PHASE = "";
 		context.ADDL_PBX_FRAMEWORK_GROUP = "";
-		
+
 		context.frameworkSearchPaths = [];
-		
+
 		for (dependency in project.dependencies) {
-			
+
 			var name = null;
 			var path = null;
 			var fileType = null;
-			
+
 			if (Path.extension (dependency.name) == "framework") {
-				
+
 				name = dependency.name;
 				path = "/System/Library/Frameworks/" + dependency.name;
 				fileType = "wrapper.framework";
-				
+
 			} else if (Path.extension (dependency.name) == "tbd") {
-				
+
 				name = dependency.name;
 				path = "usr/lib/" + dependency.name;
 				fileType = "sourcecode.text-based-dylib-definition";
-				
+
 			} else if (Path.extension (dependency.path) == "framework") {
-				
+
 				name = Path.withoutDirectory (dependency.path);
 				path = PathHelper.tryFullPath (dependency.path);
 				fileType = "wrapper.framework";
-				
+
 			}
-			
+
 			if (name != null) {
-				
+
 				var frameworkID = "11C0000000000018" + StringHelper.getUniqueID ();
 				var fileID = "11C0000000000018" + StringHelper.getUniqueID ();
-				
+
 				ArrayHelper.addUnique (context.frameworkSearchPaths, Path.directory (path));
-				
+
 				context.ADDL_PBX_BUILD_FILE += "		" + frameworkID + " /* " + name + " in Frameworks */ = {isa = PBXBuildFile; fileRef = " + fileID + " /* " + name + " */; };\n";
 				context.ADDL_PBX_FILE_REFERENCE += "		" + fileID + " /* " + name + " */ = {isa = PBXFileReference; lastKnownFileType = \"" + fileType + "\"; name = \"" + name + "\"; path = \"" + path + "\"; sourceTree = SDKROOT; };\n";
 				context.ADDL_PBX_FRAMEWORKS_BUILD_PHASE += "				" + frameworkID + " /* " + name + " in Frameworks */,\n";
 				context.ADDL_PBX_FRAMEWORK_GROUP += "				" + fileID + " /* " + name + " */,\n";
-				
+
 			}
-			
+
 		}
-		
+
 		context.HXML_PATH = PathHelper.findTemplate (project.templatePaths, "tvos/PROJ/haxe/Build.hxml");
 		context.PRERENDERED_ICON = project.config.getBool ("tvos.prerenderedIcon", false);
-		
+
 		var haxelibPath = project.environment.get ("HAXELIB_PATH");
-		
+
 		if (haxelibPath != null) {
-			
+
 			context.HAXELIB_PATH = 'export HAXELIB_PATH=$haxelibPath;';
-			
+
 		} else {
-			
+
 			context.HAXELIB_PATH = '';
-			
+
 		}
-		
+
 		return context;
-		
+
 	}
-	
-	
+
+
 	public override function rebuild ():Void {
-		
+
 		var arm64 = (command == "rebuild" || (project.architectures.indexOf (Architecture.ARM64) > -1 && !project.targetFlags.exists ("simulator")));
 		var i386 = (command == "rebuild" || project.targetFlags.exists ("simulator"));
 		var x86_64 = (command == "rebuild" || project.targetFlags.exists ("simulator"));
-		
+
 		var commands = [];
-		
+
 		if (arm64) commands.push ([ "-Dtvos", "-Dappletvos", "-DHXCPP_CPP11", "-DHXCPP_ARM64", "-DOBJC_ARC", "-DENABLE_BITCODE" ]);
 		if (i386) commands.push ([ "-Dtvos", "-Dappletvsim", "-Dsimulator", "-DHXCPP_CPP11", "-DOBJC_ARC", "-DENABLE_BITCODE" ]);
 		if (x86_64) commands.push ([ "-Dtvos", "-Dappletvsim", "-Dsimulator", "-DHXCPP_M64", "-DHXCPP_CPP11", "-DOBJC_ARC", "-DENABLE_BITCODE" ]);
-		
+
 		CPPHelper.rebuild (project, commands);
-		
+
 	}
-	
-	
+
+
 	public override function run ():Void {
-		
+
 		if (project.targetFlags.exists ("xcode")) return;
-		
+
 		TVOSHelper.launch (project, targetDirectory);
-		
+
 	}
-	
-	
+
+
 	public override function update ():Void {
-		
+
 		project = project.clone ();
-		
+
 		for (asset in project.assets) {
-			
+
 			if (asset.embed && asset.sourcePath == "") {
-				
+
 				var path = PathHelper.combine (targetDirectory + "/" + project.app.file + "/obj/tmp", asset.targetPath);
 				PathHelper.mkdir (Path.directory (path));
 				FileHelper.copyAsset (asset, path);
 				asset.sourcePath = path;
-				
+
 			}
-			
+
 		}
-		
+
 		//var manifest = new Asset ();
 		//manifest.id = "__manifest__";
 		//manifest.data = AssetHelper.createManifest (project).serialize ();
 		//manifest.resourceName = manifest.flatName = manifest.targetPath = "manifest";
 		//manifest.type = AssetType.TEXT;
 		//project.assets.push (manifest);
-		
+
 		var context = generateContext ();
 		context.OUTPUT_DIR = targetDirectory;
-		
+
 		var projectDirectory = targetDirectory + "/" + project.app.file + "/";
-		
+
 		PathHelper.mkdir (targetDirectory);
 		PathHelper.mkdir (projectDirectory);
 		PathHelper.mkdir (projectDirectory + "/haxe");
 		PathHelper.mkdir (projectDirectory + "/haxe/lime/installer");
-		
+
 		var iconSizes:Array<IconSize> = [
 			{ name : "Icon-Small.png", size : 29 },
 			{ name : "Icon-Small-40.png", size : 40 },
@@ -393,30 +393,30 @@ class TVOSPlatform extends PlatformTarget {
 			{ name : "Icon-76@2x.png", size : 152 },
 			{ name : "Icon-60@3x.png", size : 180 },
 		];
-		
+
 		context.HAS_ICON = true;
-		
+
 		var iconPath = PathHelper.combine (projectDirectory, "Images.xcassets/AppIcon.appiconset");
 		PathHelper.mkdir (iconPath);
-		
+
 		var icons = project.icons;
-		
+
 		if (icons.length == 0) {
-			
+
 			icons = [ new Icon (PathHelper.findTemplate (project.templatePaths, "default/icon.svg")) ];
-			
+
 		}
-		
+
 		for (iconSize in iconSizes) {
-			
+
 			if (!IconHelper.createIcon (icons, iconSize.size, iconSize.size, PathHelper.combine (iconPath, iconSize.name))) {
-				
+
 				context.HAS_ICON = false;
-				
+
 			}
-			
+
 		}
-		
+
 		var splashSizes:Array<SplashSize> = [
 			{ name: "Default.png", w: 320, h: 480 }, // iPhone, portrait
 			{ name: "Default@2x.png", w: 640, h: 960  }, // iPhone Retina, portrait
@@ -429,49 +429,49 @@ class TVOSPlatform extends PlatformTarget {
 			{ name: "Default-736h@3x.png", w: 1242,	h: 2208 }, // iPhone 6 Plus, portrait
 			{ name: "Default-736h-Landscape@3x.png", w: 2208, h: 1242 }, // iPhone 6 Plus, landscape
 		];
-		
+
 		var splashScreenPath = PathHelper.combine (projectDirectory, "Images.xcassets/LaunchImage.launchimage");
 		PathHelper.mkdir (splashScreenPath);
-		
+
 		for (size in splashSizes) {
-			
+
 			var match = false;
-			
+
 			for (splashScreen in project.splashScreens) {
-				
+
 				if (splashScreen.width == size.w && splashScreen.height == size.h && Path.extension (splashScreen.path) == "png") {
-					
+
 					FileHelper.copyFile (splashScreen.path, PathHelper.combine (splashScreenPath, size.name));
 					match = true;
-					
+
 				}
-				
+
 			}
-			
+
 			if (!match) {
-				
+
 				var imagePath = PathHelper.combine (splashScreenPath, size.name);
-				
+
 				if (!FileSystem.exists (imagePath)) {
-					
+
 					LogHelper.info ("", " - \x1b[1mGenerating image:\x1b[0m " + imagePath);
-					
+
 					var image = new Image (null, 0, 0, size.w, size.h, (0xFF << 24) | (project.window.background & 0xFFFFFF));
 					var bytes = image.encode ("png");
-					
+
 					File.saveBytes (imagePath, bytes);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		context.HAS_LAUNCH_IMAGE = true;
-		
+
 		PathHelper.mkdir (projectDirectory + "/resources");
 		PathHelper.mkdir (projectDirectory + "/haxe/build");
-		
+
 		FileHelper.recursiveSmartCopyTemplate (project, "tvos/resources", projectDirectory + "/resources", context, true, false);
 		FileHelper.recursiveSmartCopyTemplate (project, "tvos/PROJ/haxe", projectDirectory + "/haxe", context);
 		FileHelper.recursiveSmartCopyTemplate (project, "haxe", projectDirectory + "/haxe", context);
@@ -481,155 +481,155 @@ class TVOSPlatform extends PlatformTarget {
 		FileHelper.copyFileTemplate (project.templatePaths, "tvos/PROJ/PROJ-Info.plist", projectDirectory + "/" + project.app.file + "-Info.plist", context);
 		FileHelper.copyFileTemplate (project.templatePaths, "tvos/PROJ/PROJ-Prefix.pch", projectDirectory + "/" + project.app.file + "-Prefix.pch", context);
 		FileHelper.recursiveSmartCopyTemplate (project, "tvos/PROJ.xcodeproj", targetDirectory + "/" + project.app.file + ".xcodeproj", context);
-		
+
 		//SWFHelper.generateSWFClasses (project, projectDirectory + "/haxe");
-		
+
 		PathHelper.mkdir (projectDirectory + "/lib");
-		
+
 		for (archID in 0...3) {
-			
+
 			var arch = [ "arm64", "i386", "x86_64" ][archID];
-			
+
 			if (arch == "arm64" && !context.ARM64)
 				continue;
-			
+
 			var libExt = [ ".appletvos-64.a", ".appletvsim.a", ".appletvsim-64.a" ][archID];
-			
+
 			PathHelper.mkdir (projectDirectory + "/lib/" + arch);
 			PathHelper.mkdir (projectDirectory + "/lib/" + arch + "-debug");
-			
+
 			for (ndll in project.ndlls) {
-				
+
 				//if (ndll.haxelib != null) {
-					
+
 					var releaseLib = PathHelper.getLibraryPath (ndll, "AppleTV", "lib", libExt);
 					LogHelper.info("releaseLib: " + releaseLib);
 					var debugLib = PathHelper.getLibraryPath (ndll, "AppleTV", "lib", libExt, true);
 					var releaseDest = projectDirectory + "/lib/" + arch + "/lib" + ndll.name + ".a";
 					LogHelper.info("releaseDest: " + releaseDest);
 					var debugDest = projectDirectory + "/lib/" + arch + "-debug/lib" + ndll.name + ".a";
-					
+
 					if (!FileSystem.exists (releaseLib)) {
-						
+
 						releaseLib = PathHelper.getLibraryPath (ndll, "AppleTV", "lib", ".appletvos-64.a");
 						LogHelper.info("alternative releaseLib: " + releaseLib);
 						debugLib = PathHelper.getLibraryPath (ndll, "AppleTV", "lib", ".appletvos-64.a", true);
-						
+
 					}
-					
+
 					FileHelper.copyIfNewer (releaseLib, releaseDest);
-					
+
 					if (FileSystem.exists (debugLib) && debugLib != releaseLib) {
-						
+
 						FileHelper.copyIfNewer (debugLib, debugDest);
-						
+
 					} else if (FileSystem.exists (debugDest)) {
-						
+
 						FileSystem.deleteFile (debugDest);
-						
+
 					}
-					
+
 				//}
-				
+
 			}
-			
+
 			for (dependency in project.dependencies) {
-				
+
 				if (StringTools.endsWith (dependency.path, ".a")) {
-					
+
 					var fileName = Path.withoutDirectory (dependency.path);
-					
+
 					if (!StringTools.startsWith (fileName, "lib")) {
-						
+
 						fileName = "lib" + fileName;
-						
+
 					}
-					
+
 					FileHelper.copyIfNewer (dependency.path, projectDirectory + "/lib/" + arch + "/" + fileName);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		PathHelper.mkdir (projectDirectory + "/assets");
-		
+
 		for (asset in project.assets) {
-			
+
 			if (asset.type != AssetType.TEMPLATE) {
-				
+
 				var targetPath = PathHelper.combine (projectDirectory + "/assets/", asset.resourceName);
-				
+
 				//var sourceAssetPath:String = projectDirectory + "haxe/" + asset.sourcePath;
-				
+
 				PathHelper.mkdir (Path.directory (targetPath));
 				FileHelper.copyAssetIfNewer (asset, targetPath);
-				
+
 				//PathHelper.mkdir (Path.directory (sourceAssetPath));
 				//FileHelper.linkFile (flatAssetPath, sourceAssetPath, true, true);
-				
+
 			} else {
-				
+
 				var targetPath = PathHelper.combine (projectDirectory, asset.targetPath);
-				
+
 				PathHelper.mkdir (Path.directory (targetPath));
 				FileHelper.copyAsset (asset, targetPath, context);
-				
+
 			}
-			
+
 		}
-		
+
 		if (project.targetFlags.exists ("xcode") && PlatformHelper.hostPlatform == Platform.MAC && command == "update") {
-			
+
 			ProcessHelper.runCommand ("", "open", [ targetDirectory + "/" + project.app.file + ".xcodeproj" ] );
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	/*private function updateLaunchImage () {
-		
+
 		var destination = buildDirectory + "/ios";
 		PathHelper.mkdir (destination);
-		
+
 		var has_launch_image = false;
 		if (launchImages.length > 0) has_launch_image = true;
-		
+
 		for (launchImage in launchImages) {
-			
+
 			var splitPath = launchImage.name.split ("/");
 			var path = destination + "/" + splitPath[splitPath.length - 1];
 			FileHelper.copyFile (launchImage.name, path, context, false);
-			
+
 		}
-		
+
 		context.HAS_LAUNCH_IMAGE = has_launch_image;
-		
+
 	}*/
-	
-	
+
+
 	@ignore public override function install ():Void {}
 	@ignore public override function trace ():Void {}
 	@ignore public override function uninstall ():Void {}
-	
-	
+
+
 }
 
 
 private typedef IconSize = {
-	
+
 	name:String,
 	size:Int,
-	
+
 }
 
 
 private typedef SplashSize = {
-	
+
 	name:String,
 	w:Int,
 	h:Int,
-	
+
 }

--- a/templates/ios/template/{{app.file}}/exportOptions-adhoc.plist
+++ b/templates/ios/template/{{app.file}}/exportOptions-adhoc.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>ad-hoc</string>
+		::if (config.ios.adhoc.manifest != null)::<key>manifest</key>
+		<dict>
+			<key>appURL</key>
+			<string>::config.ios.adhoc.manifest.appURL::</string>
+			<key>displayImageURL</key>
+			<string>::config.ios.adhoc.manifest.displayImageURL::</string>
+			<key>fullSizeImageURL</key>
+			<string>::config.ios.adhoc.manifest.fullSizeImageURL::</string>
+		</dict>::end::
+	</dict>
+</plist>

--- a/templates/ios/template/{{app.file}}/exportOptions-appstore.plist
+++ b/templates/ios/template/{{app.file}}/exportOptions-appstore.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>app-store</string>
+	</dict>
+</plist>

--- a/templates/ios/template/{{app.file}}/exportOptions-development.plist
+++ b/templates/ios/template/{{app.file}}/exportOptions-development.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>development</string>
+	</dict>
+</plist>

--- a/templates/ios/template/{{app.file}}/exportOptions-enterprise.plist
+++ b/templates/ios/template/{{app.file}}/exportOptions-enterprise.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>enterprise</string>
+	</dict>
+</plist>

--- a/templates/tvos/PROJ/exportOptions-adhoc.plist
+++ b/templates/tvos/PROJ/exportOptions-adhoc.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>ad-hoc</string>
+		::if (config.ios.adhoc.manifest != null)::<key>manifest</key>
+		<dict>
+			<key>appURL</key>
+			<string>::config.ios.adhoc.manifest.appURL::</string>
+			<key>displayImageURL</key>
+			<string>::config.ios.adhoc.manifest.displayImageURL::</string>
+			<key>fullSizeImageURL</key>
+			<string>::config.ios.adhoc.manifest.fullSizeImageURL::</string>
+		</dict>::end::
+	</dict>
+</plist>

--- a/templates/tvos/PROJ/exportOptions-appstore.plist
+++ b/templates/tvos/PROJ/exportOptions-appstore.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>app-store</string>
+	</dict>
+</plist>

--- a/templates/tvos/PROJ/exportOptions-development.plist
+++ b/templates/tvos/PROJ/exportOptions-development.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>development</string>
+	</dict>
+</plist>

--- a/templates/tvos/PROJ/exportOptions-enterprise.plist
+++ b/templates/tvos/PROJ/exportOptions-enterprise.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>enterprise</string>
+	</dict>
+</plist>


### PR DESCRIPTION
iOS and tvOS `build` generate an `xcarchive` instead of a `.app` when `-archive` is set.

iOS and tvOS `deploy` generates an IPA provisioned for appstore, adhoc, enterprise, or development based on which of those flags is set. Defaults to appstore.

ex: `lime deploy ios -adhoc`

Includes exportOptions-{method}.plist templates for all 4 deployment methods.