### PR TITLE
Disable closure warnings for 'suspicious' code

### DIFF
--- a/src/lime/tools/HTML5Helper.hx
+++ b/src/lime/tools/HTML5Helper.hx
@@ -215,6 +215,7 @@ class HTML5Helper
 				if (!Log.verbose)
 				{
 					args.push("--jscomp_off=uselessCode");
+					args.push("--jscomp_off=suspiciousCode");	// avoid warnings caused by the embedded minified libraries
 				}
 
 				System.runCommand("", "java", args);


### PR DESCRIPTION
The already-minified embedded libaries are currently being re-minified. They contain code that looks suspicious if written by a human, like
```
while(--g);
```
So closure complains:
```
WARNING - If this if/for/while really shouldn't have a body, use {}
```
This is most-likely harmless, so until the pipeline is improved, it makes sense to just disable the warnings.

