### PR TITLE
Change NPM package.json 'name' property to use 'packageName' instead of 'title' 

### DIFF
--- a/templates/electron/template/package.json
+++ b/templates/electron/template/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "::meta.title::",
+    "name": "::meta.packageName::",
     "version": "::meta.version::",
     "main": "ElectronSetup.js",
     "scripts": {


### PR DESCRIPTION
NPM package.json name property can't have non-URL safe characters, so it's more suited to using the 'packageName' than the 'title'.
This also helps when using tools like electron-packager, which use the package name as a folder name.

Spec:
https://docs.npmjs.com/files/package.json