### PR TITLE
Change armeabi-v7 folder to armeabi-v7a

### DIFF
--- a/lime/tools/platforms/AndroidPlatform.hx
+++ b/lime/tools/platforms/AndroidPlatform.hx
@@ -89,7 +89,7 @@ class AndroidPlatform extends PlatformTarget {
 				
 				if (hasARMV5) {
 					
-					path = sourceSet + "/jniLibs/armeabi-v7";
+					path = sourceSet + "/jniLibs/armeabi-v7a";
 					
 				}
 				
@@ -123,9 +123,9 @@ class AndroidPlatform extends PlatformTarget {
 		
 		if (!ArrayHelper.containsValue (project.architectures, Architecture.ARMV7) || !hasARMV5) {
 			
-			if (FileSystem.exists (sourceSet + "/jniLibs/armeabi-v7")) {
+			if (FileSystem.exists (sourceSet + "/jniLibs/armeabi-v7a")) {
 				
-				PathHelper.removeDirectory (sourceSet + "/jniLibs/armeabi-v7");
+				PathHelper.removeDirectory (sourceSet + "/jniLibs/armeabi-v7a");
 				
 			}
 			


### PR DESCRIPTION
According to Android's NDK guide, the folder should have an armeabi-v7a directory instead of armeabi-v7 ( https://developer.android.com/ndk/guides/abis.html#sa  )

I still kept the default behaviour (a single armeabi folder) if the target is arm-v7 only for compatibility, since androids older than 4.0.4 still use that folder (https://developer.android.com/ndk/guides/abis.html#am , first note).

For the future, Lime should remove armeabi's folder entirely (since this is deprecated in NDK R16).
