### PR TITLE
Add AMD/requirejs compatibility

### DIFF
--- a/templates/html5/output.js
+++ b/templates/html5/output.js
@@ -12,6 +12,19 @@ $hx_exports.lime.embed = function(projectName) { var exports = {};
 	if (lime && lime.embed && this != lime.embed) lime.embed.apply(lime, arguments);
 	return exports;
 };
-})(typeof exports != "undefined" ? exports : typeof window != "undefined" ? window : typeof self != "undefined" ? self : this, typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this);
+::if false::
+	AMD compatibility: If define() is present we need to
+	- call it, to define our module
+	- disable it so that the embedded libraries register themselves in the global scope!
+::end::if(typeof define == "function" && define.amd) {
+	define([], function() { return $hx_exports.lime; });
+	define.__amd = define.amd;
+	define.amd = null;
+}
+})(typeof exports != "undefined" ? exports : typeof define == "function" && define.amd ? {} : typeof window != "undefined" ? window : typeof self != "undefined" ? self : this, typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this);
 ::if embeddedLibraries::::foreach (embeddedLibraries)::
 ::__current__::::end::::end::
+if(typeof define == "function" && define.__amd) {
+	define.amd = define.__amd;
+	delete define.__amd;
+}


### PR DESCRIPTION
Here's an attempt to solve the AMD issue (#1328).

If the app is loaded via AMD we do the following:
- `$hx_exports` is a fresh object, so `lime` is not exported globally, and each app gets a 100% fresh scope. `@:expose`d stuff are completely independent for each app, they can be neatly accessed via the result of `lime.embed`!
- We call `define()` to register the code.
- We disable AMD while the embeded libraries are loading, otherwise they are going to call define, which won't work.

So in the end we can do:
```
require(['myapp'], function(lime) {
    lime.embed(...);
});
```

- PS1. Embedded libraries are still registered globally, which is not ideal (theoretically a conflict between different pako versions could happen) but not a major issue. Ideally, we could use a commonjs emulator (a la browserify), making the libraries available via our own `require`, and use them in haxe via `@:jsRequire`.
- PS2. I added a template "pseudo-comment", looks ugly but the template is becoming too cryptic.


