### PR TITLE
fix support of android.gradle-plugin config value

### DIFF
--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -1983,6 +1983,10 @@ class ProjectXMLParser extends HXProject {
 
 									config.set ("android.gradle-version", value);
 
+								case "gradle-plugin":
+
+									config.set ("android.gradle-plugin", value);
+									
 								default:
 
 									name = formatAttributeName (attribute);


### PR DESCRIPTION
The ANDROID_GRADLE_PLUGIN config value is used in AndroidPlatform.hx, but was not read in ProjectXMLParser