### PR TITLE
Fix Unicode file path support on Windows

### DIFF
--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -48,6 +48,9 @@
 #include <utils/compress/Zlib.h>
 #include <vm/NekoVM.h>
 
+#include <locale>
+#include <codecvt>
+
 DEFINE_KIND (k_finalizer);
 
 
@@ -131,7 +134,8 @@ namespace lime {
 		if (val.c_str ()) {
 			
 			std::string _val = std::string (val.c_str ());
-			return new std::wstring (_val.begin (), _val.end ());
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			return new std::wstring (converter.from_bytes(_val));
 			
 		} else {
 			
@@ -147,7 +151,8 @@ namespace lime {
 		if (val) {
 			
 			std::string _val = std::string (hl_to_utf8 (val->bytes));
-			return new std::wstring (_val.begin (), _val.end ());
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			return new std::wstring (converter.from_bytes(_val));
 			
 		} else {
 			

--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -32,6 +32,8 @@
 #endif
 
 #include <SDL.h>
+#include <locale>
+#include <codecvt>
 #include <string>
 
 
@@ -99,7 +101,8 @@ namespace lime {
 			case APPLICATION: {
 				
 				char* path = SDL_GetBasePath ();
-				result = new std::wstring (path, path + strlen (path));
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				result = new std::wstring (converter.from_bytes(path));
 				SDL_free (path);
 				break;
 				
@@ -108,7 +111,8 @@ namespace lime {
 			case APPLICATION_STORAGE: {
 				
 				char* path = SDL_GetPrefPath (company, title);
-				result = new std::wstring (path, path + strlen (path));
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				result = new std::wstring (converter.from_bytes(path));
 				SDL_free (path);
 				break;
 				
@@ -126,8 +130,8 @@ namespace lime {
 				char folderPath[MAX_PATH] = "";
 				SHGetFolderPath (NULL, CSIDL_DESKTOPDIRECTORY, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
-				std::string path = std::string (folderPath);
-				result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				result = new std::wstring (converter.from_bytes(folderPath));
 				
 				#elif defined (IPHONE)
 				
@@ -163,8 +167,8 @@ namespace lime {
 				char folderPath[MAX_PATH] = "";
 				SHGetFolderPath (NULL, CSIDL_MYDOCUMENTS, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
-				std::string path = std::string (folderPath);
-				result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				result = new std::wstring (converter.from_bytes(folderPath));
 				
 				#elif defined (IPHONE)
 				
@@ -181,7 +185,8 @@ namespace lime {
 				if (home != NULL) {
 					
 					std::string path = std::string (home) + std::string ("/Documents");
-					result = new std::wstring (path.begin (), path.end ());
+					std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+					result = new std::wstring (converter.from_bytes(path.c_str()));
 					
 				}
 				
@@ -201,8 +206,8 @@ namespace lime {
 				char folderPath[MAX_PATH] = "";
 				SHGetFolderPath (NULL, CSIDL_FONTS, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
-				std::string path = std::string (folderPath);
-				result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				result = new std::wstring (converter.from_bytes(folderPath));
 				
 				#elif defined (HX_MACOS)
 				
@@ -241,8 +246,8 @@ namespace lime {
 				char folderPath[MAX_PATH] = "";
 				SHGetFolderPath (NULL, CSIDL_PROFILE, NULL, SHGFP_TYPE_CURRENT, folderPath);
 				WIN_StringToUTF8 (folderPath);
-				std::string path = std::string (folderPath);
-				result = new std::wstring (path.begin (), path.end ());
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				result = new std::wstring (converter.from_bytes(folderPath));
 				
 				#elif defined (IPHONE)
 				
@@ -259,7 +264,8 @@ namespace lime {
 				if (home != NULL) {
 					
 					std::string path = std::string (home);
-					result = new std::wstring (path.begin (), path.end ());
+					std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+					result = new std::wstring (converter.from_bytes(path.c_str()));
 					
 				}
 				
@@ -625,10 +631,16 @@ namespace lime {
 		#else
 		
 		FILE* result;
+		std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+		std::wstring* wfilename = new std::wstring (converter.from_bytes(filename));
+		std::wstring* wmode = new std::wstring (converter.from_bytes(mode));
 		
 		System::GCEnterBlocking ();
-		result = ::fopen (filename, mode);
+		result = ::_wfopen (wfilename->c_str(), wmode->c_str());
 		System::GCExitBlocking ();
+		
+		delete wfilename;
+		delete wmode;
 		
 		if (result) {
 			


### PR DESCRIPTION
Rewritten https://github.com/openfl/lime/pull/1207 against latest commit in lime:develop.

Change SDLSystem::fopen() on Windows to interpret filename as a UTF-8 string and call ::_wfopen() instead of ::fopen(). Fix conversions between UTF-8 strings and UTF-16 wstrings. These changes allow Lime to open files (e.g. assets and .sol files) from paths which use extended Unicode characters, e.g. user folders where the Windows username includes accents.

This commit resolves issues #1083 and #1016.

I suspect the FT_New_Face() code path in src/text/Font.cpp may still have problems, as it relies on FreeType to load the file, and FreeType appears to just use fopen() (in FT_Stream_Open()). However, I've tried the PiratePig sample and it seems to load its font asset just fine - so it's presumably using the FT_New_Memory_Face() code path to load assets.