### PR TITLE
Fix HTML5 compilation with latest Haxe dev

### DIFF
--- a/src/lime/utils/DataView.hx
+++ b/src/lime/utils/DataView.hx
@@ -8,7 +8,7 @@ import js.lib.DataView as JSDataView;
 import js.html.DataView as JSDataView;
 #end
 @:forward
-abstract DataView(JSDataView) from JSDataView to JSDataView
+abstract DataView(JSDataView) from JSDataView to JSDataView to ArrayBufferView
 {
 	public inline function new(buffer:ArrayBuffer, byteOffset:Null<Int> = null, byteLength:Null<Int> = null)
 	{

--- a/src/lime/utils/Float32Array.hx
+++ b/src/lime/utils/Float32Array.hx
@@ -10,7 +10,7 @@ import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
 @:arrayAccess
-abstract Float32Array(JSFloat32Array) from JSFloat32Array to JSFloat32Array
+abstract Float32Array(JSFloat32Array) from JSFloat32Array to JSFloat32Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 4;
 

--- a/src/lime/utils/Float64Array.hx
+++ b/src/lime/utils/Float64Array.hx
@@ -9,7 +9,7 @@ import js.html.Float64Array as JSFloat64Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Float64Array(JSFloat64Array) from JSFloat64Array to JSFloat64Array
+abstract Float64Array(JSFloat64Array) from JSFloat64Array to JSFloat64Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 8;
 

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -9,7 +9,7 @@ import js.html.Int16Array as JSInt16Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Int16Array(JSInt16Array) from JSInt16Array to JSInt16Array
+abstract Int16Array(JSInt16Array) from JSInt16Array to JSInt16Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 2;
 

--- a/src/lime/utils/Int32Array.hx
+++ b/src/lime/utils/Int32Array.hx
@@ -9,7 +9,7 @@ import js.html.Int32Array as JSInt32Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Int32Array(JSInt32Array) from JSInt32Array to JSInt32Array
+abstract Int32Array(JSInt32Array) from JSInt32Array to JSInt32Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 4;
 

--- a/src/lime/utils/Int8Array.hx
+++ b/src/lime/utils/Int8Array.hx
@@ -9,7 +9,7 @@ import js.html.Int8Array as JSInt8Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Int8Array(JSInt8Array) from JSInt8Array to JSInt8Array
+abstract Int8Array(JSInt8Array) from JSInt8Array to JSInt8Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 1;
 

--- a/src/lime/utils/UInt16Array.hx
+++ b/src/lime/utils/UInt16Array.hx
@@ -9,7 +9,7 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint16Array as JSUInt16Array;
 #end
 @:forward
-abstract UInt16Array(JSUInt16Array) from JSUInt16Array to JSUInt16Array
+abstract UInt16Array(JSUInt16Array) from JSUInt16Array to JSUInt16Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 2;
 

--- a/src/lime/utils/UInt32Array.hx
+++ b/src/lime/utils/UInt32Array.hx
@@ -9,7 +9,7 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint32Array as JSUInt32Array;
 #end
 @:forward
-abstract UInt32Array(JSUInt32Array) from JSUInt32Array to JSUInt32Array
+abstract UInt32Array(JSUInt32Array) from JSUInt32Array to JSUInt32Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 4;
 

--- a/src/lime/utils/UInt8Array.hx
+++ b/src/lime/utils/UInt8Array.hx
@@ -7,7 +7,7 @@ import js.lib.Uint8Array as JSUInt8Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract UInt8Array(JSUInt8Array) from JSUInt8Array to JSUInt8Array
+abstract UInt8Array(JSUInt8Array) from JSUInt8Array to JSUInt8Array to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 1;
 

--- a/src/lime/utils/UInt8ClampedArray.hx
+++ b/src/lime/utils/UInt8ClampedArray.hx
@@ -9,7 +9,7 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint8ClampedArray as JSUInt8ClampedArray;
 #end
 @:forward
-abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUInt8ClampedArray
+abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUInt8ClampedArray to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 1;
 


### PR DESCRIPTION
This is needed to compile with HaxeFoundation/haxe#8422 because abstract implicit casts are not transitive.