### PR TITLE
Fixed the "image.addEventListener is not a function" browser error

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -1300,7 +1300,12 @@ class Image {
 	private function __fromBase64 (base64:String, type:String, onload:Image->Void = null):Void {
 		
 		#if (js && html5)
+
+		#if openfljs
+		var image:JSImage = untyped __js__('new window.Image ()');
+		#else
 		var image = new JSImage ();
+		#end
 		
 		var image_onLoaded = function (event) {
 			
@@ -1396,7 +1401,11 @@ class Image {
 		
 		#if (js && html5)
 			
+			#if openfljs
+			var image:JSImage = untyped __js__('new window.Image ()');
+			#else
 			var image = new JSImage ();
+			#end
 			
 			#if !display
 			if (!HTML5HTTPRequest.__isSameOrigin (path)) {


### PR DESCRIPTION
Fixes #1164

The generated ES6 Image module had this in the Image.__fromBase64() static function:

var image = new Image()

which would instantiate a new object of type lime.graphics.Image as opposed to the intended HTML Image type.