### PR TITLE
Use canvas for copyPixel operations

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -365,9 +365,7 @@ class Image {
 			
 			case CANVAS:
 				
-				// The data path appears to be much faster, even with no alpha image
-				
-				//if (alphaImage != null || sourceImage.type != CANVAS) {
+				if (alphaImage != null || sourceImage.type != CANVAS) {
 					
 					ImageCanvasUtil.convertToData (this);
 					ImageCanvasUtil.convertToData (sourceImage);
@@ -375,13 +373,13 @@ class Image {
 					
 					ImageDataUtil.copyPixels (this, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
 					
-				//} else {
-					//
-					//ImageCanvasUtil.convertToCanvas (this);
-					//ImageCanvasUtil.convertToCanvas (sourceImage);
-					//ImageCanvasUtil.copyPixels (this, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
-					//
-				//}
+				} else {
+
+					ImageCanvasUtil.convertToCanvas (this);
+					ImageCanvasUtil.convertToCanvas (sourceImage);
+					ImageCanvasUtil.copyPixels (this, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
+					
+				}
 			
 			case DATA:
 				

--- a/lime/graphics/utils/ImageCanvasUtil.hx
+++ b/lime/graphics/utils/ImageCanvasUtil.hx
@@ -180,6 +180,9 @@ class ImageCanvasUtil {
 		
 		if (sourceImage.buffer.src != null) {
 			
+			// Set default composition (just in case it is different)
+			image.buffer.__srcContext.globalCompositeOperation = "source-over";
+
 			image.buffer.__srcContext.drawImage (sourceImage.buffer.src, Std.int (sourceRect.x + sourceImage.offsetX), Std.int (sourceRect.y + sourceImage.offsetY), Std.int (sourceRect.width), Std.int (sourceRect.height), Std.int (destPoint.x + image.offsetX), Std.int (destPoint.y + image.offsetY), Std.int (sourceRect.width), Std.int (sourceRect.height));
 			
 		}


### PR DESCRIPTION
I did some tests regarding copyPixels and except for very small images (around 10x10 pixels) it is significantly faster to use the canvas implementation instead of manipulating individual pixels via javascript.

E.g. in this benchmark BitmapDataScene it his around 20 times faster to use canvas than data:
https://github.com/innogames/openfl-mark
