### PR TITLE
Enable cairo for winrt

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -9,7 +9,7 @@
 	<set name="ios" value="1" if="iphone" />
 	<set name="tvos" value="1" if="appletv" />
 
-	<set name="LIME_CAIRO" value="1" unless="winrt" />
+	<set name="LIME_CAIRO" value="1"/>
 	<set name="LIME_CURL" value="1" unless="emscripten || winrt" />
 	<set name="LIME_EFSW" value="1" if="windows || mac || linux" unless="winrt" />
 	<set name="LIME_JPEG" value="1" />

--- a/templates/winrt/static/Main.cpp
+++ b/templates/winrt/static/Main.cpp
@@ -28,6 +28,7 @@ extern DECLSPEC int SDLCALL SDL_WinRTRunApp(int (*mainFunction)(int, char **), v
 #define LIME_SDL
 #define LIME_OPENGL
 #define LIME_CAIRO
+#define NATIVE_TOOLKIT_SDL_ANGLE
 
 #ifndef SDL_WINRT_METADATA_FILE_AVAILABLE
 #ifndef __cplusplus_winrt

--- a/templates/winrt/static/Main.cpp
+++ b/templates/winrt/static/Main.cpp
@@ -27,6 +27,7 @@ extern DECLSPEC int SDLCALL SDL_WinRTRunApp(int (*mainFunction)(int, char **), v
 
 #define LIME_SDL
 #define LIME_OPENGL
+#define LIME_CAIRO
 
 #ifndef SDL_WINRT_METADATA_FILE_AVAILABLE
 #ifndef __cplusplus_winrt
@@ -52,20 +53,22 @@ extern DECLSPEC int SDLCALL SDL_WinRTRunApp(int (*mainFunction)(int, char **), v
 extern "C" const char *hxRunLibrary ();
 extern "C" void hxcpp_set_top_of_stack ();
 extern "C" int zlib_register_prims ();
+extern "C" int lime_cairo_register_prims ();
 ::foreach ndlls::::if (registerStatics)::
 extern "C" int ::nameSafe::_register_prims ();::end::::end::
 
 										
 int _main(int argc, char *argv[])
 {
-   DLOG("HELLO WORLD");
-   Sleep(10000);  //uncomment to attach here in debugger
-   DLOG("HELLO WORLD2");
+   //DLOG("HELLO WORLD");
+   //Sleep(10000);  //uncomment to attach here in debugger
+   //DLOG("HELLO WORLD2");
 
    try
    {
         hxcpp_set_top_of_stack ();  
         zlib_register_prims ();
+        lime_cairo_register_prims ();
         ::foreach ndlls::::if (registerStatics)::
         ::nameSafe::_register_prims ();::end::::end::
         


### PR DESCRIPTION
DisplayingABitmap works when compiling with

lime rebuild winrt -static -Dcairo -debug -m64

openfl test project.xml winrt -static -Dcairo -debug

And adding a Sys.sleep(1); in openfl/assets/templates/haxe/ApplicationMain.hx, before var result = app.exec ();