### PR TITLE
Fixed detection of EMSCRIPTEN_SDK environment variable

### DIFF
--- a/lime/tools/platforms/EmscriptenPlatform.hx
+++ b/lime/tools/platforms/EmscriptenPlatform.hx
@@ -36,11 +36,20 @@ class EmscriptenPlatform extends PlatformTarget {
 	
 	
 	public override function build ():Void {
+		var emSdk = null;
+
+		if (project.environment.exists ("EMSCRIPTEN_SDK")) {
+
+			emSdk = project.environment.get ("EMSCRIPTEN_SDK");
+
+		} else if (project.defines.exists ("EMSCRIPTEN_SDK")) {
+
+			emSdk = project.defines.get ("EMSCRIPTEN_SDK");
+
+		}
 		
-		if (!project.defines.exists ("EMSCRIPTEN_SDK")) {
-			
+		if (emSdk == null) {
 			LogHelper.error ("You must define EMSCRIPTEN_SDK with the path to your Emscripten SDK");
-			
 		}
 		
 		var hxml = targetDirectory + "/haxe/" + buildType + ".hxml";
@@ -59,15 +68,7 @@ class EmscriptenPlatform extends PlatformTarget {
 		
 		CPPHelper.compile (project, targetDirectory + "/obj", [ "-Demscripten", "-Dwebgl", "-Dstatic_link" ]);
 		
-		if (project.environment.exists ("EMSCRIPTEN_SDK")) {
-			
-			project.path (project.environment.get ("EMSCRIPTEN_SDK"));
-			
-		} else if (project.defines.exists ("EMSCRIPTEN_SDK")) {
-			
-			project.path (project.defines.get ("EMSCRIPTEN_SDK"));
-			
-		}
+		project.path(emSdk);
 		
 		ProcessHelper.runCommand ("", "emcc", [ targetDirectory + "/obj/Main.cpp", "-o", targetDirectory + "/obj/Main.o" ], true, false, true);
 		


### PR DESCRIPTION
The way it was written, `lime build emscripten` would fail even if EMSCRIPTEN_SDK was set.