### PR TITLE
Replace @:fakeEnum with @:enum abstract

### DIFF
--- a/externs/air/flash/data/SQLCollationType.hx
+++ b/externs/air/flash/data/SQLCollationType.hx
@@ -1,7 +1,8 @@
 package flash.data;
 
-@:fakeEnum(String) extern enum SQLCollationType
+@:native("flash.data.SQLCollationType")
+@:enum extern abstract SQLCollationType(String)
 {
-	BINARY;
-	NO_CASE;
+	var BINARY;
+	var NO_CASE;
 }

--- a/externs/air/flash/data/SQLColumnNameStyle.hx
+++ b/externs/air/flash/data/SQLColumnNameStyle.hx
@@ -1,8 +1,9 @@
 package flash.data;
 
-@:fakeEnum(String) extern enum SQLColumnNameStyle
+@:native("flash.data.SQLColumnNameStyle")
+@:enum extern abstract SQLColumnNameStyle(String)
 {
-	DEFAULT;
-	LONG;
-	SHORT;
+	var DEFAULT;
+	var LONG;
+	var SHORT;
 }

--- a/externs/air/flash/data/SQLMode.hx
+++ b/externs/air/flash/data/SQLMode.hx
@@ -1,8 +1,9 @@
 package flash.data;
 
-@:fakeEnum(String) extern enum SQLMode
+@:native("flash.data.SQLMode")
+@:enum extern abstract SQLMode(String)
 {
-	CREATE;
-	READ;
-	UPDATE;
+	var CREATE;
+	var READ;
+	var UPDATE;
 }

--- a/externs/air/flash/data/SQLTransactionLockType.hx
+++ b/externs/air/flash/data/SQLTransactionLockType.hx
@@ -1,8 +1,9 @@
 package flash.data;
 
-@:fakeEnum(String) extern enum SQLTransactionLockType
+@:native("flash.data.SQLTransactionLockType")
+@:enum extern abstract SQLTransactionLockType(String)
 {
-	DEFERRED;
-	EXCLUSIVE;
-	IMMEDIATE;
+	var DEFERRED;
+	var EXCLUSIVE;
+	var IMMEDIATE;
 }

--- a/externs/air/flash/desktop/InvokeEventReason.hx
+++ b/externs/air/flash/desktop/InvokeEventReason.hx
@@ -1,9 +1,10 @@
 package flash.desktop;
 
-@:fakeEnum(String) extern enum InvokeEventReason
+@:native("flash.desktop.InvokeEventReason")
+@:enum extern abstract InvokeEventReason(String)
 {
-	LOGIN;
-	NOTIFICATION;
-	OPEN_URL;
-	STANDARD;
+	var LOGIN;
+	var NOTIFICATION;
+	var OPEN_URL;
+	var STANDARD;
 }

--- a/externs/air/flash/desktop/NativeDragActions.hx
+++ b/externs/air/flash/desktop/NativeDragActions.hx
@@ -1,9 +1,10 @@
 package flash.desktop;
 
-@:fakeEnum(String) extern enum NativeDragActions
+@:native("flash.desktop.NativeDragActions")
+@:enum extern abstract NativeDragActions(String)
 {
-	COPY;
-	LINK;
-	MOVE;
-	NONE;
+	var COPY;
+	var LINK;
+	var MOVE;
+	var NONE;
 }

--- a/externs/air/flash/desktop/NotificationType.hx
+++ b/externs/air/flash/desktop/NotificationType.hx
@@ -1,7 +1,8 @@
 package flash.desktop;
 
-@:fakeEnum(String) extern enum NotificationType
+@:native("flash.desktop.NotificationType")
+@:enum extern abstract NotificationType(String)
 {
-	CRITICAL;
-	INFORMATIONAL;
+	var CRITICAL;
+	var INFORMATIONAL;
 }

--- a/externs/air/flash/desktop/SystemIdleMode.hx
+++ b/externs/air/flash/desktop/SystemIdleMode.hx
@@ -1,7 +1,8 @@
 package flash.desktop;
 
-@:fakeEnum(String) extern enum SystemIdleMode
+@:native("flash.data.SQLCollationType")
+@:enum extern abstract SystemIdleMode(String)
 {
-	KEEP_AWAKE;
-	NORMAL;
+	var KEEP_AWAKE;
+	var NORMAL;
 }

--- a/externs/air/flash/display/NativeWindowDisplayState.hx
+++ b/externs/air/flash/display/NativeWindowDisplayState.hx
@@ -1,8 +1,9 @@
 package flash.display;
 
-@:fakeEnum(String) extern enum NativeWindowDisplayState
+@:native("flash.display.NativeWindowDisplayState")
+@:enum extern abstract NativeWindowDisplayState(String)
 {
-	MAXIMIZED;
-	MINIMIZED;
-	NORMAL;
+	var MAXIMIZED;
+	var MINIMIZED;
+	var NORMAL;
 }

--- a/externs/air/flash/display/NativeWindowRenderMode.hx
+++ b/externs/air/flash/display/NativeWindowRenderMode.hx
@@ -1,9 +1,10 @@
 package flash.display;
 
-@:fakeEnum(String) extern enum NativeWindowRenderMode
+@:native("flash.display.NativeWindowRenderMode")
+@:enum extern abstract NativeWindowRenderMode(String)
 {
-	AUTO;
-	CPU;
-	DIRECT;
-	GPU;
+	var AUTO;
+	var CPU;
+	var DIRECT;
+	var GPU;
 }

--- a/externs/air/flash/display/NativeWindowResize.hx
+++ b/externs/air/flash/display/NativeWindowResize.hx
@@ -1,14 +1,15 @@
 package flash.display;
 
-@:fakeEnum(String) extern enum NativeWindowResize
+@:native("flash.display.NativeWindowResize")
+@:enum extern abstract NativeWindowResize(String)
 {
-	BOTTOM;
-	BOTTOM_LEFT;
-	BOTTOM_RIGHT;
-	LEFT;
-	NONE;
-	RIGHT;
-	TOP;
-	TOP_LEFT;
-	TOP_RIGHT;
+	var BOTTOM;
+	var BOTTOM_LEFT;
+	var BOTTOM_RIGHT;
+	var LEFT;
+	var NONE;
+	var RIGHT;
+	var TOP;
+	var TOP_LEFT;
+	var TOP_RIGHT;
 }

--- a/externs/air/flash/display/NativeWindowSystemChrome.hx
+++ b/externs/air/flash/display/NativeWindowSystemChrome.hx
@@ -1,8 +1,9 @@
 package flash.display;
 
-@:fakeEnum(String) extern enum NativeWindowSystemChrome
+@:native("flash.display.NativeWindowSystemChrome")
+@:enum extern abstract NativeWindowSystemChrome(String)
 {
-	ALTERNATE;
-	NONE;
-	STANDARD;
+	var ALTERNATE;
+	var NONE;
+	var STANDARD;
 }

--- a/externs/air/flash/display/NativeWindowType.hx
+++ b/externs/air/flash/display/NativeWindowType.hx
@@ -1,8 +1,9 @@
 package flash.display;
 
-@:fakeEnum(String) extern enum NativeWindowType
+@:native("flash.display.NativeWindowType")
+@:enum extern abstract NativeWindowType(String)
 {
-	LIGHTWEIGHT;
-	NORMAL;
-	UTILITY;
+	var LIGHTWEIGHT;
+	var NORMAL;
+	var UTILITY;
 }

--- a/externs/air/flash/display/StageAspectRatio.hx
+++ b/externs/air/flash/display/StageAspectRatio.hx
@@ -1,8 +1,9 @@
 package flash.display;
 
-@:fakeEnum(String) extern enum StageAspectRatio
+@:native("flash.display.StageAspectRatio")
+@:enum extern abstract StageAspectRatio(String)
 {
-	ANY;
-	LANDSCAPE;
-	PORTRAIT;
+	var ANY;
+	var LANDSCAPE;
+	var PORTRAIT;
 }

--- a/externs/air/flash/display/StageOrientation.hx
+++ b/externs/air/flash/display/StageOrientation.hx
@@ -1,10 +1,11 @@
 package flash.display;
 
-@:fakeEnum(String) extern enum StageOrientation
+@:native("flash.display.StageOrientation")
+@:enum extern abstract StageOrientation(String)
 {
-	DEFAULT;
-	ROTATED_LEFT;
-	ROTATED_RIGHT;
-	UNKNOWN;
-	UPSIDE_DOWN;
+	var DEFAULT;
+	var ROTATED_LEFT;
+	var ROTATED_RIGHT;
+	var UNKNOWN;
+	var UPSIDE_DOWN;
 }

--- a/externs/air/flash/display3D/Context3DProfile.hx
+++ b/externs/air/flash/display3D/Context3DProfile.hx
@@ -1,14 +1,15 @@
 package flash.display3D;
 
-@:fakeEnum(String) extern enum Context3DProfile
+@:native("flash.display3D.Context3DProfile")
+@:enum extern abstract Context3DProfile(String)
 {
-	BASELINE;
-	BASELINE_CONSTRAINED;
-	BASELINE_EXTENDED;
-	STANDARD;
-	STANDARD_CONSTRAINED;
-	STANDARD_EXTENDED;
+	var BASELINE;
+	var BASELINE_CONSTRAINED;
+	var BASELINE_EXTENDED;
+	var STANDARD;
+	var STANDARD_CONSTRAINED;
+	var STANDARD_EXTENDED;
 	#if air
-	ENHANCED;
+	var ENHANCED;
 	#end
 }

--- a/externs/air/flash/errors/SQLErrorOperation.hx
+++ b/externs/air/flash/errors/SQLErrorOperation.hx
@@ -1,21 +1,22 @@
 package flash.errors;
 
-@:fakeEnum(String) extern enum SQLErrorOperation
+@:native("flash.errors.SQLErrorOperation")
+@:enum extern abstract SQLErrorOperation(String)
 {
-	ANALYZE;
-	ATTACH;
-	BEGIN;
-	CLOSE;
-	COMMIT;
-	COMPACT;
-	DEANALYZE;
-	DETACH;
-	EXECUTE;
-	OPEN;
-	REENCRYPT;
-	RELEASE_SAVEPOINT;
-	ROLLBACK;
-	ROLLBACK_TO_SAVEPOINT;
-	SCHEMA;
-	SET_SAVEPOINT;
+	var ANALYZE;
+	var ATTACH;
+	var BEGIN;
+	var CLOSE;
+	var COMMIT;
+	var COMPACT;
+	var DEANALYZE;
+	var DETACH;
+	var EXECUTE;
+	var OPEN;
+	var REENCRYPT;
+	var RELEASE_SAVEPOINT;
+	var ROLLBACK;
+	var ROLLBACK_TO_SAVEPOINT;
+	var SCHEMA;
+	var SET_SAVEPOINT;
 }

--- a/externs/air/flash/events/TouchEventIntent.hx
+++ b/externs/air/flash/events/TouchEventIntent.hx
@@ -1,8 +1,9 @@
 package flash.events;
 
-@:fakeEnum(String) extern enum TouchEventIntent
+@:native("flash.events.TouchEventIntent")
+@:enum extern abstract TouchEventIntent(String)
 {
-	ERASER;
-	PEN;
-	UNKNOWN;
+	var ERASER;
+	var PEN;
+	var UNKNOWN;
 }

--- a/externs/air/flash/filesystem/FileMode.hx
+++ b/externs/air/flash/filesystem/FileMode.hx
@@ -1,9 +1,10 @@
 package flash.filesystem;
 
-@:fakeEnum(String) extern enum FileMode
+@:native("flash.filesystem.FileMode")
+@:enum extern abstract FileMode(String)
 {
-	APPEND;
-	READ;
-	UPDATE;
-	WRITE;
+	var APPEND;
+	var READ;
+	var UPDATE;
+	var WRITE;
 }

--- a/externs/air/flash/media/AudioPlaybackMode.hx
+++ b/externs/air/flash/media/AudioPlaybackMode.hx
@@ -1,8 +1,9 @@
 package flash.media;
 
-@:fakeEnum(String) extern enum AudioPlaybackMode
+@:native("flash.media.AudioPlaybackMode")
+@:enum extern abstract AudioPlaybackMode(String)
 {
-	AMBIENT;
-	MEDIA;
-	VOICE;
+	var AMBIENT;
+	var MEDIA;
+	var VOICE;
 }

--- a/externs/air/flash/media/CameraPosition.hx
+++ b/externs/air/flash/media/CameraPosition.hx
@@ -1,8 +1,9 @@
 package flash.media;
 
-@:fakeEnum(String) extern enum CameraPosition
+@:native("flash.media.CameraPosition")
+@:enum extern abstract CameraPosition(String)
 {
-	BACK;
-	FRONT;
-	UNKNOWN;
+	var BACK;
+	var FRONT;
+	var UNKNOWN;
 }

--- a/externs/air/flash/media/MediaType.hx
+++ b/externs/air/flash/media/MediaType.hx
@@ -1,7 +1,8 @@
 package flash.media;
 
-@:fakeEnum(String) extern enum MediaType
+@:native("flash.media.MediaType")
+@:enum extern abstract MediaType(String)
 {
-	IMAGE;
-	VIDEO;
+	var IMAGE;
+	var VIDEO;
 }

--- a/externs/air/flash/net/IPVersion.hx
+++ b/externs/air/flash/net/IPVersion.hx
@@ -1,7 +1,8 @@
 package flash.net;
 
-@:fakeEnum(String) extern enum IPVersion
+@:native("flash.net.IPVersion")
+@:enum extern abstract IPVersion(String)
 {
-	IPV4;
-	IPV6;
+	var IPV4;
+	var IPV6;
 }

--- a/externs/air/flash/notifications/NotificationStyle.hx
+++ b/externs/air/flash/notifications/NotificationStyle.hx
@@ -1,8 +1,9 @@
 package flash.notifications;
 
-@:fakeEnum(String) extern enum NotificationStyle
+@:native("flash.notifications.NotificationStyle")
+@:enum extern abstract NotificationStyle(String)
 {
-	ALERT;
-	BADGE;
-	SOUND;
+	var ALERT;
+	var BADGE;
+	var SOUND;
 }

--- a/externs/air/flash/printing/PaperSize.hx
+++ b/externs/air/flash/printing/PaperSize.hx
@@ -1,22 +1,23 @@
 package flash.printing;
 
-@:fakeEnum(String) extern enum PaperSize
+@:native("flash.printing.PaperSize")
+@:enum extern abstract PaperSize(String)
 {
-	A4;
-	A5;
-	A6;
-	CHOUKEI3GOU;
-	CHOUKEI4GOU;
-	ENV_10;
-	ENV_B5;
-	ENV_C5;
-	ENV_DL;
-	ENV_MONARCH;
-	ENV_PERSONAL;
-	EXECUTIVE;
-	FOLIO;
-	JIS_B5;
-	LEGAL;
-	LETTER;
-	STATEMENT;
+	var A4;
+	var A5;
+	var A6;
+	var CHOUKEI3GOU;
+	var CHOUKEI4GOU;
+	var ENV_10;
+	var ENV_B5;
+	var ENV_C5;
+	var ENV_DL;
+	var ENV_MONARCH;
+	var ENV_PERSONAL;
+	var EXECUTIVE;
+	var FOLIO;
+	var JIS_B5;
+	var LEGAL;
+	var LETTER;
+	var STATEMENT;
 }

--- a/externs/air/flash/printing/PrintMethod.hx
+++ b/externs/air/flash/printing/PrintMethod.hx
@@ -1,8 +1,9 @@
 package flash.printing;
 
-@:fakeEnum(String) extern enum PrintMethod
+@:native("flash.printing.PrintMethod")
+@:enum extern abstract PrintMethod(String)
 {
-	AUTO;
-	BITMAP;
-	VECTOR;
+	var AUTO;
+	var BITMAP;
+	var VECTOR;
 }

--- a/externs/air/flash/security/ReferencesValidationSetting.hx
+++ b/externs/air/flash/security/ReferencesValidationSetting.hx
@@ -1,8 +1,9 @@
 package flash.security;
 
-@:fakeEnum(String) extern enum ReferencesValidationSetting
+@:native("flash.security.ReferencesValidationSetting")
+@:enum extern abstract ReferencesValidationSetting(String)
 {
-	NEVER;
-	VALID_IDENTITY;
-	VALID_OR_UNKNOWN_IDENTITY;
+	var NEVER;
+	var VALID_IDENTITY;
+	var VALID_OR_UNKNOWN_IDENTITY;
 }

--- a/externs/air/flash/security/RevocationCheckSettings.hx
+++ b/externs/air/flash/security/RevocationCheckSettings.hx
@@ -1,9 +1,10 @@
 package flash.security;
 
-@:fakeEnum(String) extern enum RevocationCheckSettings
+@:native("flash.security.RevocationCheckSettings")
+@:enum extern abstract RevocationCheckSettings(String)
 {
-	ALWAYS_REQUIRED;
-	BEST_EFFORT;
-	NEVER;
-	REQUIRED_IF_AVAILABLE;
+	var ALWAYS_REQUIRED;
+	var BEST_EFFORT;
+	var NEVER;
+	var REQUIRED_IF_AVAILABLE;
 }

--- a/externs/air/flash/security/SignatureStatus.hx
+++ b/externs/air/flash/security/SignatureStatus.hx
@@ -1,8 +1,9 @@
 package flash.security;
 
-@:fakeEnum(String) extern enum SignatureStatus
+@:native("flash.security.SignatureStatus")
+@:enum extern abstract SignatureStatus(String)
 {
-	INVALID;
-	UNKNOWN;
-	VALID;
+	var INVALID;
+	var UNKNOWN;
+	var VALID;
 }

--- a/externs/air/flash/security/SignerTrustSettings.hx
+++ b/externs/air/flash/security/SignerTrustSettings.hx
@@ -1,8 +1,9 @@
 package flash.security;
 
-@:fakeEnum(String) extern enum SignerTrustSettings
+@:native("flash.security.SignerTrustSettings")
+@:enum extern abstract SignerTrustSettings(String)
 {
-	CODE_SIGNING;
-	PLAYLIST_SIGNING;
-	SIGNING;
+	var CODE_SIGNING;
+	var PLAYLIST_SIGNING;
+	var SIGNING;
 }

--- a/externs/air/flash/text/AutoCapitalize.hx
+++ b/externs/air/flash/text/AutoCapitalize.hx
@@ -1,9 +1,10 @@
 package flash.text;
 
-@:fakeEnum(String) extern enum AutoCapitalize
+@:native("flash.text.AutoCapitalize")
+@:enum extern abstract AutoCapitalize(String)
 {
-	ALL;
-	NONE;
-	SENTENCE;
-	WORD;
+	var ALL;
+	var NONE;
+	var SENTENCE;
+	var WORD;
 }

--- a/externs/air/flash/text/ReturnKeyLabel.hx
+++ b/externs/air/flash/text/ReturnKeyLabel.hx
@@ -1,10 +1,11 @@
 package flash.text;
 
-@:fakeEnum(String) extern enum ReturnKeyLabel
+@:native("flash.text.ReturnKeyLabel")
+@:enum extern abstract ReturnKeyLabel(String)
 {
-	DEFAULT;
-	DONE;
-	GO;
-	NEXT;
-	SEARCH;
+	var DEFAULT;
+	var DONE;
+	var GO;
+	var NEXT;
+	var SEARCH;
 }

--- a/externs/air/flash/text/SoftKeyboardType.hx
+++ b/externs/air/flash/text/SoftKeyboardType.hx
@@ -1,11 +1,12 @@
 package flash.text;
 
-@:fakeEnum(String) extern enum SoftKeyboardType
+@:native("flash.text.SoftKeyboardType")
+@:enum extern abstract SoftKeyboardType(String)
 {
-	CONTACT;
-	DEFAULT;
-	EMAIL;
-	NUMBER;
-	PUNCTUATION;
-	URL;
+	var CONTACT;
+	var DEFAULT;
+	var EMAIL;
+	var NUMBER;
+	var PUNCTUATION;
+	var URL;
 }

--- a/externs/air/flash/text/StageTextClearButtonMode.hx
+++ b/externs/air/flash/text/StageTextClearButtonMode.hx
@@ -1,9 +1,10 @@
 package flash.text;
 
-@:fakeEnum(String) extern enum StageTextClearButtonMode
+@:native("flash.text.StageTextClearButtonMode")
+@:enum extern abstract StageTextClearButtonMode(String)
 {
-	ALWAYS;
-	NEVER;
-	UNLESS_EDITING;
-	WHILE_EDITING;
+	var ALWAYS;
+	var NEVER;
+	var UNLESS_EDITING;
+	var WHILE_EDITING;
 }


### PR DESCRIPTION
@:fakeEnum support will be removed in HaxeFoundation/haxe#8189

The style used here matches the re-generated Flash externs in the std lib, example: https://github.com/HaxeFoundation/haxe/blob/development/std/flash/display/PixelSnapping.hx