### PR TITLE
Implement static Angle compile. winrt adjusts.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -86,7 +86,7 @@
 		<dependency path="dependencies/FileSaver.min.js" if="html5" embed="true" />
 		<dependency path="dependencies/webgl-debug.js" if="html5 webgl-debug" embed="true" />
 		<dependency path="dependencies/stats.min.js" if="html5 stats" embed="true" />
-		<dependency path="dependencies/angle/d3dcompiler_47.dll" if="windows angle" unless="static_link" />
+		<dependency path="dependencies/angle/d3dcompiler_47.dll" if="windows angle" />
 		<dependency path="dependencies/angle/libegl.dll" if="windows angle" unless="static_link" />
 		<dependency path="dependencies/angle/libglesv2.dll" if="windows angle" unless="static_link" />
 

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -32,9 +32,9 @@
 	<set name="LIME_PIXMAN" value="1" />
 	<set name="LIME_PNG" value="1" />
 	<set name="LIME_SDL" value="1" />
-	<!-- <set name="LIME_SDL_ANGLE" value="1" if="windows" unless="static_link" /> -->
+	<!-- <set name="LIME_SDL_ANGLE" value="1" if="windows" /> -->
 	<set name="LIME_SDL_ANGLE" value="1" if="windows LIME_SDL_ANGLE" unless="static_link" />
-	<set name="LIME_SDL_ANGLE" value="1" if="windows angle" unless="static_link" />
+	<set name="LIME_SDL_ANGLE" value="1" if="windows angle" />
 	<set name="LIME_SDL_ANGLE" value="1" if="winrt" />
 	<set name="LIME_TINYFILEDIALOGS" value="1" if="windows || mac || linux" unless="winrt || emscripten" />
 	<set name="LIME_VORBIS" value="1" />
@@ -54,12 +54,34 @@
 
 	<set name="NATIVE_TOOLKIT_SDL_STATIC" value="1" />
 	<set name="NATIVE_TOOLKIT_SDL_ANGLE" value="1" if="LIME_SDL_ANGLE" />
+	<set name="NATIVE_TOOLKIT_ANGLE" value="1" if="NATIVE_TOOLKIT_SDL_ANGLE" />
 
+	<!-- -angle sets static angle: -->
+	<set name="NATIVE_TOOLKIT_STATIC_ANGLE" value="1" if="LIME_SDL_ANGLE angle" />
+	<set name="NATIVE_TOOLKIT_STATIC_ANGLE" value="1" if="winrt" />
+	<!-- <set name="NATIVE_TOOLKIT_STATIC_ANGLE" value="1" if="windows" /> -->
 	<files id="lime">
 
 		<compilerflag value="-Iinclude" />
 
 		<file name="src/ExternalInterface.cpp" />
+
+		<section if="NATIVE_TOOLKIT_STATIC_ANGLE">
+
+			<compilerflag value="-I${NATIVE_TOOLKIT_PATH}/angle/include" />
+			<compilerflag value="-I${NATIVE_TOOLKIT_PATH}/angle/src" />
+	  		<compilerflag value="-I${NATIVE_TOOLKIT_PATH}/angle/src/common/third_party/numerics" />
+			<compilerflag value="-DANGLE_ENABLE_GLSL" />
+	   		<compilerflag value="-DANGLE_ENABLE_D3D11" />
+			<compilerflag value="-DANGLE_ENABLE_D3D9" unless="winrt"/>
+	   		<compilerflag value="-DANGLE_ENABLE_HLSL" />
+	   		<compilerflag value="-DLIBANGLE_IMPLEMENTATION" />
+	   		<compilerflag value="-DEGLAPI=" />
+	   		<compilerflag value="-DNOMINMAX" />
+			<compilerflag value="-DNATIVE_TOOLKIT_STATIC_ANGLE"/>
+			<compilerflag value="-DSDL_VIDEO_STATIC_ANGLE"/>
+
+		</section>
 
 		<section if="LIME_CAIRO">
 
@@ -351,6 +373,7 @@
 	<include name="lib/vpx/files.xml" />
 	<include name="lib/webm/files.xml" />
 	<include name="lib/zlib/files.xml" />
+	<include name="lib/angle/files.xml" if="NATIVE_TOOLKIT_STATIC_ANGLE"/>
 
 	<set name="DEBUGEXTRA" value="-debug" if="fulldebug" />
 	<set name="LIBSUFFIX" value="${HX_TARGET_SUFFIX}" if="HX_TARGET_SUFFIX" />
@@ -384,6 +407,7 @@
 		<files id="native-toolkit-vpx" if="LIME_VPX" />
 		<files id="native-toolkit-webm" if="LIME_WEBM" />
 		<files id="native-toolkit-zlib" if="LIME_ZLIB" />
+		<files id="native-toolkit-angle" if="NATIVE_TOOLKIT_STATIC_ANGLE" />
 
 		<section unless="static_link">
 
@@ -393,10 +417,10 @@
 			<!-- TODO: Support single binary? -->
 			<ext value=".hdll" if="LIME_HASHLINK" />
 
-			<section if="windows">
+			<section if="windows" unless="winrt">
 
 				<lib name="gdi32.lib" />
-				<lib name="opengl32.lib" />
+				<lib name="opengl32.lib" unless="NATIVE_TOOLKIT_STATIC_ANGLE"/>
 				<lib name="user32.lib" />
 				<lib name="kernel32.lib" />
 				<lib name="advapi32.lib" />
@@ -415,16 +439,23 @@
 				<lib name="rpcrt4.lib" if="LIME_HARFBUZZ" />
 				<lib name="dwrite.lib" if="LIME_HARFBUZZ" />
 
-				<lib name="comsuppw.lib" unless="winrt" />
-
-				<lib name="D3D11.lib" if="winrt" />
-				<lib name="RuntimeObject.lib" if="winrt" />
-				<lib name="Xinput.lib" if="winrt" />
-				<lib name="DXGI.lib" if="winrt" />
+				<lib name="comsuppw.lib" />
+				<lib name="d3d9.lib" if="NATIVE_TOOLKIT_STATIC_ANGLE"/>
 
 				<lib name="-libpath:../templates/bin/hl/windows" if="LIME_HASHLINK" />
 				<lib name="libhl.lib" if="LIME_HASHLINK" />
 				<!-- <lib name="-delayload:libhl.dll" /> -->
+			</section>
+
+			<section if="winrt">
+
+				<lib name="kernel32.lib" />
+				<lib name="d3d11.lib" />
+				<lib name="Xaudio2.lib" />
+				<lib name="Xinput.lib" />
+				<lib name="DXGI.lib" />
+				<lib name="Dwrite.lib" />
+				<lib name="D3dcompiler.lib" />
 
 			</section>
 

--- a/project/src/backend/sdl/SDLWindow.cpp
+++ b/project/src/backend/sdl/SDLWindow.cpp
@@ -89,9 +89,16 @@ namespace lime {
 
 			#if defined (HX_WINDOWS) && defined (NATIVE_TOOLKIT_SDL_ANGLE)
 			SDL_GL_SetAttribute (SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+			#ifdef NATIVE_TOOLKIT_STATIC_ANGLE
+			SDL_GL_SetAttribute (SDL_GL_CONTEXT_EGL, 1);
+			SDL_GL_SetAttribute (SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+			SDL_GL_SetAttribute (SDL_GL_CONTEXT_MINOR_VERSION, 1);
+			//SDL_SetHint (SDL_HINT_VIDEO_WIN_D3DCOMPILER, "d3dcompiler_47.dll");
+			#else
 			SDL_GL_SetAttribute (SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 			SDL_GL_SetAttribute (SDL_GL_CONTEXT_MINOR_VERSION, 0);
 			SDL_SetHint (SDL_HINT_VIDEO_WIN_D3DCOMPILER, "d3dcompiler_47.dll");
+			#endif
 			#endif
 
 			#if defined (RASPBERRYPI)

--- a/project/src/graphics/opengl/OpenGL.h
+++ b/project/src/graphics/opengl/OpenGL.h
@@ -73,6 +73,19 @@
 
 #elif defined (HX_WINDOWS)
 
+#ifdef NATIVE_TOOLKIT_STATIC_ANGLE
+
+// Static link, not dll import
+#define EGLAPI
+#define GL_APICALL
+#define LIME_GLES
+#define GL_GLEXT_PROTOTYPES
+#define LIME_GLES3_API
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+
+#else
+
 //#define LIME_GLES3_API
 #include <windows.h>
 #ifndef NATIVE_TOOLKIT_SDL_ANGLE
@@ -97,8 +110,10 @@ typedef ptrdiff_t GLsizeiptrARB;
 
 #endif
 
+#endif
 
-#ifdef HX_WINDOWS
+
+#if defined (HX_WINDOWS) && !defined (NATIVE_TOOLKIT_STATIC_ANGLE)
 typedef HDC WinDC;
 typedef HGLRC GLCtx;
 #else

--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -36,7 +36,7 @@ namespace lime {
 	int OpenGLBindings::defaultRenderbuffer = 0;
 	void* OpenGLBindings::handle = 0;
 
-	#ifdef NATIVE_TOOLKIT_SDL_ANGLE
+	#if defined (NATIVE_TOOLKIT_SDL_ANGLE) && !defined (NATIVE_TOOLKIT_STATIC_ANGLE)
 	void* OpenGLBindings::eglHandle = 0;
 	#endif
 
@@ -5316,10 +5316,10 @@ namespace lime {
 
 			#endif
 
-			#ifdef NATIVE_TOOLKIT_SDL_ANGLE
+			#if defined (NATIVE_TOOLKIT_SDL_ANGLE) && !defined (NATIVE_TOOLKIT_STATIC_ANGLE)
 
 			#ifdef HX_WINRT
-			return true;
+			return false;
 			#else
 			OpenGLBindings::eglHandle = LoadLibraryW (L"libegl.dll");
 

--- a/templates/cpp/static/BuildMain.xml
+++ b/templates/cpp/static/BuildMain.xml
@@ -17,7 +17,7 @@
 		<section if="windows">
 
 			<lib name="gdi32.lib" />
-			<lib name="opengl32.lib" />
+			<lib name="opengl32.lib" unless="NATIVE_TOOLKIT_STATIC_ANGLE"/>
 			<lib name="user32.lib" />
 			<lib name="kernel32.lib" />
 			<lib name="advapi32.lib" />
@@ -35,6 +35,7 @@
 			<lib name="rpcrt4.lib" />
 			<lib name="dwrite.lib" />
 			<lib name="setupapi.lib" />
+		        <lib name="d3d9.lib" if="NATIVE_TOOLKIT_STATIC_ANGLE"/>
 
 		</section>
 

--- a/templates/winrt/scripts/newcertificate.ps1
+++ b/templates/winrt/scripts/newcertificate.ps1
@@ -1,6 +1,6 @@
-Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.Subject -match "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL_Example::end::" } | Remove-Item
-New-SelfSignedCertificate -Type Custom -Subject "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL_Example::end::" -KeyUsage DigitalSignature -FriendlyName OpenFLDisplayingCert -CertStoreLocation "Cert:\LocalMachine\My"
-#Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.Subject -match "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL_Example::end::" }
+Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.Subject -match "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL::end::" } | Remove-Item
+New-SelfSignedCertificate -Type Custom -Subject "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL::end::" -KeyUsage DigitalSignature -FriendlyName OpenFLDisplayingCert -CertStoreLocation "Cert:\LocalMachine\My"
+#Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.Subject -match "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL::end::" }
 $pwd = ConvertTo-SecureString -String ::if APP_CERTIFICATE_PWD::APP_CERTIFICATE_PWD::else::"openflexample"::end:: -Force -AsPlainText 
-$thumbprint=(dir cert:\localmachine\My -recurse | where {$_.Subject -match "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL_Example::end::"} ).Thumbprint;
+$thumbprint=(dir cert:\localmachine\My -recurse | where {$_.Subject -match "CN=::if APP_COMPANYID::APP_COMPANYID::else::OpenFL::end::"} ).Thumbprint;
 Export-PfxCertificate -cert "Cert:\LocalMachine\My\$thumbprint" -FilePath ::APP_FILE::.pfx -Password $pwd


### PR DESCRIPTION
`-angle` is used to compile using Angle source. **It requires to add reference to "angle" in project/lib**
(tested with https://github.com/madrazo/lime-1/tree/winrt7/project/lib/angle)

```
haxelib run lime rebuild tools
haxelib run lime rebuild windows -angle -clean
haxelib run openfl test project.xml windows -angle _(-angle may not be needed)_
haxelib run lime rebuild windows -angle -static
haxelib run openfl test project.xml windows -angle -static _(-angle is needed for final link)_
```
Set winrt default to -64 and -static, so it compiles with:
```
haxelib run lime rebuild winrt
haxelib run openfl test project.xml winrt
```

winrt: Adjust appx default cert path and password. Fix make certificate instruction.