### PR TITLE
Export multiple IPA types with one deploy command

### DIFF
--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -123,8 +123,7 @@ class IOSHelper {
 		project.setenv ("CONFIGURATION", configuration);
 		
 		// setting CONFIGURATION and PLATFORM_NAME in project.environment doesn't set them for xcodebuild so also pass via command line
-		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion];
-		commands.push("-IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1");
+		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion ];
 		
 		if (project.targetFlags.exists ("simulator")) {
 			


### PR DESCRIPTION
Avoids re-generating an xcarchive for each IPA type you wish to create so all IPAs have the same UUID and can be symbolicated with the same symbols.

Usage: `openfl deploy ios [-adhoc] [-appstore] [-enterprise] [-development]`