### PR TITLE
Use electron.main.App.commandLine type

### DIFF
--- a/templates/electron/haxe/ElectronSetup.hx
+++ b/templates/electron/haxe/ElectronSetup.hx
@@ -7,7 +7,7 @@ class ElectronSetup {
 
 	static function main()
 	{
-		untyped (electron.main.App).commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
+		electron.main.App.commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
 
 		var windows:Array<OpenFLWindow> = [
 			::foreach windows::
@@ -46,9 +46,7 @@ class ElectronSetup {
 			if (height == 0) height = 600;
 			var frame:Bool = window.borderless == false;
 
-			var commandLine = Reflect.getProperty(electron.main.App, "commandLine");
-			var appendSwitch:haxe.Constraints.Function = Reflect.getProperty(commandLine, "appendSwitch");
-			appendSwitch('--autoplay-policy','no-user-gesture-required');
+			electron.main.App.commandLine.appendSwitch('--autoplay-policy','no-user-gesture-required');
 			
 			electron.main.App.on( 'ready', function(e) {
 				var config:Dynamic = {


### PR DESCRIPTION
`electron.main.App.commandLine` is now defined in electron externs, no need for untyped workaround anymore.