### PR TITLE
Tweaks to make HTTP requests work with HashLink

### DIFF
--- a/src/lime/_internal/backend/native/NativeHTTPRequest.hx
+++ b/src/lime/_internal/backend/native/NativeHTTPRequest.hx
@@ -37,7 +37,7 @@ class NativeHTTPRequest
 	private static var multiProgressTimer:Timer;
 	private static var multiThreadPool:ThreadPool;
 	private static var multiThreadPoolRunning:Bool;
-	#if (cpp || neko)
+	#if (cpp || neko || hl)
 	private static var multiAddHandle:Deque<CURL>;
 	#end
 
@@ -299,7 +299,7 @@ class NativeHTTPRequest
 				activeInstances.push(this);
 				multiInstances.set(curl, this);
 
-				#if (cpp || neko)
+				#if (cpp || neko || hl)
 				if (multiAddHandle == null) multiAddHandle = new Deque<CURL>();
 				multiAddHandle.add(curl);
 				#end
@@ -374,20 +374,19 @@ class NativeHTTPRequest
 		}
 	}
 
-	private function curl_onProgress(curl:CURL, dltotal:Int, dlnow:Int, uptotal:Int, upnow:Int):Int
+	private function curl_onProgress(curl:CURL, dltotal:Float, dlnow:Float, uptotal:Float, upnow:Float):Void
 	{
 		if (upnow > writeBytesLoaded || dlnow > writeBytesLoaded || uptotal > writeBytesTotal || dltotal > writeBytesTotal)
 		{
-			if (upnow > writeBytesLoaded) writeBytesLoaded = upnow;
-			if (dlnow > writeBytesLoaded) writeBytesLoaded = dlnow;
-			if (uptotal > writeBytesTotal) writeBytesTotal = uptotal;
-			if (dltotal > writeBytesTotal) writeBytesTotal = dltotal;
+			if (upnow > writeBytesLoaded) writeBytesLoaded = Std.int(upnow);
+			if (dlnow > writeBytesLoaded) writeBytesLoaded = Std.int(dlnow);
+			if (uptotal > writeBytesTotal) writeBytesTotal = Std.int(uptotal);
+			if (dltotal > writeBytesTotal) writeBytesTotal = Std.int(dltotal);
 
 			// Wrong thread
 			// promise.progress (bytesLoaded, bytesTotal);
 		}
 
-		return 0;
 	}
 
 	private function curl_onWrite(curl:CURL, output:Bytes):Int
@@ -497,7 +496,7 @@ class NativeHTTPRequest
 	{
 		while (true)
 		{
-			#if (cpp || neko)
+			#if (cpp || neko || hl)
 			var curl = multiAddHandle.pop(false);
 			if (curl != null) multi.addHandle(curl);
 			#end
@@ -532,7 +531,7 @@ class NativeHTTPRequest
 
 	private static function multiThreadPool_onComplete(_):Void
 	{
-		#if (cpp || neko)
+		#if (cpp || neko || hl)
 		var curl = multiAddHandle.pop(false);
 
 		if (curl != null)

--- a/src/lime/net/curl/CURL.hx
+++ b/src/lime/net/curl/CURL.hx
@@ -169,8 +169,7 @@ class CURL
 				#if hl
 				parameter = function(bytes:Bytes):Int
 				{
-					 var read = callback(this, bytes);
-					return read;
+					 return callback(this, bytes);
 				}
 				#else	
 				parameter = function(bytes:Bytes, length:Int):Int

--- a/src/lime/net/curl/CURL.hx
+++ b/src/lime/net/curl/CURL.hx
@@ -166,12 +166,6 @@ class CURL
 
 			case CURLOption.WRITEFUNCTION:
 				var callback:CURL->Bytes->Int = cast parameter;
-				#if hl
-				parameter = function(bytes:Bytes):Int
-				{
-					 return callback(this, bytes);
-				}
-				#else	
 				parameter = function(bytes:Bytes, length:Int):Int
 				{
 					var cacheLength = bytes.length;
@@ -180,7 +174,6 @@ class CURL
 					@:privateAccess bytes.length = cacheLength;
 					return read;
 				}
-				#end
 				bytes = Bytes.alloc(0);
 
 			// case CURLOption.READFUNCTION:

--- a/src/lime/net/curl/CURL.hx
+++ b/src/lime/net/curl/CURL.hx
@@ -159,14 +159,21 @@ class CURL
 
 			case CURLOption.XFERINFOFUNCTION:
 				var callback:CURL->Int->Int->Int->Int->Int = cast parameter;
-				parameter = function(dltotal:Int, dlnow:Int, ultotal:Int, ulnow:Int)
+				parameter = function(dltotal:Int, dlnow:Int, ultotal:Int, ulnow:Int):Int
 				{
 					return callback(this, dltotal, dlnow, ultotal, ulnow);
 				}
 
 			case CURLOption.WRITEFUNCTION:
 				var callback:CURL->Bytes->Int = cast parameter;
-				parameter = function(bytes:Bytes, length:Int)
+				#if hl
+				parameter = function(bytes:Bytes):Int
+				{
+					 var read = callback(this, bytes);
+					return read;
+				}
+				#else	
+				parameter = function(bytes:Bytes, length:Int):Int
 				{
 					var cacheLength = bytes.length;
 					@:privateAccess bytes.length = length;
@@ -174,7 +181,7 @@ class CURL
 					@:privateAccess bytes.length = cacheLength;
 					return read;
 				}
-
+				#end
 				bytes = Bytes.alloc(0);
 
 			// case CURLOption.READFUNCTION:


### PR DESCRIPTION
OpenFLs Urlloader fails to respond with anything when target is Hashlink and the request  protocol is http/https. From what i can tell when debugging the issue seems to be related to the signature for the `WRITEFUNCTION` callback function passed to the native curl method, for some reason when targeting HL the second parameter is unavailable. 


Side note: 
Lime should probably use XFERINFOFUNCTION instead of PROGRESSFUNCTION 
https://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html