### PR TITLE
Added 'suppress_devtools' compiler flag

### DIFF
--- a/templates/electron/haxe/ElectronSetup.hx
+++ b/templates/electron/haxe/ElectronSetup.hx
@@ -64,7 +64,7 @@ class ElectronSetup {
 				});
 
 				ElectronSetup.window.loadURL( 'file://' + js.Node.__dirname + '/index.html' );
-				#if debug
+				#if (debug && !suppress_devtools)
 					ElectronSetup.window.webContents.openDevTools();
 				#end
 			});

--- a/templates/electron/hxml/debug.hxml
+++ b/templates/electron/hxml/debug.hxml
@@ -6,6 +6,10 @@
 -lib electron
 -main ApplicationMain ::HAXE_FLAGS::
 
+-D html5
+-D html
+-debug
+
 --next
 -js ::OUTPUT_DIR::/bin/ElectronSetup.js
 -cp ::OUTPUT_DIR::/haxe

--- a/templates/electron/hxml/final.hxml
+++ b/templates/electron/hxml/final.hxml
@@ -6,6 +6,9 @@
 -lib electron
 -main ApplicationMain ::HAXE_FLAGS::
 
+-D html5
+-D html
+
 --next
 -js ::OUTPUT_DIR::/bin/ElectronSetup.js
 -cp ::OUTPUT_DIR::/haxe

--- a/templates/electron/hxml/release.hxml
+++ b/templates/electron/hxml/release.hxml
@@ -6,6 +6,9 @@
 -lib electron
 -main ApplicationMain ::HAXE_FLAGS::
 
+-D html5
+-D html
+
 --next
 -js ::OUTPUT_DIR::/bin/ElectronSetup.js
 -cp ::OUTPUT_DIR::/haxe


### PR DESCRIPTION
Added 'suppress_devtools' compiler flag to prevent auto-opening of dev tools when targeting Electron.