### PR TITLE
Add initial support for iOS splash screens in air target

### DIFF
--- a/tools/platforms/AIRPlatform.hx
+++ b/tools/platforms/AIRPlatform.hx
@@ -24,6 +24,7 @@ class AIRPlatform extends FlashPlatform {
 	
 	
 	private var iconData:Array<Dynamic>;
+	private var splashScreenData: Array<String>;
 	private var targetPlatform:Platform;
 	private var targetPlatformType:PlatformType;
 	
@@ -93,6 +94,12 @@ class AIRPlatform extends FlashPlatform {
 				
 				files.push (icon.path);
 				
+			}
+			
+			if (splashScreenData != null) {
+				for (splashScreen in splashScreenData) {
+					files.push(splashScreen);
+				}
 			}
 			
 			var targetPath = switch (targetPlatform) {
@@ -342,6 +349,16 @@ class AIRPlatform extends FlashPlatform {
 				
 			}
 			
+		}
+		if (project.splashScreens != null) {
+			splashScreenData = [];
+			for (splash in project.splashScreens) {
+				var splashPath = PathHelper.standardize(splash.path);
+				var splashName = splashPath.substr(splashPath.lastIndexOf("/") + 1);
+				var path = PathHelper.combine(destination, splashName);
+				splashScreenData.push(splashName);
+				FileHelper.copyFile(splash.path, path, context);
+			}
 		}
 		
 	}


### PR DESCRIPTION
Added initial support for splash screen on air target for iOS devices.

To add splash screen it should be registered in project.xml like for the native target.

<splashScreen path="./splash/Default.png" if="ios" />
<splashScreen path="./splash/Default@2x.png" if="ios" />
....

A full list of needed splash screens is [here](http://blogs.adobe.com/airodynamics/2015/03/09/launch-images-on-ios-with-adobe-air/)


In future, some automatization could be added to validate iPhone / iPad / universal app splash screens and print warning if some are missing.