### PR TITLE
Closure fix

### DIFF
--- a/lime/tools/helpers/FileHelper.hx
+++ b/lime/tools/helpers/FileHelper.hx
@@ -481,6 +481,26 @@ class FileHelper {
 	}
 	
 	
+	public static function replaceText (source:String, replaceString:String, replacement:String) {
+		
+		if (FileSystem.exists (source)) {
+			
+			var output = File.getContent (source);
+			
+			var index = output.indexOf (replaceString);
+			
+			if (index > -1) {
+				
+				output = output.substr (0, index) + replacement + output.substr (index + replaceString.length);
+				File.saveContent (source, output);
+				
+			}
+			
+		}
+		
+	}
+	
+	
 	public static function isNewer (source:String, destination:String):Bool {
 		
 		if (source == null || !FileSystem.exists (source)) {

--- a/lime/tools/helpers/HTML5Helper.hx
+++ b/lime/tools/helpers/HTML5Helper.hx
@@ -12,6 +12,7 @@ import lime.project.Asset;
 import lime.project.Haxelib;
 import lime.project.HXProject;
 import lime.project.Platform;
+import lime.project.Version;
 import sys.FileSystem;
 import sys.io.File;
 
@@ -23,6 +24,31 @@ import cpp.vm.Thread;
 
 
 class HTML5Helper {
+	
+	
+	public static function encodeSourceMappingURL (sourceFile:String) {
+		
+		// This is only required for projects with url-unsafe characters built with a Haxe version prior to 4.0.0
+		
+		var filename = Path.withoutDirectory (sourceFile);
+		
+		if (filename != StringTools.urlEncode (filename)) {
+			
+			var output = ProcessHelper.runProcess ("", "haxe", [ "-version" ], true, true, true, false, true);
+			var haxeVer:Version = StringTools.trim (output);
+			
+			if (haxeVer < ("4.0.0" : Version)) {
+				
+				var replaceString = "//# sourceMappingURL=" + filename + ".map";
+				var replacement = "//# sourceMappingURL=" + StringTools.urlEncode (filename) + ".map";
+				
+				FileHelper.replaceText (sourceFile, replaceString, replacement);
+				
+			}
+			
+		}
+		
+	}
 	
 	
 	public static function generateFontData (project:HXProject, font:Asset):String {
@@ -216,7 +242,7 @@ class HTML5Helper {
 					// closure does not include a sourceMappingURL in the created .js, we do it here
 					#if !nodejs
 					var f = File.append (tempFile);
-					f.writeString ("//# sourceMappingURL=" + Path.withoutDirectory (sourceFile) + ".map");
+					f.writeString ("//# sourceMappingURL=" + StringTools.urlEncode (Path.withoutDirectory (sourceFile)) + ".map");
 					f.close ();
 					#end
 					

--- a/lime/tools/helpers/ModuleHelper.hx
+++ b/lime/tools/helpers/ModuleHelper.hx
@@ -203,21 +203,10 @@ class ModuleHelper {
 	
 	public static function patchFile (outputPath:String):Void {
 		
-		if (FileSystem.exists (outputPath)) {
-			
-			var output = File.getContent (outputPath);
-			
-			var replaceString = "var $hxClasses = {}";
-			var index = output.indexOf (replaceString);
-			
-			if (index > -1) {
-				
-				output = output.substr (0, index) + "if (!$hx_exports.$hxClasses) $hx_exports.$hxClasses = {};\nvar $hxClasses = $hx_exports.$hxClasses" + output.substr (index + replaceString.length);
-				File.saveContent (outputPath, output);
-				
-			}
-			
-		}
+		var replaceString = "var $hxClasses = {}";
+		var replacement = "if (!$hx_exports.$hxClasses) $hx_exports.$hxClasses = {};\nvar $hxClasses = $hx_exports.$hxClasses";
+		
+		FileHelper.replaceText (outputPath, replaceString, replacement);
 		
 	}
 	

--- a/lime/tools/helpers/ProcessHelper.hx
+++ b/lime/tools/helpers/ProcessHelper.hx
@@ -380,13 +380,13 @@ class ProcessHelper {
 				}
 				
 				result = process.exitCode ();
-				process.close ();
 				
 				output = buffer.getBytes ().toString ();
 				
 				if (output == "") {
 					
 					var error = process.stderr.readAll ().toString ();
+					process.close ();
 					
 					if (result != 0 || error != "") {
 						
@@ -422,6 +422,10 @@ class ProcessHelper {
 						
 					}*/
 					
+				} else {
+				
+					process.close ();
+				
 				}
 				
 			}

--- a/lime/tools/platforms/HTML5Platform.hx
+++ b/lime/tools/platforms/HTML5Platform.hx
@@ -60,6 +60,8 @@ class HTML5Platform extends PlatformTarget {
 			
 			if (noOutput) return;
 			
+			HTML5Helper.encodeSourceMappingURL (targetDirectory + "/bin/" + project.app.file + ".js"); 
+			
 			if (project.targetFlags.exists ("webgl")) {
 				
 				FileHelper.copyFile (targetDirectory + "/obj/ApplicationMain.js", outputFile);


### PR DESCRIPTION
Closure compiler fails with "Sourcemap url was invalid" when publishing to html5.

This fix manually applies the url encoding to the sourceMappingURL at the end of the Haxe-generated .js file if needed.