### PR TITLE
Font metrics in html5

### DIFF
--- a/lime/text/Font.hx
+++ b/lime/text/Font.hx
@@ -40,15 +40,15 @@ import haxe.io.Path;
 class Font {
 	
 	
-	public var ascender (get, null):Int;
-	public var descender (get, null):Int;
+	@:isVar public var ascender (get, set):Null<Int>;		// no "= 0", cause asset sub-classes set properties before calling
+	@:isVar public var descender (get, set):Null<Int>;		// super(). better indicate a missing value with null anyway.
 	public var height (get, null):Int;
 	public var name (default, null):String;
 	public var numGlyphs (get, null):Int;
 	public var src:Dynamic;
 	public var underlinePosition (get, null):Int;
 	public var underlineThickness (get, null):Int;
-	public var unitsPerEM (get, null):Int;
+	@:isVar public var unitsPerEM (get, set):Null<Int>;
 	
 	@:noCompletion private var __fontID:String;
 	@:noCompletion private var __fontPath:String;
@@ -584,24 +584,38 @@ class Font {
 	
 	
 	
-	private function get_ascender ():Int {
+	private function get_ascender ():Null<Int> {
 		
 		#if (lime_cffi && !macro)
 		return NativeCFFI.lime_font_get_ascender (src);
 		#else
-		return 0;
+		return ascender;
 		#end
 		
 	}
 	
 	
-	private function get_descender ():Int {
+	private function set_ascender (value:Null<Int>):Null<Int> {
+		
+		return ascender = value;
+		
+	}
+	
+	
+	private function get_descender ():Null<Int> {
 		
 		#if (lime_cffi && !macro)
 		return NativeCFFI.lime_font_get_descender (src);
 		#else
-		return 0;
+		return descender;
 		#end
+		
+	}
+	
+	
+	private function set_descender (value:Null<Int>):Null<Int> {
+		
+		return descender = value;
 		
 	}
 	
@@ -650,13 +664,20 @@ class Font {
 	}
 	
 	
-	private function get_unitsPerEM ():Int {
+	private function get_unitsPerEM ():Null<Int> {
 		
 		#if (lime_cffi && !macro)
 		return NativeCFFI.lime_font_get_units_per_em (src);
 		#else
-		return 0;
+		return unitsPerEM;
 		#end
+		
+	}
+	
+	
+	private function set_unitsPerEM (value:Null<Int>):Null<Int> {
+		
+		return unitsPerEM = value;
 		
 	}
 	

--- a/lime/tools/platforms/HTML5Platform.hx
+++ b/lime/tools/platforms/HTML5Platform.hx
@@ -3,6 +3,7 @@ package lime.tools.platforms;
 
 import haxe.io.Path;
 import haxe.Template;
+import lime.text.Font;
 import lime.tools.helpers.DeploymentHelper;
 import lime.tools.helpers.FileHelper;
 import lime.tools.helpers.HTML5Helper;
@@ -338,6 +339,12 @@ class HTML5Platform extends PlatformTarget {
 					for (embeddedAsset in embeddedAssets) {
 						
 						if (embeddedAsset.type == "font" && embeddedAsset.sourcePath == asset.sourcePath) {
+							
+							// in html5 we cannot compute font metrics, so we store them for known fonts
+							var font = Font.fromFile (asset.sourcePath);
+							embeddedAsset.ascender = font.ascender;
+							embeddedAsset.descender = font.descender;
+							embeddedAsset.unitsPerEM = font.unitsPerEM;
 							
 							if (shouldEmbedFont) {
 								

--- a/lime/utils/AssetLibrary.hx
+++ b/lime/utils/AssetLibrary.hx
@@ -21,6 +21,8 @@ import flash.media.Sound;
 @:noDebug
 #end
 
+@:access(lime.text.Font)
+
 
 class AssetLibrary {
 	
@@ -560,7 +562,9 @@ class AssetLibrary {
 			var font:Font = Type.createInstance (classTypes.get (id), []);
 			
 			#if (js && html5)
-			return Font.loadFromName (font.name);
+			// font might have properties set via its classType constructor.
+			// Use __loadFromName to preserve these properties in the loaded font.
+			return font.__loadFromName (font.name);
 			#else
 			return Future.withValue (font);
 			#end

--- a/templates/haxe/ManifestResources.hx
+++ b/templates/haxe/ManifestResources.hx
@@ -91,14 +91,14 @@ import sys.FileSystem;
 
 #else
 
-::if (assets != null)::::foreach assets::::if (type == "font")::@:keep @:expose('__ASSET__::flatName::') #if display private #end class __ASSET__::flatName:: extends lime.text.Font { public function new () { #if !html5 __fontPath = "::targetPath::"; #end name = "::fontName::"; super (); }}
+::if (assets != null)::::foreach assets::::if (type == "font")::@:keep @:expose('__ASSET__::flatName::') #if display private #end class __ASSET__::flatName:: extends lime.text.Font { public function new () { #if !html5 __fontPath = "::targetPath::"; #else ascender = ::ascender::; descender = ::descender::; unitsPerEM = ::unitsPerEM::; #end name = "::fontName::"; super (); }}
 ::end::::end::::end::
 
 #end
 
 #if (openfl && !flash)
 
-::if (assets != null)::::foreach assets::::if (type == "font")::@:keep @:expose('__ASSET__OPENFL__::flatName::') #if display private #end class __ASSET__OPENFL__::flatName:: extends openfl.text.Font { public function new () { ::if (embed)::var font = new __ASSET__::flatName:: (); src = font.src; name = font.name;::else::#if !html5 ::if (targetPath != null)::__fontPath = #if (ios || tvos) "assets/" + #end "::targetPath::";::else::::if (library != null)::__fontID = "::library:::::id::";::else::__fontID = "::id::";::end::::end:: #end name = "::fontName::";::end:: super (); }}
+::if (assets != null)::::foreach assets::::if (type == "font")::@:keep @:expose('__ASSET__OPENFL__::flatName::') #if display private #end class __ASSET__OPENFL__::flatName:: extends openfl.text.Font { public function new () { ::if (embed)::__initFromLimeFont(new __ASSET__::flatName:: ());::else::#if !html5 ::if (targetPath != null)::__fontPath = #if (ios || tvos) "assets/" + #end "::targetPath::";::else::::if (library != null)::__fontID = "::library:::::id::";::else::__fontID = "::id::";::end::::end:: #end name = "::fontName::";::end:: super (); }}
 ::end::::end::::end::
 
 #end


### PR DESCRIPTION
The lack of font metrics in html5 is reponsible for at least two serious issues (openfl/openfl#908, openfl/openfl#1801). Unfortunately, there doesn't seem to be a reliable method to get font metrics in html5, especially if we want to support webfonts of any format added dynamically at runtime outside our control.

This PR mitigates this issue by:
 1. making font metrics automatically available for fonts known at build time
 2. allowing the developer to manually add font metrics for dynamically embedded fonts

In both cases, font metrics are used to solve both openfl/openfl#908, openfl/openfl#1801. If not available, the bahaviour stays the same as before. The changes also make it simple to add automated font metric computation in the future, if some reliable method is found.

Detailed summary of the changes (for both openfl and lime):

- font metric properties of `lime.text.font` are now writeable
- for fonts known at build time, font metrics are automatically made available by setting the properties in the generated `__ASSET__*` classes in `ManifestResources.hx`.

- added `openfl.text.Font.registerFontInstance`, allowing to manually add metrics for fonts not known at build time, as follows:  (also demonstrated in this [demo](http://chatziko.github.io/firefox-workaround/Export/html5/bin/))

      var font = new Font(fontName);
      font.ascender = 600;
      font.ascender = 500;
      font.unitsPerEM = 1000;
      Fonts.registerFontInstance(font);

- if font metrics are available:
  * `TextEngine` uses them to properly compute `textHeight` (fixes openfl/openfl#908). As a bonus, this makes the corresponding methods quasi-identical for html5 and lime_cffi, so less `#if`s.

  * `CanvasTextField` uses them to correctly position text in Firefox (fixes openfl/openfl#1801).

- if in the future we find a way to compute metrics automatically for web fonts, we can just add it to `lime.text.Font` and they'll be used automatically for the above purposes.

**Note:** the corresponding openfl PR openfl/openfl#1814 needs to be merged at the same time.




