### PR TITLE
Minification fixes/improvements

### DIFF
--- a/lime/tools/helpers/HTML5Helper.hx
+++ b/lime/tools/helpers/HTML5Helper.hx
@@ -182,7 +182,7 @@ class HTML5Helper {
 			} else {
 				
 				var templatePaths = [ PathHelper.combine (PathHelper.getHaxelib (new Haxelib ("lime")), "templates") ].concat (project.templatePaths);
-				var args = [ "-Dapple.awt.UIElement=true", "-jar", PathHelper.findTemplate (templatePaths, "bin/compiler.jar"), "--js", sourceFile, "--js_output_file", tempFile ];
+				var args = [ "-Dapple.awt.UIElement=true", "-jar", PathHelper.findTemplate (templatePaths, "bin/compiler.jar"), "--strict_mode_input", "false", "--js", sourceFile, "--js_output_file", tempFile ];
 				
 				if (project.targetFlags.exists ("advanced")) {
 					

--- a/lime/tools/helpers/HTML5Helper.hx
+++ b/lime/tools/helpers/HTML5Helper.hx
@@ -193,16 +193,14 @@ class HTML5Helper {
 				
 				if (FileSystem.exists (sourceFile + ".map") || project.targetFlags.exists ("source-map")) {
 					
+					// if an input .js.map exists closure automatically detects it (from sourceMappingURL)
+					// --source_map_location_mapping adds file:// to paths (similarly to haxe's .js.map)
+					
 					args.push ("--create_source_map");
 					args.push (tempFile + ".map");
+					args.push ("--source_map_location_mapping");
+					args.push ("/|file:///");
 					
-					if (FileSystem.exists (sourceFile + ".map")) {
-						
-						args.push ("--source_map_input");
-						args.push (sourceFile + "|" + sourceFile + ".map");
-						
-					}
-				
 				}
 				
 				if (!LogHelper.verbose) {
@@ -214,6 +212,11 @@ class HTML5Helper {
 				ProcessHelper.runCommand ("", "java", args);
 				
 				if (FileSystem.exists (tempFile + ".map")) {
+					
+					// closure does not include a sourceMappingURL in the created .js, we do it here
+					var f = File.append (tempFile);
+					f.writeString ("//# sourceMappingURL=" + Path.withoutDirectory (sourceFile) + ".map");
+					f.close ();
 					
 					File.copy (tempFile + ".map", sourceFile + ".map");
 					FileSystem.deleteFile (tempFile + ".map");

--- a/lime/tools/helpers/HTML5Helper.hx
+++ b/lime/tools/helpers/HTML5Helper.hx
@@ -191,7 +191,7 @@ class HTML5Helper {
 					
 				}
 				
-				if (project.debug || project.targetFlags.exists ("source-map")) {
+				if (FileSystem.exists (sourceFile + ".map") || project.targetFlags.exists ("source-map")) {
 					
 					args.push ("--create_source_map");
 					args.push (tempFile + ".map");
@@ -213,7 +213,7 @@ class HTML5Helper {
 				
 				ProcessHelper.runCommand ("", "java", args);
 				
-				if (project.debug || project.targetFlags.exists ("source-map")) {
+				if (FileSystem.exists (tempFile + ".map")) {
 					
 					File.copy (tempFile + ".map", sourceFile + ".map");
 					FileSystem.deleteFile (tempFile + ".map");


### PR DESCRIPTION
Some closure-related fixes/improvements:

1. pass `--strict_mode_input false`, closes openfl/openfl#1827

2. pass `--source_map_location_mapping "/|file:///"`, which causes paths to be prefixed by `file://` (similarly to the haxe-generated .js.map) so that the debugger can find them.

3. Even when closure creates a .js.map, it does _not_ add a `//# sourceMappingURL` to the .js file! We do it ourselves so that the debugger can find it.

4. Haxe can generate source maps for `-final` builds using `-Djs-souce.map`, but minification discards them cause it is triggered by `debug || source-map`. I changed the condition to `<souce.js.map exists> || source-map` which is simpler.

With the above changes debugging a minified app in chrome dev tools works pretty well.



