### PR TITLE
Fix Windows and iOS compile CFFI issues

### DIFF
--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -675,7 +675,7 @@ class System {
 
 		if (__deviceModel == null) {
 
-			#if (windows || ios || tvos)
+			#if (lime_cffi && !macro && (windows || ios || tvos))
 			#if hl
 			__deviceModel = @:privateAccess String.fromUTF8 (NativeCFFI.lime_system_get_device_model ());
 			#else
@@ -710,7 +710,7 @@ class System {
 
 		if (__deviceVendor == null) {
 
-			#if (windows && !html5)
+			#if (lime_cffi && !macro && windows && !html5)
 			#if hl
 			__deviceVendor = @:privateAccess String.fromUTF8 (NativeCFFI.lime_system_get_device_vendor ());
 			#else
@@ -811,7 +811,7 @@ class System {
 
 		if (__platformLabel == null) {
 
-			#if (windows && !html5)
+			#if (lime_cffi && !macro && windows && !html5)
 			#if hl
 			var label:String = @:privateAccess String.fromUTF8 (NativeCFFI.lime_system_get_platform_label ());
 			#else
@@ -879,7 +879,7 @@ class System {
 
 		if (__platformVersion == null) {
 
-			#if (windows && !html5)
+			#if (lime_cffi && !macro && windows && !html5)
 			#if hl
 			__platformVersion = @:privateAccess String.fromUTF8 (NativeCFFI.lime_system_get_platform_version ());
 			#else
@@ -889,7 +889,7 @@ class System {
 			var release = JNI.createStaticField ("android/os/Build$VERSION", "RELEASE", "Ljava/lang/String;").get ();
 			var api = JNI.createStaticField ("android/os/Build$VERSION", "SDK_INT", "I").get ();
 			if (release != null && api != null) __platformVersion = release + " (API " + api + ")";
-			#elseif (ios || tvos)
+			#elseif (lime_cffi && !macro && (ios || tvos))
 			__platformVersion = NativeCFFI.lime_system_get_platform_version ();
 			#elseif mac
 			__platformVersion = __runProcess ("sw_vers", [ "-productVersion" ]);


### PR DESCRIPTION
With newest Lime (6.4.0) we were getting some build errors on Windows and iOS. It's probably due to some library that called a Lime system function in a macro when it shouldn't, possibly via OpenFL. Nonetheless Lime can protect against this. I believe this PR will resolve the issues.

Example errors:
```
  - Running command: haxe Export/windows/cpp/final/haxe/final.hxml -D no_console
 C:/cygwin64/opt/haxe/lib/lime/6,4,0/lime/system/System.hx:713: characters 19-58 : Class<lime._backend.native.NativeCFFI> has no field lime_system_get_device_model
 C:/cygwin64/opt/haxe/lib/lime/6,4,0/lime/system/System.hx:744: characters 20-60 : Class<lime._backend.native.NativeCFFI> has no field lime_system_get_device_vendor
 C:/cygwin64/opt/haxe/lib/lime/6,4,0/lime/system/System.hx:841: characters 22-63 : Class<lime._backend.native.NativeCFFI> has no field lime_system_get_platform_label
 C:/cygwin64/opt/haxe/lib/lime/6,4,0/lime/system/System.hx:905: characters 23-66 : Class<lime._backend.native.NativeCFFI> has no field lime_system_get_platform_version
```

Seems to be related to:

- http://community.openfl.org/t/cffi-errors-with-macro/10563
- http://community.openfl.org/t/error-float-of-string-windows-target/10189/11