### PR TITLE
Automatic iOS and tvOS provisioning and device registration

### DIFF
--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -158,10 +158,10 @@ class IOSHelper {
 			});
 
 		if (xcodeVersions[0] >= 9) {
-			if (project.config.getBool('ios.allowProvisioningUpdates', true)) {
+			if (project.config.getBool('ios.allow-provisioning-updates', true)) {
 				commands.push("-allowProvisioningUpdates");
 			}
-			if (project.config.getBool('ios.allowProvisioningDeviceRegistration', true)) {
+			if (project.config.getBool('ios.allow-provisioning-device-registration', true)) {
 				commands.push("-allowProvisioningDeviceRegistration");
 			}
 		}

--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -150,6 +150,22 @@ class IOSHelper {
 		commands.push ("-project");
 		commands.push (project.app.file + ".xcodeproj");
 		
+		var xcodeVersions = getXcodeVersion()
+			.split(".")
+			.map(function (i:String) {
+				var ver = Std.parseInt(i);
+				return ver != null ? ver : 0;
+			});
+
+		if (xcodeVersions[0] >= 9) {
+			if (project.config.getBool('ios.allowProvisioningUpdates', true)) {
+				commands.push("-allowProvisioningUpdates");
+			}
+			if (project.config.getBool('ios.allowProvisioningDeviceRegistration', true)) {
+				commands.push("-allowProvisioningDeviceRegistration");
+			}
+		}
+
 		return commands;
 		
 	}

--- a/lime/tools/helpers/TVOSHelper.hx
+++ b/lime/tools/helpers/TVOSHelper.hx
@@ -138,10 +138,10 @@ class TVOSHelper {
 			});
 
 		if (xcodeVersions[0] >= 9) {
-			if (project.config.getBool('ios.allowProvisioningUpdates', true)) {
+			if (project.config.getBool('ios.allow-provisioning-updates', true)) {
 				commands.push("-allowProvisioningUpdates");
 			}
-			if (project.config.getBool('ios.allowProvisioningDeviceRegistration', true)) {
+			if (project.config.getBool('ios.allow-provisioning-device-registration', true)) {
 				commands.push("-allowProvisioningDeviceRegistration");
 			}
 		}

--- a/lime/tools/helpers/TVOSHelper.hx
+++ b/lime/tools/helpers/TVOSHelper.hx
@@ -130,6 +130,22 @@ class TVOSHelper {
 		commands.push ("-project");
 		commands.push (project.app.file + ".xcodeproj");
 		
+		var xcodeVersions = getXcodeVersion()
+			.split(".")
+			.map(function (i:String) {
+				var ver = Std.parseInt(i);
+				return ver != null ? ver : 0;
+			});
+
+		if (xcodeVersions[0] >= 9) {
+			if (project.config.getBool('ios.allowProvisioningUpdates', true)) {
+				commands.push("-allowProvisioningUpdates");
+			}
+			if (project.config.getBool('ios.allowProvisioningDeviceRegistration', true)) {
+				commands.push("-allowProvisioningDeviceRegistration");
+			}
+		}
+
 		return commands;
 		
 	}


### PR DESCRIPTION
Only available when using XCode 9 or above.

Can be disabled by setting config.ios.allowProvisioningUpdates and config.ios.allowProvisioningDeviceRegistration to false.

xcodebuild --help for -allowProvisioningUpdates and -allowProvisioningDeviceRegistration:

-allowProvisioningUpdates: Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode's Accounts preference pane.

-allowProvisioningDeviceRegistration: Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if -allowProvisioningUpdates is also passed.