### PR TITLE
Add adobe air custom simulator support

### DIFF
--- a/lime/tools/helpers/AIRHelper.hx
+++ b/lime/tools/helpers/AIRHelper.hx
@@ -149,44 +149,30 @@ class AIRHelper {
 		args = args.concat ([ targetPath + extension, applicationXML ]);
 		
 		if (targetPlatform == IOS && PlatformHelper.hostPlatform == Platform.MAC && project.targetFlags.exists ("simulator")) {
-			
-			args.push ("-platformsdk");
-			args.push (IOSHelper.getSDKDirectory (project));
-			
+			args.push("-platformsdk");
+			args.push(IOSHelper.getSDKDirectory(project));
 		}
 		
 		if (fileDirectory != null && fileDirectory != "") {
-			
-			args.push ("-C");
-			args.push (fileDirectory);
-			
+			args.push("-C");
+			args.push(fileDirectory);
 		}
-		
-		args = args.concat (files);
-
-		var extDirs:Array<String> = getExtDirs(project);
-
+		args = args.concat(files);
+		var extDirs: Array<String> = getExtDirs(project);
 		if (extDirs.length > 0) {
-
 			args.push("-extdir");
-
 			for (extDir in extDirs) {
-
 				args.push(extDir);
-
 			}
 		}
-		
 		if (targetPlatform == ANDROID) {
-			
-			Sys.putEnv ("AIR_NOANDROIDFLAIR", "true");
-			
+			Sys.putEnv("AIR_NOANDROIDFLAIR", "true");
 		}
-		
+		if (targetPlatform == IOS) {
+			Sys.putEnv("AIR_IOS_SIMULATOR_DEVICE", XCodeHelper.getSimulatorName(project.targetFlags));	
+		}
 		ProcessHelper.runCommand (workingDirectory, project.defines.get ("AIR_SDK") + "/bin/adt", args);
-		
 		return targetPath + extension;
-		
 	}
 
 
@@ -236,6 +222,7 @@ class AIRHelper {
 			
 			ProcessHelper.runCommand (workingDirectory, project.defines.get ("AIR_SDK") + "/bin/adt", [ "-uninstallApp" ].concat (args).concat ([ "-appid", project.meta.packageName ]), true, true);
 			ProcessHelper.runCommand (workingDirectory, project.defines.get ("AIR_SDK") + "/bin/adt", [ "-installApp" ].concat (args).concat ([ "-package", FileSystem.fullPath (workingDirectory) + "/" + (rootDirectory != null ? rootDirectory + "/" : "") + project.app.file + ".ipa" ]));
+			ProcessHelper.runCommand (workingDirectory, project.defines.get ("AIR_SDK") + "/bin/adt", [ "-launchApp" ].concat (args).concat ([ "-appid", project.meta.packageName ]), true, true);
 			
 			if (project.targetFlags.exists ("simulator")) {
 

--- a/lime/tools/helpers/XCodeHelper.hx
+++ b/lime/tools/helpers/XCodeHelper.hx
@@ -1,0 +1,86 @@
+package lime.tools.helpers;
+
+import lime.tools.helpers.ProcessHelper;
+
+private class SimulatorInfo {
+	public var id: String;
+	public var name: String;
+	public function new(id: String, name: String) {
+		this.id = id;
+		this.name = name;
+	}
+}
+class XCodeHelper {
+	static inline var DefaultIPadSimulator = "ipad-air";
+	static inline var DefaultIPhoneSimulator = "iphone-6";
+	public function new () {}
+	public static function getSimulatorId(targetFlags: Map<String, String>): String {
+		return getSelectedSimulator(targetFlags).id;
+	}
+	public static function getSimulatorName(targetFlags: Map<String, String>): String {
+		return getSelectedSimulator(targetFlags).name;
+	}
+	static function getSelectedSimulator(targetFlags: Map<String, String>): SimulatorInfo {
+		var output = getSimulators();
+		var lines = output.split("\n");
+		var foundSection = false;
+		var device = "";
+		var deviceID = "";
+		var deviceName = "";
+		var devices = new Map<String, SimulatorInfo> ();
+		var currentDevice: Null<SimulatorInfo> = null;
+		
+		for (line in lines) {
+			if (StringTools.startsWith (line, "--")) {
+				if (line.indexOf("iOS") > -1) {
+					foundSection = true;
+				} else if (foundSection) {
+					break;
+				}
+			} else if (foundSection) {
+				deviceName = extractSimulatorFullName(StringTools.trim(line));
+				deviceID = extractSimulatorId(StringTools.trim(line));
+				device = extractSimulatorFlagName(StringTools.trim(line));
+				devices.set(device, new SimulatorInfo(deviceID, deviceName));
+				if (targetFlags.exists(device)) {
+					currentDevice = devices.get(device);
+					break;	
+				}
+			}
+		}
+		if (currentDevice == null) {
+			if (targetFlags.exists("ipad")) {
+				currentDevice = devices.get(DefaultIPadSimulator);
+			} else {
+				currentDevice = devices.get(DefaultIPhoneSimulator);
+			}
+		}
+		return currentDevice;
+	}
+	static function getSimulators(): String {
+		return ProcessHelper.runProcess("", "xcrun", ["simctl", "list", "devices"]);
+	}
+	static function extractSimulatorId(line: String): String {
+		var id = line.substring(line.indexOf("(") + 1, line.indexOf(")"));
+		if (id.indexOf("inch") > -1 || id.indexOf("generation") > -1) {
+			var startIndex = line.indexOf(")") + 2;
+			id = line.substring(line.indexOf("(", startIndex) + 1, line.indexOf(")", startIndex));
+		}
+		return id;
+	}
+	static function extractSimulatorFullName(line: String): String {
+		var name = "";
+		if (line.indexOf("inch") > -1 || line.indexOf("generation") > -1) {
+			name = line.substring(0, line.indexOf(")") + 1);
+		} else {
+			name = line.substring(0, line.indexOf("(") - 1);
+		}
+		return name;
+	}
+	static function extractSimulatorFlagName(line: String): String {
+		var device = line.substring(0, line.indexOf("(") - 1);
+		device = device.toLowerCase();
+		device = StringTools.replace(device, " ", "-");
+		return device;
+	}
+}

--- a/lime/tools/platforms/AIRPlatform.hx
+++ b/lime/tools/platforms/AIRPlatform.hx
@@ -220,6 +220,7 @@ class AIRPlatform extends FlashPlatform {
 		var context = generateContext ();
 		context.OUTPUT_DIR = targetDirectory;
 		context.AIR_SDK_VERSION = project.config.getString ("air.sdk-version", "28.0");
+		context.TARGET_DEVICES = switch (project.config.getString ("ios.device", "universal")) { case "iphone": [{ device: 1}]; case "ipad": [{ device: 2}]; default: [{ device: 1}, { device: 2}];  }
 		
 		var buildNumber = Std.string (context.APP_BUILD_NUMBER);
 		

--- a/templates/air/template/application.xml
+++ b/templates/air/template/application.xml
@@ -65,6 +65,16 @@
 		</manifestAdditions> 
 	</android>
 	<iPhone>
+		<InfoAdditions>
+			<![CDATA[
+::if (TARGET_DEVICES != null)::			
+<key>UIDeviceFamily</key>
+<array>::foreach TARGET_DEVICES::
+	<string>::device::</string>::end::
+</array>
+::end::
+]]>
+		</InfoAdditions>
 		<requestedDisplayResolution>::if WIN_ALLOW_HIGH_DPI::high::else::standard::end::</requestedDisplayResolution>
 	</iPhone>
 	::if (extensions != null)::<extensions>::foreach extensions::


### PR DESCRIPTION
Improved Adobe air target:
- auto launch adobe air app on iOS simulator
- add universal device support for adobe air
- add adobe air custom simulator support

Same logic as for native iOS builds is reused (ios.device for device support and -simulator-name as argument).
Tested on adobe air target, will check if native works as before as soon as will fix [errors](http://community.openfl.org/t/mobile-build-fails-with-dev-version-of-lime/10687) on the native build.

Right now moved sim check code as-is to separate file so it can be reused, but in future maybe could be refactored a bit as well and covered with unit tests.

More tests and feedbacks are welcome :).