### PR TITLE
Bugfix Uncaught RangeError: Invalid typed array length: 512

### DIFF
--- a/lime/utils/DataPointer.hx
+++ b/lime/utils/DataPointer.hx
@@ -248,6 +248,7 @@ abstract DataPointer(DataPointerType) to DataPointerType {
 					
 				} else {
 					
+					if (length > data.bufferView.byteLength) length = data.bufferView.byteLength;
 					return new Float32Array (data.bufferView.buffer, data.bufferView.byteOffset + data.offset, Std.int (length / Float32Array.BYTES_PER_ELEMENT));
 					
 				}


### PR DESCRIPTION
**Intention**: fix bug 'Uncaught RangeError: Invalid typed array length: 512'

**Reproduce steps**: 
- checkout standard example of away3d for Haxe https://github.com/openfl/away3d-samples/tree/master/intermediate/PolarBearAWDAnimation

- compile with openfl for HTML5 target and run

- observe the error

**Explanation**: (DataPointer.hx -> toFloat32Array) it happens when param 'length' is bigger then actual 'byteLength' of bufferView (in this specific example length == 2048, but the actual byteLength == 1936), so this is attempt to read more bytes than exist.