### PR TITLE
Fix ImageDataUtil.gaussianBlur crash on iOS

### DIFF
--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -668,10 +668,10 @@ class ImageDataUtil {
 			while (i >= 0) {
 				a = Std.int(imgB[ i + 3 ] * strength );
 				a = a < 0 ? 0 : (a > 255 ? 255 : a);
-				imgB[ i + offset] = fromPreMult( imgB[ i ], a );
-				imgB[ i + 1 + offset] = fromPreMult( imgB[ i + 1 ], a );
-				imgB[ i + 2 + offset] = fromPreMult( imgB[ i + 2 ], a );
-				imgB[ i + 3 + offset] = a;
+				imgB[ i ] = fromPreMult( imgB[ i ], a );
+				imgB[ i + 1 ] = fromPreMult( imgB[ i + 1 ], a );
+				imgB[ i + 2 ] = fromPreMult( imgB[ i + 2 ], a );
+				imgB[ i + 3 ] = a;
 				i -= 4;
 			}
 			for (i in 0...offset)


### PR DESCRIPTION
The previous code went beyond the array bounds. I've just fixed the crash and the blur works good for me but it seems that something weird in the code:

```haxe
var i:Int = 0;
		var a:Int;
		if (offset < 0) {
			while (i < imgA.length) {
				a = Std.int(imgB[ i + 3 ] * strength );
				a = a < 0 ? 0 : (a > 255 ? 255 : a);
				imgB[ i ] = fromPreMult( imgB[ i ], a );
				imgB[ i + 1 ] = fromPreMult( imgB[ i + 1 ], a );
				imgB[ i + 2 ] = fromPreMult( imgB[ i + 2 ], a );
				imgB[ i + 3 ] = a;
				i += 4;
			}
			for (i in imgA.length - offset...imgA.length)
				imgB[ i ] = 0;
		} else {
			i = imgA.length - 4;
			while (i >= 0) {
				a = Std.int(imgB[ i + 3 ] * strength );
				a = a < 0 ? 0 : (a > 255 ? 255 : a);
				imgB[ i ] = fromPreMult( imgB[ i ], a );
				imgB[ i + 1 ] = fromPreMult( imgB[ i + 1 ], a );
				imgB[ i + 2 ] = fromPreMult( imgB[ i + 2 ], a );
				imgB[ i + 3 ] = a;
				i -= 4;
			}
			for (i in 0...offset)
				imgB[ i ] = 0;
		}
```
The whole array is set. Then the part related to offset is set.