### PR TITLE
Add `failIfMajorPerformanceCaveat` option

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -284,7 +284,8 @@ class HTML5Window
 						depth: Reflect.hasField(contextAttributes, "depth") ? contextAttributes.depth : true,
 						premultipliedAlpha: true,
 						stencil: Reflect.hasField(contextAttributes, "stencil") ? contextAttributes.stencil : false,
-						preserveDrawingBuffer: false
+						preserveDrawingBuffer: false,
+						failIfMajorPerformanceCaveat: true
 					};
 
 				var glContextType = ["webgl", "experimental-webgl"];


### PR DESCRIPTION
This option is also [used in pixi.js](https://github.com/pixijs/pixi.js/blob/824b8d20ecbacad0c80d82a002009aded7f62ab1/packages/utils/src/browser/isWebGLSupported.js#L16) do detect is WebGL is supported

See https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2.1 for description:
If the value is true, context creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than that of a native application making equivalent OpenGL calls. This could happen for a number of reasons, including:
* An implementation might switch to a software rasterizer if the user's GPU driver is known to be unstable.
* An implementation might require reading back the framebuffer from GPU memory to system memory before compositing it with the rest of the page, significantly reducing performance. 

Applications that don't require high performance should leave this parameter at its default value of false. Applications that require high performance may set this parameter to true, and if context creation fails then the application may prefer to use a fallback rendering path such as a 2D canvas context. Alternatively the application can retry WebGL context creation with this parameter set to false, with the knowledge that a reduced-fidelity rendering mode should be used to improve performance.