### PR TITLE
HTML5 externs fix: void functions may return non-void

### DIFF
--- a/src/lime/media/HTML5AudioContext.hx
+++ b/src/lime/media/HTML5AudioContext.hx
@@ -378,7 +378,7 @@ class HTML5AudioContext {
 		#if (js && html5)
 		if (buffer.__srcAudio != null) {
 
-			return buffer.__srcAudio.load ();
+			buffer.__srcAudio.load ();
 
 		}
 		#end
@@ -391,7 +391,7 @@ class HTML5AudioContext {
 		#if (js && html5)
 		if (buffer.__srcAudio != null) {
 
-			return buffer.__srcAudio.pause ();
+			buffer.__srcAudio.pause ();
 
 		}
 		#end
@@ -404,7 +404,7 @@ class HTML5AudioContext {
 		#if (js && html5)
 		if (buffer.__srcAudio != null) {
 
-			return buffer.__srcAudio.play ();
+			buffer.__srcAudio.play ();
 
 		}
 		#end


### PR DESCRIPTION
A number of functions are annotated as `: Void` but return the result of call. In recent versions of the HTMLMediaElement specification `play()` [returns a promise](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#Return_value). To avoid errors when the externs are updated I've removed the `return`.

(See https://github.com/HaxeFoundation/haxe/pull/7354)