### PR TITLE
WIP: Trying to fix support for unicode text for native targets

### DIFF
--- a/project/src/text/harfbuzz/HarfbuzzBindings.cpp
+++ b/project/src/text/harfbuzz/HarfbuzzBindings.cpp
@@ -258,7 +258,7 @@ namespace lime {
 
 	void lime_hb_buffer_add_utf8 (value buffer, HxString text, int itemOffset, int itemLength) {
 
-		hb_buffer_add_utf8 ((hb_buffer_t*)val_data (buffer), text.c_str (), text.length, itemOffset, itemLength);
+		hb_buffer_add_utf8 ((hb_buffer_t*)val_data (buffer), hxs_utf8 (text, 0), text.length, itemOffset, itemLength);
 
 	}
 
@@ -696,7 +696,7 @@ namespace lime {
 
 	int lime_hb_buffer_serialize_format_from_string (HxString str) {
 
-		return hb_buffer_serialize_format_from_string (str.c_str (), str.length);
+		return hb_buffer_serialize_format_from_string (hxs_utf8 (str, 0), str.length);
 
 	}
 
@@ -1097,7 +1097,7 @@ namespace lime {
 
 		hb_feature_t feature;
 
-		if (hb_feature_from_string (str.c_str (), str.length, &feature)) {
+		if (hb_feature_from_string (hxs_utf8 (str, 0), str.length, &feature)) {
 
 			// TODO;
 			return alloc_null ();
@@ -1370,7 +1370,7 @@ namespace lime {
 
 		hb_codepoint_t glyph = 0;
 
-		if (hb_font_glyph_from_string ((hb_font_t*)val_data (font), s.c_str (), s.length, &glyph)) {
+		if (hb_font_glyph_from_string ((hb_font_t*)val_data (font), hxs_utf8 (s, 0), s.length, &glyph)) {
 
 			return glyph;
 
@@ -1558,7 +1558,7 @@ namespace lime {
 
 	value lime_hb_language_from_string (HxString str) {
 
-		hb_language_t language = hb_language_from_string (str.c_str (), str.length);
+		hb_language_t language = hb_language_from_string (hxs_utf8 (str, 0), str.length);
 		return CFFIPointer ((void*)language);
 
 	}


### PR DESCRIPTION
## WORK IN PROGRESS, DO NOT MERGE

Currently, it seems that support for non-ASCII text is broken when using the latest versions of Haxe 4, Lime, and OpenFl.

- Haxe - 4.0.5
- Lime - latest from `develop` branch
- OpenFl - 8.9.6
- hxcpp - 4.0.64
- Target - mac or android, probably windows, linux and ios are affected too

### Before fix

**[just lime] TextRendering sample from lime-samples (mac):**
![Screen Shot 2020-04-06 at 10 04 02](https://user-images.githubusercontent.com/85473/78548309-45d75480-7809-11ea-8071-dde3313fea59.png)

**[openfl + lime] Some random game (android):**
![photo_2020-04-06_13-18-53](https://user-images.githubusercontent.com/85473/78548272-322bee00-7809-11ea-9c21-8efcd48a073a.jpg)

I tried to figure this out and found out that `HxString` may contain data with different encodings. I tried to change `c_str()` to `hxs_utf8()` in the `HarfbuzzBindings.cpp`, and I thought it might help (at least if I print them using `printf()`, the console will show the correct lines). However, there's something else I haven't found yet.

### After fix

**[just lime] TextRendering sample from lime-samples (mac):**
![Screen Shot 2020-04-06 at 13 10 50](https://user-images.githubusercontent.com/85473/78548654-cc8c3180-7809-11ea-9306-1a0961588933.png)

I don't know Arabic or Chinese, but the Russian text I added is cut in the middle. The correct text should be: `Съешь же ещё этих мягких французских булок да выпей чаю.`.

**[openfl + lime] Some random game (android):**
![photo_2020-04-06_13-24-58](https://user-images.githubusercontent.com/85473/78548867-1d9c2580-780a-11ea-95f8-2448b89cc674.jpg)

OpenFl gives a more weird result. It removes all spaces and cuts off individual words. For example instead of `Узнай больше` it renders `Узнбол` (`Узн` + `бол`)