### PR TITLE
window title can be set as an attribute in project.xml

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -134,7 +134,7 @@ class HXProject extends Script {
 
 		defaultMeta = { title: "MyApplication", description: "", packageName: "com.example.myapp", version: "1.0.0", company: "", companyUrl: "", buildNumber: null, companyId: "" }
 		defaultApp = { main: "Main", file: "MyApplication", path: "bin", preloader: "", swfVersion: 17, url: "", init: null }
-		defaultWindow = { width: 800, height: 600, parameters: "{}", background: 0xFFFFFF, fps: 30, hardware: true, display: 0, resizable: true, borderless: false, orientation: Orientation.AUTO, vsync: false, fullscreen: false, allowHighDPI: true, alwaysOnTop: false, antialiasing: 0, allowShaders: true, requireShaders: false, depthBuffer: true, stencilBuffer: true, colorDepth: 32, maximized: false, minimized: false, hidden: false }
+		defaultWindow = { width: 800, height: 600, parameters: "{}", background: 0xFFFFFF, fps: 30, hardware: true, display: 0, resizable: true, borderless: false, orientation: Orientation.AUTO, vsync: false, fullscreen: false, allowHighDPI: true, alwaysOnTop: false, antialiasing: 0, allowShaders: true, requireShaders: false, depthBuffer: true, stencilBuffer: true, colorDepth: 32, maximized: false, minimized: false, hidden: false, title:"" }
 
 		platformType = PlatformType.DESKTOP;
 		architectures = [];
@@ -1189,7 +1189,7 @@ class HXProject extends Script {
 
 			}
 
-			windows[i].title = meta.title;
+			if(windows[i].title=="") windows[i].title = meta.title;
 
 		}
 

--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -2212,7 +2212,7 @@ class ProjectXMLParser extends HXProject {
 
 					}
 
-				case "parameters":
+				case "parameters", "title":
 
 					if (Reflect.hasField (windows[id], name)) {
 


### PR DESCRIPTION
Allow a window title to be set as an attribute on a window element in project.xml
Defaults back to Meta.title when the attribute is not set.