### PR TITLE
Haptic support on HTML5

### DIFF
--- a/src/lime/ui/Haptic.hx
+++ b/src/lime/ui/Haptic.hx
@@ -41,6 +41,30 @@ class Haptic {
 
 		}
 
+		var pattern:Array<Int> = [];
+		if (period == 0) {
+			pattern = [duration];
+		}
+		else {
+			var periodMS:Int = Std.int(Math.ceil (period / 2));
+			var count:Int = Std.int(Math.ceil ((duration / period) * 2));
+			pattern = [0]; //w3c spec says to vibrate on even elements of the pattern and android waits on even elements. This line makes the Navigator.vibrate match android behavior. https://w3c.github.io/vibration/ vs https://developer.android.com/reference/android/os/Vibrator.html#vibrate(long[],%20int)
+			for (i in 0...count) {
+				pattern.push(periodMS);
+			}
+		}
+
+		try {
+			if (!js.Browser.navigator.vibrate(pattern)) {
+				Log.warn ("Navigator.vibrate() returned false.");
+			}
+
+		} catch (e:Dynamic) {
+
+			Log.warn ("Navigator.vibrate() threw an error (it might be Internet Explorer or Edge not supporting the feature)");
+
+		}
+
 		#elseif (lime_cffi && !macro)
 
 		NativeCFFI.lime_haptic_vibrate (period, duration);

--- a/src/lime/ui/Haptic.hx
+++ b/src/lime/ui/Haptic.hx
@@ -40,31 +40,43 @@ class Haptic {
 			Log.warn ("Haptic.vibrate is not available (the VIBRATE permission may be missing)");
 
 		}
-
-		var pattern:Array<Int> = [];
+		
+		#elseif (js && html5)
+		
+		var pattern = [];
+		
 		if (period == 0) {
-			pattern = [duration];
-		}
-		else {
-			var periodMS:Int = Std.int(Math.ceil (period / 2));
-			var count:Int = Std.int(Math.ceil ((duration / period) * 2));
+			
+			pattern = [ duration ];
+			
+		} else {
+			
+			var periodMS = Std.int (Math.ceil (period / 2));
+			var count = Std.int (Math.ceil ((duration / period) * 2));
 			pattern = [0]; //w3c spec says to vibrate on even elements of the pattern and android waits on even elements. This line makes the Navigator.vibrate match android behavior. https://w3c.github.io/vibration/ vs https://developer.android.com/reference/android/os/Vibrator.html#vibrate(long[],%20int)
+			
 			for (i in 0...count) {
-				pattern.push(periodMS);
+				
+				pattern.push (periodMS);
+				
 			}
+			
 		}
-
+		
 		try {
-			if (!js.Browser.navigator.vibrate(pattern)) {
-				Log.warn ("Navigator.vibrate() returned false.");
+			
+			if (!js.Browser.navigator.vibrate (pattern)) {
+				
+				Log.verbose ("Navigator.vibrate() returned false.");
+				
 			}
-
+			
 		} catch (e:Dynamic) {
-
-			Log.warn ("Navigator.vibrate() threw an error (it might be Internet Explorer or Edge not supporting the feature)");
-
+			
+			Log.verbose ("Navigator.vibrate() threw an error (it might be Internet Explorer or Edge not supporting the feature)");
+			
 		}
-
+		
 		#elseif (lime_cffi && !macro)
 
 		NativeCFFI.lime_haptic_vibrate (period, duration);


### PR DESCRIPTION
Haptic support for HTML5 via Navigator.vibrate (https://developer.mozilla.org/en-US/docs/Web/API/Vibration_API)

---

**note:**

w3c spec says to vibrate on even elements of the pattern and android waits on even elements.

**w3c**
> If the index of time is even (the first entry has index 0), vibrate the device for time milliseconds.

https://w3c.github.io/vibration/

**android**
> The first value indicates the number of milliseconds to wait before turning the vibrator on. 

https://developer.android.com/reference/android/os/Vibrator.html#vibrate(long[],%20int)


The code has a line that adds a zero to the pattern to make the html5 behavior match the android behavior.