### PR TITLE
WIP: Add language support for air, ios, tvios, mac, android

### DIFF
--- a/lime/project/HXProject.hx
+++ b/lime/project/HXProject.hx
@@ -64,6 +64,7 @@ class HXProject {
 	public var targetHandlers:Map<String, String>;
 	public var templateContext (get_templateContext, null):Dynamic;
 	public var templatePaths:Array<String>;
+	public var language: Language;
 	@:isVar public var window (get, set):WindowData;
 	public var windows:Array<WindowData>;
 	
@@ -310,6 +311,7 @@ class HXProject {
 		samplePaths = new Array<String> ();
 		splashScreens = new Array<SplashScreen> ();
 		targetHandlers = new Map<String, String> ();
+		language = new Language();
 		
 	}
 	
@@ -369,7 +371,7 @@ class HXProject {
 			project.icons.push (icon.clone ());
 			
 		}
-		
+		project.language = language.clone();
 		project.javaPaths = javaPaths.copy ();
 		
 		if (keystore != null) {
@@ -906,6 +908,7 @@ class HXProject {
 			haxelibs = ArrayHelper.concatUnique (haxelibs, project.haxelibs, true, "name");
 			icons = ArrayHelper.concatUnique (icons, project.icons);
 			javaPaths = ArrayHelper.concatUnique (javaPaths, project.javaPaths, true);
+			language.merge(project.language);
 			
 			if (keystore == null) {
 				

--- a/lime/project/Language.hx
+++ b/lime/project/Language.hx
@@ -1,0 +1,20 @@
+package lime.project;
+
+import lime.tools.helpers.ArrayHelper;
+
+class Language {
+	public var supported: Array<String>;
+	public function new(?supported: Array<String>) {
+		if (supported != null) {
+			this.supported = supported;
+		} else {
+			this.supported = [];	
+		}
+	}
+	public function clone(): Language {
+		return new Language(supported.copy());
+	}
+	public function merge(languageToMerge: Language) {
+		supported = ArrayHelper.concatUnique (supported, languageToMerge.supported);
+	}
+}

--- a/lime/project/ProjectXMLParser.hx
+++ b/lime/project/ProjectXMLParser.hx
@@ -1582,6 +1582,10 @@ class ProjectXMLParser extends HXProject {
 						}
 						
 						icons.push (icon);
+					case "language":
+						if (element.has.supported) {
+							language.supported = element.att.supported.split(" ");
+						}
 					
 					case "source", "classpath":
 						

--- a/lime/tools/platforms/AIRPlatform.hx
+++ b/lime/tools/platforms/AIRPlatform.hx
@@ -221,6 +221,12 @@ class AIRPlatform extends FlashPlatform {
 		context.OUTPUT_DIR = targetDirectory;
 		context.AIR_SDK_VERSION = project.config.getString ("air.sdk-version", "25.0");
 		
+		if (project.language.supported.length > 0) {
+			context.SUPPORTED_LANGUAGES = project.language.supported.join(" ");
+		} else {
+			context.SUPPORTED_LANGUAGES = "";
+		}
+		
 		var buildNumber = Std.string (context.APP_BUILD_NUMBER);
 		
 		if (buildNumber.length <= 3) {
@@ -278,6 +284,7 @@ class AIRPlatform extends FlashPlatform {
 		}
 		
 		if (iconData.length > 0) context.icons = iconData;
+		context.language = project.language;
 
 		context.extensions = new Array<String>();
 

--- a/lime/tools/platforms/AndroidPlatform.hx
+++ b/lime/tools/platforms/AndroidPlatform.hx
@@ -181,6 +181,12 @@ class AndroidPlatform extends PlatformTarget {
 		context.CPP_DIR = targetDirectory + "/obj";
 		context.OUTPUT_DIR = targetDirectory;
 		
+		if (project.language.supported.length > 0) {
+			context.SUPPORTED_LANGUAGES = project.language.supported.join(", ");
+		} else {
+			context.SUPPORTED_LANGUAGES = "";
+		}
+		
 		var template = new Template (File.getContent (hxml));
 		
 		return template.execute (context) + "\n-D display";

--- a/lime/tools/platforms/IOSPlatform.hx
+++ b/lime/tools/platforms/IOSPlatform.hx
@@ -138,6 +138,15 @@ class IOSPlatform extends PlatformTarget {
 		context.OBJC_ARC = false;
 		context.KEY_STORE_IDENTITY = project.config.getString ("ios.identity");
 		
+		if (project.language.supported.length > 0) {
+			context.SUPPORTED_LANGUAGES = [];
+			for (lang in project.language.supported) {
+				context.SUPPORTED_LANGUAGES.push({ lang: lang });
+			}
+		} else {
+			context.SUPPORTED_LANGUAGES = null;
+		}
+		
 		if (project.config.exists ("ios.provisioning-profile")) {
 			
 			context.IOS_PROVISIONING_PROFILE = PathHelper.tryFullPath (project.config.getString ("ios.provisioning-profile"));

--- a/lime/tools/platforms/MacPlatform.hx
+++ b/lime/tools/platforms/MacPlatform.hx
@@ -227,6 +227,15 @@ class MacPlatform extends PlatformTarget {
 		context.CPP_DIR = targetDirectory + "/obj/";
 		context.BUILD_DIR = project.app.path + "/mac" + (is64 ? "64" : "");
 		
+		if (project.language.supported.length > 0) {
+			context.SUPPORTED_LANGUAGES = [];
+			for (lang in project.language.supported) {
+				context.SUPPORTED_LANGUAGES.push({ lang: lang });
+			}
+		} else {
+			context.SUPPORTED_LANGUAGES = null;
+		}
+		
 		return context;
 		
 	}

--- a/lime/tools/platforms/TVOSPlatform.hx
+++ b/lime/tools/platforms/TVOSPlatform.hx
@@ -126,6 +126,15 @@ class TVOSPlatform extends PlatformTarget {
 		context.OBJC_ARC = false;
 		context.KEY_STORE_IDENTITY = project.config.getString ("tvos.identity");
 		
+		if (project.language.supported.length > 0) {
+			context.SUPPORTED_LANGUAGES = [];
+			for (lang in project.language.supported) {
+				context.SUPPORTED_LANGUAGES.push({ lang: lang });
+			}
+		} else {
+			context.SUPPORTED_LANGUAGES = null;
+		}
+		
 		context.linkedLibraries = [];
 		
 		for (dependency in project.dependencies) {

--- a/templates/air/template/application.xml
+++ b/templates/air/template/application.xml
@@ -36,6 +36,7 @@
 	::if (icons != null)::<icon>::foreach icons::
 		<image::size::x::size::>::path::</image::size::x::size::>::end:: 
 	</icon>::end::
+	::if (SUPPORTED_LANGUAGES != "")::<supportedLanguages>::SUPPORTED_LANGUAGES::</supportedLanguages>::end::
 	<customUpdateUI>false</customUpdateUI>
 	<allowBrowserInvocation>false</allowBrowserInvocation>
 	<!-- <fileTypes>

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -15,6 +15,9 @@ android {
 		targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
 		versionCode Integer.parseInt(project.VERSION_CODE)
 		versionName project.VERSION_NAME
+        ::if (SUPPORTED_LANGUAGES != "")::
+        resConfigs ::SUPPORTED_LANGUAGES::
+        ::end::
 	}
 	
 	::if KEY_STORE::

--- a/templates/ios/template/{{app.file}}/{{app.file}}-Info.plist
+++ b/templates/ios/template/{{app.file}}/{{app.file}}-Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	::if (SUPPORTED_LANGUAGES != null)::
+	<key>CFBundleLocalizations</key>
+	<array>
+		::foreach SUPPORTED_LANGUAGES::<string>::lang::</string>::end::
+	</array>
+	::end::
 	<key>CFBundleDisplayName</key>
 	<string>::APP_TITLE::</string>
 	<key>CFBundleExecutable</key>

--- a/templates/mac/Info.plist
+++ b/templates/mac/Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	::if (SUPPORTED_LANGUAGES != null)::
+	<key>CFBundleLocalizations</key>
+	<array>
+		::foreach SUPPORTED_LANGUAGES::<string>::lang::</string>::end::
+	</array>
+	::end::
 	<key>CFBundleExecutable</key>
 	<string>::APP_FILE::</string>
 	<key>CFBundleIconFile</key>

--- a/templates/tvos/PROJ/PROJ-Info.plist
+++ b/templates/tvos/PROJ/PROJ-Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	::if (SUPPORTED_LANGUAGES != null)::
+	<key>CFBundleLocalizations</key>
+	<array>
+		::foreach SUPPORTED_LANGUAGES::<string>::lang::</string>::end::
+	</array>
+	::end::
 	<key>CFBundleDisplayName</key>
 	<string>::APP_TITLE::</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Added supported language tag for air, mac, tvos, ios, android. This prop lets to control what languages will be bundled in apps. 
Did testing on iOS, air, had issues to set up android, will try to test later.

Tried to align as much as possible with code style, but as it's my first PR here, please comment if something is wrong.

To use this feature language tag is used inside the `project.xml` for example like this `<language supported="en de" />`