### PR TITLE
Remove offset from AlphaView in CopyPixels 

### DIFF
--- a/project/src/graphics/utils/ImageDataUtil.cpp
+++ b/project/src/graphics/utils/ImageDataUtil.cpp
@@ -215,7 +215,6 @@ namespace lime {
 
 			Rectangle alphaRect = Rectangle (alphaPoint->x, alphaPoint->y, alphaImage->width, alphaImage->height);
 			ImageDataView alphaView = ImageDataView (alphaImage, &alphaRect);
-			alphaView.Offset (sourceView.x, sourceView.y);
 
 			destView.Clip (destPoint->x, destPoint->y, alphaView.width, alphaView.height);
 

--- a/src/lime/_internal/graphics/ImageDataUtil.hx
+++ b/src/lime/_internal/graphics/ImageDataUtil.hx
@@ -426,7 +426,6 @@ class ImageDataUtil {
 					var alphaPosition, alphaPixel:RGBA;
 
 					var alphaView = new ImageDataView (alphaImage, new Rectangle (alphaPoint.x, alphaPoint.y, alphaImage.width, alphaImage.height));
-					alphaView.offset (sourceView.x, sourceView.y);
 
 					destView.clip (Std.int (destPoint.x), Std.int (destPoint.y), alphaView.width, alphaView.height);
 


### PR DESCRIPTION
Fixes [this issue](https://github.com/openfl/openfl/issues/2127), which I erroneously opened as an openfl issue.

This fixes the issue on HTML and Neko targets. I am unable to test on C++ target, but I presume the issue occurred there, and that it fixes the issue there too.