### PR TITLE
calculate AssetsMacro.cacheVersion at compile time

### DIFF
--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -54,7 +54,7 @@ class AssetsMacro {
 
 	macro public static function cacheVersion () {
 
-		return macro Std.int (Math.random () * 1000000);
+		return macro $v{Std.int (Math.random () * 1000000)};
 
 	}
 


### PR DESCRIPTION
AssetsMacro.cacheVersion was changed in this commit.
https://github.com/openfl/lime/commit/aa4c4b6a05a31d0b70c409682e889b59c35cadc3

And now, it is calculated at run time.

However, I think compile time calculation is better than run time one, because of browser cache in html5.