### PR TITLE
update Rpi GLES and EGL linkerflags

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -214,8 +214,8 @@
 				<compilerflag value="-I/opt/vc/include"/>
 				<compilerflag value="-I/opt/vc/include/interface/vcos/pthreads"/>
 				<compilerflag value="-I/opt/vc/include/interface/vmcs_host/linux"/>
-				<compilerflag value="-lGLESv2" />
-				<compilerflag value="-lEGL" />
+				<compilerflag value="-lbrcmGLESv2" />
+				<compilerflag value="-lbrcmEGL" />
 				<compilerflag value="-Wl,--no-undefined -lm -L/opt/vc/lib -lbcm_host -ldl -lpthread -lrt" />
 			</section>
 			
@@ -432,8 +432,8 @@
 				<lib name="-lbcm_host" />
 				<lib name="-ldl" />
 				<lib name="-lm" />
-				<lib name="-lGLESv2" />
-				<lib name="-lEGL" />
+				<lib name="-lbrcmGLESv2" />
+				<lib name="-lbrcmEGL" />
 				<lib name="-L/opt/vc/lib" />
 				
 			</section>


### PR DESCRIPTION
updates RaspberryPi  (rpi) GLES and EGL linkerflags to point to the brcmGLESv2 and brcmEGL libraries. These are available on both an up to date Raspbian Jessie and the newer Raspbian Stretch.