### PR TITLE
Don't do any magical implicit to-canvas conversion in the Image.src getter.

### DIFF
--- a/lime/graphics/Image.hx
+++ b/lime/graphics/Image.hx
@@ -1828,14 +1828,6 @@ class Image {
 	
 	private function get_src ():Dynamic {
 		
-		#if (js && html5)
-		if (buffer.__srcCanvas == null) {
-			
-			ImageCanvasUtil.convertToCanvas (this);
-			
-		}
-		#end
-		
 		return buffer.src;
 		
 	}


### PR DESCRIPTION
We want to access normal source value which can be HTML Image element, also suitable for texture uploading.

If anyone needs a canvas, they can convert explicitly (as it's actually done already).