### PR TITLE
Use Google's default repository for extension-api and extension template gradle dependencies.

### DIFF
--- a/dependencies/extension-api/build.gradle
+++ b/dependencies/extension-api/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
-		maven {
-			url "http://repo1.maven.org/maven2/"
+		jcenter {
+			url "http://jcenter.bintray.com/"
 		}
 	}
 	

--- a/lime/tools/helpers/IOSHelper.hx
+++ b/lime/tools/helpers/IOSHelper.hx
@@ -123,8 +123,7 @@ class IOSHelper {
 		project.setenv ("CONFIGURATION", configuration);
 		
 		// setting CONFIGURATION and PLATFORM_NAME in project.environment doesn't set them for xcodebuild so also pass via command line
-		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion];
-		commands.push("-IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1");
+		var commands = [ "-configuration", configuration, "PLATFORM_NAME=" + platformName, "SDKROOT=" + platformName + iphoneVersion ];
 		
 		if (project.targetFlags.exists ("simulator")) {
 			

--- a/templates/extension/dependencies/android/build.gradle
+++ b/templates/extension/dependencies/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
-		maven {
-			url "http://repo1.maven.org/maven2/"
+		jcenter {
+			url "http://jcenter.bintray.com/"
 		}
 	}
 	


### PR DESCRIPTION
Jcenter is the default for Android Studio projects, is a superset of Maven Central, and is what is used in the default lime template.

This fixes Android builds failing to resolve gradle and gradle plugin versions that are missing from Maven Central.