### PR TITLE
Fix CFFIMacro for latest Haxe dev

### DIFF
--- a/src/lime/_internal/macros/CFFIMacro.hx
+++ b/src/lime/_internal/macros/CFFIMacro.hx
@@ -79,6 +79,10 @@ class CFFIMacro {
 
 										expr += "return false";
 
+									case "Void":
+
+										expr += "return";
+
 									default:
 
 										expr += "return null";


### PR DESCRIPTION
`return null` is no longer allowed for Void-returns: HaxeFoundation/haxe#7198

This was causing issues when building a completion cache with the HL target:

    lime/src/lime/_internal/backend/native/NativeCFFI.hx:3435: characters 9-82 : Cannot return `null` from Void-function