### PR TITLE
FIX conditionals in openglbindings to include 'defined (RASPBERRYPI)'

### DIFF
--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -40,7 +40,7 @@ namespace lime {
 	void* OpenGLBindings::eglHandle = 0;
 	#endif
 	
-	#if !defined(ANDROID) && !defined(IPHONE)
+	#if !defined(ANDROID) && !defined(IPHONE) && !defined (RASPBERRYPI)
 	typedef void (APIENTRY * GL_DebugMessageCallback_Func)(GLDEBUGPROC, const void *);
 	GL_DebugMessageCallback_Func glDebugMessageCallback_ptr = 0;
 	#endif
@@ -191,7 +191,7 @@ namespace lime {
 	}
 	
 	
-	#if !defined(ANDROID) && !defined(IPHONE)
+	#if !defined(ANDROID) && !defined(IPHONE) %% !defined (RASPBERRYPI)
 	void APIENTRY gl_debug_callback (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, GLvoid *userParam) {
 		
 		puts (message);
@@ -1160,7 +1160,7 @@ namespace lime {
 	
 	value lime_gl_get_extension (HxString name) {
 		
-		#if !defined(ANDROID) && !defined(IPHONE)
+		#if !defined(ANDROID) && !defined(IPHONE) %% !defined (RASPBERRYPI)
 		if (!glDebugMessageCallback_ptr && strcmp (name.__s, "KHR_debug") == 0) {
 			
 			glDebugMessageCallback_ptr = (GL_DebugMessageCallback_Func)SDL_GL_GetProcAddress ("glDebugMessageCallback");


### PR DESCRIPTION
For compiling on the raspberry pi, 
OpenGLBindings needs to include 
` && !defined (RASPBERRYPI)`
in 3 places.