### PR TITLE
MouseUp event added on the window a RELEASE_OUTSIDE event can be detected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fixed default framebuffer binding when using iOS simulator
 * Fixed support for properly detecting MP3 format in some files
 * Fixed support for builds on macOS/Linux when `$HOME` variable is not present
+* Fixed crash in continuous-testing when no window can be initialized
 
 
 6.0.1 (01/16/2018)

--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -225,9 +225,6 @@ class HTML5Window {
 				
 			}
 			
-			//Release outside browser window
-			Browser.window.addEventListener("mouseup", handleMouseEvent);
-			
 			// Disable image drag on Firefox
 			Browser.document.addEventListener ("dragstart", function (e) {
 				if (e.target.nodeName.toLowerCase () == "img") {
@@ -445,6 +442,13 @@ class HTML5Window {
 				
 				case "mousedown":
 					
+					if (event.currentTarget == element) {
+						
+						// Release outside browser window
+						Browser.window.addEventListener ("mouseup", handleMouseEvent);
+						
+					}
+					
 					parent.onMouseDown.dispatch (x, y, event.button);
 					
 					if (parent.onMouseDown.canceled) {
@@ -483,7 +487,13 @@ class HTML5Window {
 				
 				case "mouseup":
 					
-					event.stopPropagation ();
+					Browser.window.removeEventListener ("mouseup", handleMouseEvent);
+					
+					if (event.currentTarget == element) {
+						
+						event.stopPropagation ();
+						
+					}
 					
 					parent.onMouseUp.dispatch (x, y, event.button);
 					

--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -225,6 +225,9 @@ class HTML5Window {
 				
 			}
 			
+			//Release outside browser window
+			Browser.window.addEventListener("mouseup", handleMouseEvent);
+			
 			// Disable image drag on Firefox
 			Browser.document.addEventListener ("dragstart", function (e) {
 				if (e.target.nodeName.toLowerCase () == "img") {
@@ -479,6 +482,8 @@ class HTML5Window {
 					}
 				
 				case "mouseup":
+					
+					event.stopPropagation ();
 					
 					parent.onMouseUp.dispatch (x, y, event.button);
 					


### PR DESCRIPTION
Currently mouse events are added to a div element and therefore releasing mouse outside of the browser window doesn't trigger mouseup event. A mouse up event listener is added to the window and it is only executed when mouse is released outside of the window. This way we catch the "RELEASE_OUTSIDE" event