### PR TITLE
Fix Unicode file path support on Windows

### DIFF
--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -7,6 +7,9 @@
 #endif
 
 
+#include <locale>
+#include <codecvt>
+#include <string>
 #include <hx/CFFIPrime.h>
 #include <app/Application.h>
 #include <app/ApplicationEvent.h>
@@ -116,7 +119,8 @@ namespace lime {
 		if (val.c_str ()) {
 			
 			std::string _val = std::string (val.c_str ());
-			return new std::wstring (_val.begin (), _val.end ());
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			return new std::wstring (converter.from_bytes(_val));
 			
 		} else {
 			

--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -32,6 +32,8 @@
 #endif
 
 #include <SDL.h>
+#include <locale>
+#include <codecvt>
 #include <string>
 
 
@@ -96,7 +98,8 @@ namespace lime {
 			case APPLICATION: {
 				
 				char* path = SDL_GetBasePath ();
-				std::wstring* result = new std::wstring (path, path + strlen (path));
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				SDL_free (path);
 				return result;
 				break;
@@ -106,7 +109,8 @@ namespace lime {
 			case APPLICATION_STORAGE: {
 				
 				char* path = SDL_GetPrefPath (company, title);
-				std::wstring* result = new std::wstring (path, path + strlen (path));
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				SDL_free (path);
 				return result;
 				break;
@@ -127,7 +131,8 @@ namespace lime {
 				SHGetFolderPath (NULL, CSIDL_DESKTOPDIRECTORY, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
 				std::string path = std::string (folderPath);
-				std::wstring* result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				return result;
 				
 				#elif defined (IPHONE)
@@ -167,7 +172,8 @@ namespace lime {
 				SHGetFolderPath (NULL, CSIDL_MYDOCUMENTS, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
 				std::string path = std::string (folderPath);
-				std::wstring* result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				return result;
 				
 				#elif defined (IPHONE)
@@ -189,7 +195,8 @@ namespace lime {
 				}
 
 				std::string path = std::string (home) + std::string ("/Documents");
-				std::wstring* result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				return result;
 				
 				#endif
@@ -209,7 +216,8 @@ namespace lime {
 				SHGetFolderPath (NULL, CSIDL_FONTS, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
 				std::string path = std::string (folderPath);
-				std::wstring* result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				return result;
 				
 				#elif defined (HX_MACOS)
@@ -251,7 +259,8 @@ namespace lime {
 				SHGetFolderPath (NULL, CSIDL_PROFILE, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
 				std::string path = std::string (folderPath);
-				std::wstring* result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				return result;
 				
 				#elif defined (IPHONE)
@@ -273,7 +282,8 @@ namespace lime {
 				}
 
 				std::string path = std::string (home);
-				std::wstring* result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				std::wstring* result = new std::wstring (converter.from_bytes(path));
 				return result;
 				
 				#endif
@@ -617,7 +627,14 @@ namespace lime {
 		
 		#else
 		
-		FILE* result = ::fopen (filename, mode);
+		std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+		std::wstring* wfilename = new std::wstring (converter.from_bytes(filename));
+		std::wstring* wmode = new std::wstring (converter.from_bytes(mode));
+		
+		FILE* result = ::_wfopen (wfilename->c_str(), wmode->c_str());
+		
+		delete wfilename;
+		delete wmode;
 		
 		if (result) {
 			


### PR DESCRIPTION
Change SDLSystem::fopen() on Windows to interpret filename as a UTF-8 string and call ::_wfopen() instead of ::fopen(). Fix conversions between UTF-8 strings and UTF-16 wstrings. These changes allow Lime to open files (e.g. assets and .sol files) from paths which use extended Unicode characters.

This commit resolves issue https://github.com/openfl/lime/issues/1083 and most of https://github.com/openfl/lime/issues/1016.

Remaining issue: we depend on FreeType to load font assets. FreeType appears to just use fopen() (in FT_Stream_Open()), so Lime's loading of font assets from Unicode paths is probably still broken on Windows? I don't use any font assets, so I haven't tested it yet. If it's still an issue we could fix FreeType, or alternatively open the file in Lime and call FT_New_Memory_Face() instead of FT_New_Face().