### PR TITLE
Html5 mp3 detection update

### DIFF
--- a/src/lime/media/AudioBuffer.hx
+++ b/src/lime/media/AudioBuffer.hx
@@ -433,7 +433,7 @@ class AudioBuffer {
 
 				switch ([bytes.get(0), bytes.get(1), bytes.get(2)]) {
 
-					case [73, 68, 51] | [255, 251, _] | [255, 250, _]: return "audio/mp3";
+					case [73, 68, 51] | [255, 251, _] | [255, 250, _] | [255, 243, _]: return "audio/mp3";
 					default:
 
 				}


### PR DESCRIPTION
Looks like MP3 could have FF FX bits (https://www.garykessler.net/library/file_sigs.html),
but in my sample for mp3 22k second bit was 243 and after change normally plays in Firefox and Chrome.
Need test and maybe update algo to take into account all second bits started with F