### PR TITLE
Update ImageDataUtil's resizeBuffer method so it clears source data

### DIFF
--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -1159,6 +1159,15 @@ class ImageDataUtil {
 		buffer.width = newWidth;
 		buffer.height = newHeight;
 		
+		#if (js && html5)
+		buffer.__srcImage = null;
+		buffer.__srcImageData = null;
+		buffer.__srcCanvas = null;
+		buffer.__srcContext = null;
+		#end
+		
+		image.dirty = true;
+		image.version++;
 	}
 	
 	


### PR DESCRIPTION
This modification helped me to reduce memory consumption on html5 target (especially with activated `openfl_power_of_two` haxedef).
I'm not sure if it's right to do so, and ask you to consider this change