### PR TITLE
Guard against getEnv("HOME") returning null on some platforms

### DIFF
--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -136,7 +136,15 @@ namespace lime {
 				
 				#elif !defined (ANDROID)
 				
-				std::string path = std::string (getenv ("HOME")) + std::string ("/Desktop");
+				char const* home = getenv ("HOME");
+
+				if (home == NULL) {
+
+					return 0;
+
+				}
+
+				std::string path = std::string (home) + std::string ("/Desktop");
 				std::wstring* result = new std::wstring (path.begin (), path.end ());
 				return result;
 				
@@ -172,7 +180,15 @@ namespace lime {
 				
 				#else
 				
-				std::string path = std::string (getenv ("HOME")) + std::string ("/Documents");
+				char const* home = getenv ("HOME");
+
+				if (home == NULL) {
+
+					return 0;
+
+				}
+
+				std::string path = std::string (home) + std::string ("/Documents");
 				std::wstring* result = new std::wstring (path.begin (), path.end ());
 				return result;
 				
@@ -248,7 +264,15 @@ namespace lime {
 				
 				#else
 				
-				std::string path = getenv ("HOME");
+				char const* home = getenv ("HOME");
+
+				if (home == NULL) {
+
+					return 0;
+
+				}
+
+				std::string path = std::string (home);
 				std::wstring* result = new std::wstring (path.begin (), path.end ());
 				return result;
 				


### PR DESCRIPTION
Attempting to convert a null pointer to std::string seems to be undefined behavior, see https://stackoverflow.com/questions/5867242/how-to-put-the-contents-of-getenv-into-a-string. In my case it was causing a crash.