### PR TITLE
Fix canvas smoothing on html5

### DIFF
--- a/src/lime/_internal/graphics/ImageCanvasUtil.hx
+++ b/src/lime/_internal/graphics/ImageCanvasUtil.hx
@@ -194,8 +194,6 @@ class ImageCanvasUtil
 			{
 				buffer.__srcContext = buffer.__srcCanvas.getContext("2d");
 			}
-
-			buffer.__srcContext.imageSmoothingEnabled = false;
 		}
 		#end
 	}


### PR DESCRIPTION
This PR removes the line that forces `imageSmoothingEnabled` to false.

It fixes [openf#2102](https://github.com/openfl/openfl/issues/2102), and potentialy #1116 and [this one](https://community.openfl.org/t/bitmapdata-draw-smoothing-does-not-work-html5/7509) too. 

If it is intended that the smoothing is disabled here, you can close this PR and I'll make another one in OpenFL to adjust `BitmapData.draw` accordingly.