### PR TITLE
Use Unifill.uLength() in UTF8String get_length()

### DIFF
--- a/src/lime/text/UTF8String.hx
+++ b/src/lime/text/UTF8String.hx
@@ -359,7 +359,7 @@ abstract UTF8String(String) from String to String {
 
 	@:noCompletion private function get_length ():Int {
 
-		return this == null ? 0 : Utf8.length (this);
+		return this == null ? 0 : Unifill.uLength (this);
 
 	}
 


### PR DESCRIPTION
If the String isn't a valid UTF8 string haxe.Utf8.length() will throw a cryptic "Invalid UTF8" error while Unifill.uLength() will return 0