### PR TITLE
Update to the latest Gradle 5.6.3 and Gradle Android plugin 3.5.1

### DIFF
--- a/dependencies/extension-api/build.gradle
+++ b/dependencies/extension-api/build.gradle
@@ -3,6 +3,9 @@ buildscript {
 		jcenter {
 			url "http://jcenter.bintray.com/"
 		}
+		maven {
+			url 'https://maven.google.com/'
+		}
 	}
 	
 	dependencies {

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -66,19 +66,17 @@ android {
 	}
 	
 	android.applicationVariants.all { variant ->
-		variant.outputs.each { output ->
-			def outputFile = output.outputFile
-			
-			if (outputFile != null && outputFile.name.endsWith('.apk')) {
-				output.outputFile = new File(outputFile.parent, "::APP_FILE::-" + variant.buildType.name + ".apk")
+		variant.outputs.all { output ->
+			if (outputFileName != null && outputFileName.endsWith('.apk')) {
+				outputFileName =  "::APP_FILE::-" + variant.buildType.name + ".apk"
 			}
 		}
 	}
 }
 
 dependencies {
-	compile fileTree(dir: 'libs', include: ['*.jar'])
-	::if (ANDROID_LIBRARY_PROJECTS)::::foreach (ANDROID_LIBRARY_PROJECTS)::compile project(':deps:::name::')
+	api fileTree(dir: 'libs', include: ['*.jar'])
+	::if (ANDROID_LIBRARY_PROJECTS)::::foreach (ANDROID_LIBRARY_PROJECTS)::api project(':deps:::name::')
 	::end::::end::
 }
 

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -5,6 +5,9 @@ buildscript {
 		jcenter {
 			url "http://jcenter.bintray.com/"
 		}
+		maven {
+			url "https://maven.google.com/"
+		}
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
@@ -30,7 +33,7 @@ task clean(type: Delete) {
 	delete rootProject.buildDir
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
 	gradleVersion = '::ANDROID_GRADLE_VERSION::'
 }
 
@@ -38,7 +41,7 @@ configure(subprojects.findAll {!it.file('build.gradle').exists() && it.file('bui
 	buildscript {
 		repositories {
 			maven {
-				url "http://repo1.maven.org/maven2/"
+				url "https://maven.google.com/"
 			}
 		}
 		
@@ -63,7 +66,7 @@ configure(subprojects.findAll {!it.file('build.gradle').exists() && it.file('bui
 	}
 	
 	dependencies {
-		compile fileTree(dir: 'libs', include: ['*.jar'])
-		compile project(':deps:extension-api')
+		api fileTree(dir: 'libs', include: ['*.jar'])
+		api project(':deps:extension-api')
 	}
 }

--- a/templates/extension/dependencies/android/build.gradle
+++ b/templates/extension/dependencies/android/build.gradle
@@ -3,6 +3,9 @@ buildscript {
 		jcenter {
 			url "http://jcenter.bintray.com/"
 		}
+		maven {
+			url "https://maven.google.com/"
+		}
 	}
 	
 	dependencies {
@@ -18,5 +21,5 @@ android {
 }
 
 dependencies {
-	compile project(':deps:extension-api')
+	api project(':deps:extension-api')
 }

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -236,25 +236,35 @@ class AndroidPlatform extends PlatformTarget
 
 	public override function install():Void
 	{
-		var build = "-debug";
+		var build = "debug";
 
 		if (project.keystore != null)
 		{
-			build = "-release";
+			build = "release";
+		}
+		
+		if (project.environment.exists("ANDROID_GRADLE_TASK"))
+		{
+			var task = project.environment.get("ANDROID_GRADLE_TASK");
+			if ( task == "assembleDebug" ) {
+			  build = "debug";
+			} else {
+			  build = "release";
+			}
 		}
 
 		var outputDirectory = null;
 
 		if (project.config.exists("android.gradle-build-directory"))
 		{
-			outputDirectory = Path.combine(project.config.getString("android.gradle-build-directory"), project.app.file + "/app/outputs/apk");
+			outputDirectory = Path.combine(project.config.getString("android.gradle-build-directory"), project.app.file + "/app/outputs/apk/"+build);
 		}
 		else
 		{
-			outputDirectory = Path.combine(FileSystem.fullPath(targetDirectory), "bin/app/build/outputs/apk");
+			outputDirectory = Path.combine(FileSystem.fullPath(targetDirectory), "bin/app/build/outputs/apk/"+build);
 		}
 
-		var apkPath = Path.combine(outputDirectory, project.app.file + build + ".apk");
+		var apkPath = Path.combine(outputDirectory, project.app.file + "-" + build + ".apk");
 
 		deviceID = AndroidHelper.install(project, apkPath, deviceID);
 	}
@@ -371,8 +381,9 @@ class AndroidPlatform extends PlatformTarget
 			"android.permission.VIBRATE",
 			"android.permission.ACCESS_NETWORK_STATE"
 		]);
-		context.ANDROID_GRADLE_VERSION = project.config.getString("android.gradle-version", "2.10");
-		context.ANDROID_GRADLE_PLUGIN = project.config.getString("android.gradle-plugin", "2.1.0");
+		context.ANDROID_GRADLE_VERSION = project.config.getString("android.gradle-version", "5.6.3");
+		context.ANDROID_GRADLE_PLUGIN = project.config.getString("android.gradle-plugin", "3.5.1");
+
 		context.ANDROID_LIBRARY_PROJECTS = [];
 
 		if (!project.environment.exists("ANDROID_SDK") || !project.environment.exists("ANDROID_NDK_ROOT"))


### PR DESCRIPTION
This pull request will update to the gradle 5.6.3 and gradle android plugin 3.5.1 ( as default) .
  Also there some fix for  ANDROID_GRADLE_TASK .
 From gradle 4.x each apk file is in separate folder ( debug/ , release/ , etc) , so this is also fixed .
 In build.gradle "compile" is not supported anymore, so it was replaced with api ( or implementation)