### PR TITLE
Fix syntax error in extensions on the html5 target

### DIFF
--- a/src/lime/graphics/opengl/ext/ANGLE_instanced_arrays.hx
+++ b/src/lime/graphics/opengl/ext/ANGLE_instanced_arrays.hx
@@ -19,7 +19,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("ANGLE_instanced_arrays")
-extern @:noCompletion class ANGLE_instanced_arrays
+@:noCompletion extern class ANGLE_instanced_arrays
 {
 	public var VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE:Int;
 	public function drawArraysInstancedANGLE(mode:Int, first:Int, count:Int, primcount:Int):Void;

--- a/src/lime/graphics/opengl/ext/EXT_blend_minmax.hx
+++ b/src/lime/graphics/opengl/ext/EXT_blend_minmax.hx
@@ -11,7 +11,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("ANGLE_instanced_arrays")
-extern @:noCompletion class EXT_blend_minmax
+@:noCompletion extern class EXT_blend_minmax
 {
 	public var MIN_EXT:Int;
 	public var MAX_EXT:Int;

--- a/src/lime/graphics/opengl/ext/EXT_color_buffer_float.hx
+++ b/src/lime/graphics/opengl/ext/EXT_color_buffer_float.hx
@@ -7,5 +7,5 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("EXT_color_buffer_float")
-extern @:noCompletion class EXT_color_buffer_float {}
+@:noCompletion extern class EXT_color_buffer_float {}
 #end

--- a/src/lime/graphics/opengl/ext/EXT_color_buffer_half_float.hx
+++ b/src/lime/graphics/opengl/ext/EXT_color_buffer_half_float.hx
@@ -17,7 +17,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("EXT_color_buffer_half_float")
-extern @:noCompletion class EXT_color_buffer_half_float
+@:noCompletion extern class EXT_color_buffer_half_float
 {
 	public var RGBA16F_EXT:Int;
 	public var RGB16F_EXT:Int;

--- a/src/lime/graphics/opengl/ext/EXT_disjoint_timer_query.hx
+++ b/src/lime/graphics/opengl/ext/EXT_disjoint_timer_query.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("EXT_disjoint_timer_query")
-extern @:noCompletion class EXT_disjoint_timer_query
+@:noCompletion extern class EXT_disjoint_timer_query
 {
 	public var QUERY_COUNTER_BITS_EXT:Int;
 	public var CURRENT_QUERY_EXT:Int;

--- a/src/lime/graphics/opengl/ext/EXT_frag_depth.hx
+++ b/src/lime/graphics/opengl/ext/EXT_frag_depth.hx
@@ -2,5 +2,5 @@ package lime.graphics.opengl.ext;
 
 #if (js && html5)
 @:native("EXT_frag_depth")
-extern @:noCompletion class EXT_frag_depth {}
+@:noCompletion extern class EXT_frag_depth {}
 #end

--- a/src/lime/graphics/opengl/ext/EXT_sRGB.hx
+++ b/src/lime/graphics/opengl/ext/EXT_sRGB.hx
@@ -13,7 +13,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("EXT_sRGB")
-extern @:noCompletion class EXT_sRGB
+@:noCompletion extern class EXT_sRGB
 {
 	public var SRGB_EXT:Int;
 	public var SRGB_ALPHA_EXT:Int;

--- a/src/lime/graphics/opengl/ext/EXT_shader_texture_lod.hx
+++ b/src/lime/graphics/opengl/ext/EXT_shader_texture_lod.hx
@@ -8,5 +8,5 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("EXT_shader_texture_lod")
-extern @:noCompletion class EXT_shader_texture_lod {}
+@:noCompletion extern class EXT_shader_texture_lod {}
 #end

--- a/src/lime/graphics/opengl/ext/EXT_texture_filter_anisotropic.hx
+++ b/src/lime/graphics/opengl/ext/EXT_texture_filter_anisotropic.hx
@@ -11,7 +11,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("EXT_texture_filter_anisotropic")
-extern @:noCompletion class EXT_texture_filter_anisotropic
+@:noCompletion extern class EXT_texture_filter_anisotropic
 {
 	public var TEXTURE_MAX_ANISOTROPY_EXT:Int;
 	public var MAX_TEXTURE_MAX_ANISOTROPY_EXT:Int;

--- a/src/lime/graphics/opengl/ext/OES_element_index_uint.hx
+++ b/src/lime/graphics/opengl/ext/OES_element_index_uint.hx
@@ -10,5 +10,5 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("OES_element_index_uint")
-extern @:noCompletion class OES_element_index_uint {}
+@:noCompletion extern class OES_element_index_uint {}
 #end

--- a/src/lime/graphics/opengl/ext/OES_standard_derivatives.hx
+++ b/src/lime/graphics/opengl/ext/OES_standard_derivatives.hx
@@ -10,7 +10,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("OES_standard_derivatives")
-extern @:noCompletion class OES_standard_derivatives
+@:noCompletion extern class OES_standard_derivatives
 {
 	public var FRAGMENT_SHADER_DERIVATIVE_HINT_OES:Int;
 }

--- a/src/lime/graphics/opengl/ext/OES_texture_float.hx
+++ b/src/lime/graphics/opengl/ext/OES_texture_float.hx
@@ -7,5 +7,5 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("OES_texture_float")
-extern @:noCompletion class OES_texture_float {}
+@:noCompletion extern class OES_texture_float {}
 #end

--- a/src/lime/graphics/opengl/ext/OES_texture_float_linear.hx
+++ b/src/lime/graphics/opengl/ext/OES_texture_float_linear.hx
@@ -7,5 +7,5 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("OES_texture_float_linear")
-extern @:noCompletion class OES_texture_float_linear {}
+@:noCompletion extern class OES_texture_float_linear {}
 #end

--- a/src/lime/graphics/opengl/ext/OES_texture_half_float.hx
+++ b/src/lime/graphics/opengl/ext/OES_texture_half_float.hx
@@ -10,7 +10,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("OES_texture_half_float")
-extern @:noCompletion class OES_texture_half_float
+@:noCompletion extern class OES_texture_half_float
 {
 	public var HALF_FLOAT_OES:Int;
 }

--- a/src/lime/graphics/opengl/ext/OES_texture_half_float_linear.hx
+++ b/src/lime/graphics/opengl/ext/OES_texture_half_float_linear.hx
@@ -7,5 +7,5 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("OES_texture_half_float_linear")
-extern @:noCompletion class OES_texture_half_float_linear {}
+@:noCompletion extern class OES_texture_half_float_linear {}
 #end

--- a/src/lime/graphics/opengl/ext/OES_vertex_array_object.hx
+++ b/src/lime/graphics/opengl/ext/OES_vertex_array_object.hx
@@ -29,7 +29,7 @@ package lime.graphics.opengl.ext;
 }
 #else
 @:native("OES_vertex_array_object")
-extern @:noCompletion class OES_vertex_array_object
+@:noCompletion extern class OES_vertex_array_object
 {
 	public var VERTEX_ARRAY_BINDING_OES:Int;
 	public function createVertexArrayOES():Dynamic; /*WebGLVertexArrayObject*/

--- a/src/lime/graphics/opengl/ext/WEBGL_color_buffer_float.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_color_buffer_float.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_color_buffer_float")
-extern @:noCompletion class WEBGL_color_buffer_float
+@:noCompletion extern class WEBGL_color_buffer_float
 {
 	public var RGBA32F_EXT:Int;
 	public var RGB32F_EXT:Int;

--- a/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_atc.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_atc.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_compressed_texture_atc")
-extern @:noCompletion class WEBGL_compressed_texture_atc
+@:noCompletion extern class WEBGL_compressed_texture_atc
 {
 	public var COMPRESSED_RGB_ATC_WEBGL:Int;
 	public var COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL:Int;

--- a/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_compressed_texture_etc")
-extern @:noCompletion class WEBGL_compressed_texture_etc
+@:noCompletion extern class WEBGL_compressed_texture_etc
 {
 	public var COMPRESSED_R11_EAC:Int;
 	public var COMPRESSED_SIGNED_R11_EAC:Int;

--- a/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc1.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_etc1.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_compressed_texture_etc1")
-extern @:noCompletion class WEBGL_compressed_texture_etc1
+@:noCompletion extern class WEBGL_compressed_texture_etc1
 {
 	public var COMPRESSED_RGB_ETC1_WEBGL:Int;
 }

--- a/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_pvrtc.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_pvrtc.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_compressed_texture_pvrtc")
-extern @:noCompletion class WEBGL_compressed_texture_pvrtc
+@:noCompletion extern class WEBGL_compressed_texture_pvrtc
 {
 	public var COMPRESSED_RGB_PVRTC_4BPPV1_IMG:Int;
 	public var COMPRESSED_RGBA_PVRTC_4BPPV1_IMG:Int;

--- a/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_s3tc.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_compressed_texture_s3tc.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_compressed_texture_s3tc")
-extern @:noCompletion class WEBGL_compressed_texture_s3tc
+@:noCompletion extern class WEBGL_compressed_texture_s3tc
 {
 	public var COMPRESSED_RGB_S3TC_DXT1_EXT:Int;
 	public var COMPRESSED_RGBA_S3TC_DXT1_EXT:Int;

--- a/src/lime/graphics/opengl/ext/WEBGL_debug_renderer_info.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_debug_renderer_info.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_debug_renderer_info")
-extern @:noCompletion class WEBGL_debug_renderer_info
+@:noCompletion extern class WEBGL_debug_renderer_info
 {
 	public var UNMASKED_VENDOR_WEBGL:Int;
 	public var UNMASKED_RENDERER_WEBGL:Int;

--- a/src/lime/graphics/opengl/ext/WEBGL_debug_shaders.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_debug_shaders.hx
@@ -5,7 +5,7 @@ import lime.graphics.opengl.GLShader;
 
 @:keep
 @:native("WEBGL_debug_shaders")
-extern @:noCompletion class WEBGL_debug_shaders
+@:noCompletion extern class WEBGL_debug_shaders
 {
 	public function getTranslatedShaderSource(shader:GLShader):String;
 }

--- a/src/lime/graphics/opengl/ext/WEBGL_depth_texture.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_depth_texture.hx
@@ -5,7 +5,7 @@ import lime.graphics.opengl.GLShader;
 
 @:keep
 @:native("WEBGL_depth_texture")
-extern @:noCompletion class WEBGL_depth_texture
+@:noCompletion extern class WEBGL_depth_texture
 {
 	public var UNSIGNED_INT_24_8_WEBGL:Int;
 }

--- a/src/lime/graphics/opengl/ext/WEBGL_draw_buffers.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_draw_buffers.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_draw_buffers")
-extern @:noCompletion class WEBGL_draw_buffers
+@:noCompletion extern class WEBGL_draw_buffers
 {
 	public var COLOR_ATTACHMENT0_WEBGL:Int;
 	public var COLOR_ATTACHMENT1_WEBGL:Int;

--- a/src/lime/graphics/opengl/ext/WEBGL_lose_context.hx
+++ b/src/lime/graphics/opengl/ext/WEBGL_lose_context.hx
@@ -3,7 +3,7 @@ package lime.graphics.opengl.ext;
 #if (js && html5)
 @:keep
 @:native("WEBGL_lose_context")
-extern @:noCompletion class WEBGL_lose_context
+@:noCompletion extern class WEBGL_lose_context
 {
 	public function loseContext():Void;
 	public function restoreContext():Void;


### PR DESCRIPTION
`extern @:noCompletion ...`
to 
`@:noCompletion extern ...`