### PR TITLE
add language-specific rules (for e.g. Turkish) to Utf8String casing

### DIFF
--- a/src/lime/text/UTF8String.hx
+++ b/src/lime/text/UTF8String.hx
@@ -209,22 +209,35 @@ abstract UTF8String(String) from String to String {
 		Returns a String where all characters of `this` String are lower case.
 
 		Affects the characters `A-Z`. Other characters remain unchanged.
+		
+		If `language` is specified, language-specific casing rules will be followed.
 	**/
-	public function toLowerCase ():String {
+	public function toLowerCase (language:Language=null):String {
 
+		if(language == null) language = STANDARD;
+		
 		#if sys
 
 		if (lowercaseMap == null) {
 
 			lowercaseMap = new Map<Int, Int> ();
-			Utf8Ext.fillUpperToLowerMap (uppercaseMap);
-
+			Utf8Ext.fillUpperToLowerMap (lowercaseMap);
+			
 		}
 
 		var r = new Utf8 ();
 
 		Utf8.iter (this, function (v) {
 
+			if(language != STANDARD)
+			{
+				var v2 = toLowerCaseLanguageFixes(v,language);
+				if(v2 != v)
+				{
+					r.addChar(v2);
+					return;
+				}
+			}
 			r.addChar (lowercaseMap.exists (v) ? lowercaseMap[v] : v);
 
 		});
@@ -239,6 +252,19 @@ abstract UTF8String(String) from String to String {
 
 	}
 
+	private static function toLowerCaseLanguageFixes(v:Int,language:Language):Int
+	{
+		return switch(language)
+		{
+			case TURKISH:
+				switch(v)
+				{
+					case 0xC4B0: 0x69; //İ-->i (large dotted İ to small i) //probably redundant and can be removed, presented here for logical symmtery for when genuine cases are needed
+					default: v;
+				}
+			default: v;
+		}
+	}
 
 	/**
 		Returns the String itself.
@@ -254,22 +280,35 @@ abstract UTF8String(String) from String to String {
 		Returns a String where all characters of `this` String are upper case.
 
 		Affects the characters `a-z`. Other characters remain unchanged.
+		
+		If `language` is specified, language-specific casing rules will be followed.
 	**/
-	public function toUpperCase ():String {
+	public function toUpperCase (language:Language=null):String {
 
+		if(language == null) language = STANDARD;
+	
 		#if sys
 
 		if (uppercaseMap == null) {
 
 			uppercaseMap = new Map<Int, Int> ();
 			Utf8Ext.fillLowerToUpperMap (uppercaseMap);
-
+		
 		}
 
 		var r = new Utf8 ();
 
 		Utf8.iter (this, function(v) {
 
+			if(language != STANDARD)
+			{
+				var v2 = toUpperCaseLanguageFixes(v,language);
+				if(v2 != v)
+				{
+					r.addChar(v2);
+					return;
+				}
+			}
 			r.addChar (uppercaseMap.exists (v) ? uppercaseMap[v] : v);
 
 		});
@@ -282,6 +321,20 @@ abstract UTF8String(String) from String to String {
 
 		#end
 
+	}
+	
+	private static function toUpperCaseLanguageFixes(v:Int,language:Language):Int
+	{
+		return switch(language)
+		{
+			case TURKISH:
+				switch(v)
+				{
+					case 0x69: 0xC4B0; //i-->İ (small i to large dotted İ)
+					default: v;
+				}
+			default: v;
+		}
 	}
 
 
@@ -748,4 +801,11 @@ for (i in 0...51) map[0x10CC0+i] = 0x10C80+i;
 for (i in 0...32) map[0x118C0+i] = 0x118A0+i;
 for (i in 0...34) map[0x1E922+i] = 0x1E900+i;
 }
+}
+
+enum Language
+{
+	STANDARD;	//any language that doesn't have surprising results with casing
+	TURKISH;	//turkish
+				//add more special case languages as necessary
 }

--- a/src/lime/text/UTF8String.hx
+++ b/src/lime/text/UTF8String.hx
@@ -4,6 +4,7 @@ package lime.text;
 import haxe.Utf8;
 import lime._internal.unifill.Unifill;
 import lime._internal.unifill.CodePoint;
+import lime.system.Locale;
 
 
 abstract UTF8String(String) from String to String {
@@ -123,7 +124,7 @@ abstract UTF8String(String) from String to String {
 
 		If `str` cannot be found, -1 is returned.
 	**/
-	public function lastIndexOf(str:String, ?startIndex:Int):Int {
+	public function lastIndexOf (str:String, ?startIndex:Int):Int {
 
 		return Unifill.uLastIndexOf (this, str, startIndex);
 
@@ -212,10 +213,8 @@ abstract UTF8String(String) from String to String {
 		
 		If `language` is specified, language-specific casing rules will be followed.
 	**/
-	public function toLowerCase (language:Language=null):String {
+	public function toLowerCase (locale:Locale = null):String {
 
-		if(language == null) language = STANDARD;
-		
 		#if sys
 
 		if (lowercaseMap == null) {
@@ -229,12 +228,12 @@ abstract UTF8String(String) from String to String {
 
 		Utf8.iter (this, function (v) {
 
-			if(language != STANDARD)
+			if (language != null)
 			{
-				var v2 = toLowerCaseLanguageFixes(v,language);
-				if(v2 != v)
+				var v2 = toLowerCaseLocaleFixes (v, locale);
+				if (v2 != v)
 				{
-					r.addChar(v2);
+					r.addChar (v2);
 					return;
 				}
 			}
@@ -252,12 +251,13 @@ abstract UTF8String(String) from String to String {
 
 	}
 
-	private static function toLowerCaseLanguageFixes(v:Int,language:Language):Int
+
+	private static function toLowerCaseLocaleFixes (v:Int, locale:Locale):Int
 	{
-		return switch(language)
+		return switch (locale.language)
 		{
-			case TURKISH:
-				switch(v)
+			case "tr":
+				switch (v)
 				{
 					case 0xC4B0: 0x69; //İ-->i (large dotted İ to small i) //probably redundant and can be removed, presented here for logical symmtery for when genuine cases are needed
 					default: v;
@@ -265,6 +265,7 @@ abstract UTF8String(String) from String to String {
 			default: v;
 		}
 	}
+
 
 	/**
 		Returns the String itself.
@@ -283,10 +284,8 @@ abstract UTF8String(String) from String to String {
 		
 		If `language` is specified, language-specific casing rules will be followed.
 	**/
-	public function toUpperCase (language:Language=null):String {
+	public function toUpperCase (locale:Locale = null):String {
 
-		if(language == null) language = STANDARD;
-	
 		#if sys
 
 		if (uppercaseMap == null) {
@@ -298,14 +297,14 @@ abstract UTF8String(String) from String to String {
 
 		var r = new Utf8 ();
 
-		Utf8.iter (this, function(v) {
+		Utf8.iter (this, function (v) {
 
-			if(language != STANDARD)
+			if (locale != null)
 			{
-				var v2 = toUpperCaseLanguageFixes(v,language);
-				if(v2 != v)
+				var v2 = toUpperCaseLocaleFixes (v, locale);
+				if (v2 != v)
 				{
-					r.addChar(v2);
+					r.addChar (v2);
 					return;
 				}
 			}
@@ -322,13 +321,14 @@ abstract UTF8String(String) from String to String {
 		#end
 
 	}
-	
-	private static function toUpperCaseLanguageFixes(v:Int,language:Language):Int
+
+
+	private static function toUpperCaseLocaleFixes (v:Int, locale:Locale):Int
 	{
-		return switch(language)
+		return switch (locale.language)
 		{
-			case TURKISH:
-				switch(v)
+			case "tr":
+				switch (v)
 				{
 					case 0x69: 0xC4B0; //i-->İ (small i to large dotted İ)
 					default: v;
@@ -801,11 +801,4 @@ for (i in 0...51) map[0x10CC0+i] = 0x10C80+i;
 for (i in 0...32) map[0x118C0+i] = 0x118A0+i;
 for (i in 0...34) map[0x1E922+i] = 0x1E900+i;
 }
-}
-
-enum Language
-{
-	STANDARD;	//any language that doesn't have surprising results with casing
-	TURKISH;	//turkish
-				//add more special case languages as necessary
 }

--- a/src/lime/text/UTF8String.hx
+++ b/src/lime/text/UTF8String.hx
@@ -228,7 +228,7 @@ abstract UTF8String(String) from String to String {
 
 		Utf8.iter (this, function (v) {
 
-			if (language != null)
+			if (locale != null)
 			{
 				var v2 = toLowerCaseLocaleFixes (v, locale);
 				if (v2 != v)


### PR DESCRIPTION
Turns out that having a map of upper to lower case unicode glyphs, even taking into account asymmetrical operations, isn't enough. A good example of this is Turkish.

Turkish uses what looks pretty much just like some letters from the Latin alphabet with a few variants with diacritics. 

https://unicode-table.com/en/alphabets/turkish/

And indeed, these are all just using the same glyphs as the various european alphabets do. Same exact unicode points. BUT, the rules for Turkish are subtly different.

Notably, Turkish has dotted and undotted i's, in both lower and upper case.

Capital I: https://unicode-table.com/en/0049/
Small dotless I: https://unicode-table.com/en/0131/

Capital dotted I: https://unicode-table.com/en/0130/
Small dotless I: https://unicode-table.com/en/0069/

The tricky bit is, that the "i" and "I" characters are shared with standard latin alphabets and it's impossible to tell from text alone whether the user wants the Turkish capitalization rules or not.

The only solution for this, is for the user to be able to tell the system which language rules they intend to use.

So this proposed change adds an optional parameter to the Utf8String toUpperCase() and toLowerCase() functions, which allows the user to specify the language. For now I'm just adding "TURKISH" and "STANDARD" (everything else), and Turkish technically only has the one case to take care of properly.

Technically you only need it going from lower case to upper case to make sure that a dotted lowercase i becomes a dotted capital I, because a dotless lowercase I is already mapped to a dotless capital I, and a dotted capital I is already mapped to a dotted lowercase I, but I put both cases in explicitly for Turkish since I figure there will be other language-specific gotchas in the future, and it helps to have the symmetrical structure already in place.
