### PR TITLE
Invert defines checked for KHR_debug in OpenGLBindings

### DIFF
--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -40,7 +40,7 @@ namespace lime {
 	void* OpenGLBindings::eglHandle = 0;
 	#endif
 	
-	#if !defined(ANDROID) && !defined(IPHONE) && !defined (RASPBERRYPI) && !defined (EMSCRIPTEN)
+	#if defined(HX_LINUX) || defined(HX_WINDOWS) || defined(HX_MACOS)
 	typedef void (APIENTRY * GL_DebugMessageCallback_Func)(GLDEBUGPROC, const void *);
 	GL_DebugMessageCallback_Func glDebugMessageCallback_ptr = 0;
 	#endif
@@ -191,7 +191,7 @@ namespace lime {
 	}
 	
 	
-	#if !defined(ANDROID) && !defined(IPHONE) && !defined (RASPBERRYPI) && !defined (EMSCRIPTEN)
+	#if defined(HX_LINUX) || defined(HX_WINDOWS) || defined(HX_MACOS)
 	void APIENTRY gl_debug_callback (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, GLvoid *userParam) {
 		
 		puts (message);
@@ -1160,7 +1160,7 @@ namespace lime {
 	
 	value lime_gl_get_extension (HxString name) {
 		
-		#if !defined(ANDROID) && !defined(IPHONE) && !defined (RASPBERRYPI) && !defined (EMSCRIPTEN)
+		#if defined(HX_LINUX) || defined(HX_WINDOWS) || defined(HX_MACOS)
 		if (!glDebugMessageCallback_ptr && strcmp (name.__s, "KHR_debug") == 0) {
 			
 			glDebugMessageCallback_ptr = (GL_DebugMessageCallback_Func)SDL_GL_GetProcAddress ("glDebugMessageCallback");


### PR DESCRIPTION
It seems there's less platforms that _don't_ support it than platforms that do (i.e. only desktop).