### PR TITLE
js.html.compat is being removed in haxe 4

### DIFF
--- a/src/haxe/io/Bytes.hx
+++ b/src/haxe/io/Bytes.hx
@@ -575,8 +575,10 @@ class Bytes {
 
 
 #if !nodejs
+#if (haxe_ver < 4.0)
 import js.html.compat.Uint8Array;
 import js.html.compat.DataView;
+#end
 #end
 
 #if !macro


### PR DESCRIPTION
Adds `#if (haxe_ver < 4.0)` around a reference to `js.html.compat`

See https://github.com/HaxeFoundation/haxe/issues/7091