### PR TITLE
check mousedown cancelled for context menu disabling

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -469,7 +469,7 @@ class HTML5Window {
 
 	private function handleContextMenuEvent (event:MouseEvent):Void {
 
-		if (parent.onMouseUp.canceled && event.cancelable) {
+		if ((parent.onMouseUp.canceled || parent.onMouseDown.canceled) && event.cancelable) {
 
 			event.preventDefault ();
 


### PR DESCRIPTION
Checks whether the right click mouse up or down event was cancelled to prevent to context menu from showing up on html5. coincides with an [OpenFL PR](https://github.com/openfl/openfl/pull/2097) where down events are cancelled. 

It's possible we only need to check down events and the mouseup cancels mean nothing, but I left them in in case it's needed for other OS/browser context menus.