### PR TITLE
Add wifi debug for mobile air

### DIFF
--- a/lime/tools/helpers/AIRHelper.hx
+++ b/lime/tools/helpers/AIRHelper.hx
@@ -129,6 +129,12 @@ class AIRHelper {
 			
 			args.push ("-target");
 			args.push (airTarget);
+			if (project.debug) {
+				args.push("-connect");
+				if (project.config.exists("air.connect")) {
+					args.push(project.config.getString("air.connect"));
+				}
+			}
 			args = args.concat (signingOptions);
 			
 		}


### PR DESCRIPTION
Added [wifi](https://help.adobe.com/en_US/air/build/WSd106d9f573d8da23-dcd13bd12a7d944d0b-7ffe.html) debugger for adobe air mobile platforms. It will connect automatically in debug build so running fdb will be needed otherwise it will wait for connect. By default it will connect to current ip but if custom ip is needed it can be passed through `<config:air connect="127.0.0.1" />` 

As usual feedback, comments and wishes are welcome :)