### PR TITLE
video and audio auto play

### DIFF
--- a/templates/electron/haxe/ElectronSetup.hx
+++ b/templates/electron/haxe/ElectronSetup.hx
@@ -46,6 +46,10 @@ class ElectronSetup {
 			if (height == 0) height = 600;
 			var frame:Bool = window.borderless == false;
 
+			var commandLine = Reflect.getProperty(electron.main.App, "commandLine");
+			var appendSwitch:haxe.Constraints.Function = Reflect.getProperty(commandLine, "appendSwitch");
+			appendSwitch('--autoplay-policy','no-user-gesture-required');
+			
 			electron.main.App.on( 'ready', function(e) {
 				var config:Dynamic = {
 					fullscreen: window.fullscreen,


### PR DESCRIPTION
--autoplay-policy, no-user-gesture-required flags to allow video and audio to play without user input within electron