### PR TITLE
Don't use the hxelectron library when building ApplicationMain.

### DIFF
--- a/templates/electron/hxml/debug.hxml
+++ b/templates/electron/hxml/debug.hxml
@@ -3,7 +3,6 @@
 --next
 -js ::OUTPUT_FILE::
 -cp ::OUTPUT_DIR::/haxe
--lib electron
 -main ApplicationMain ::HAXE_FLAGS::
 
 -D html5

--- a/templates/electron/hxml/final.hxml
+++ b/templates/electron/hxml/final.hxml
@@ -3,7 +3,6 @@
 --next
 -js ::OUTPUT_FILE::
 -cp ::OUTPUT_DIR::/haxe
--lib electron
 -main ApplicationMain ::HAXE_FLAGS::
 
 -D html5

--- a/templates/electron/hxml/release.hxml
+++ b/templates/electron/hxml/release.hxml
@@ -3,7 +3,6 @@
 --next
 -js ::OUTPUT_FILE::
 -cp ::OUTPUT_DIR::/haxe
--lib electron
 -main ApplicationMain ::HAXE_FLAGS::
 
 -D html5


### PR DESCRIPTION
 That sets the 'nodejs' compiler flag, which emits improper JavaScript when executing in the Electron window.