### PR TITLE
Fix "adb devices" stdout redirection to file

### DIFF
--- a/src/lime/tools/AndroidHelper.hx
+++ b/src/lime/tools/AndroidHelper.hx
@@ -305,7 +305,7 @@ class AndroidHelper
 		{
 			var tempFile = System.getTemporaryFile();
 
-			System.runCommand(adbPath, adbName, ["devices", ">", tempFile], true, true);
+			System.runCommand('/bin', 'sh',  ["-c", '${adbPath}${adbName} devices > ${tempFile}'], true, true);
 
 			if (FileSystem.exists(tempFile))
 			{

--- a/src/lime/tools/AndroidHelper.hx
+++ b/src/lime/tools/AndroidHelper.hx
@@ -303,20 +303,14 @@ class AndroidHelper
 
 		if (System.hostPlatform != WINDOWS)
 		{
-			var tempFile = System.getTemporaryFile();
-
-			System.runCommand('/bin', 'sh',  ["-c", '${adbPath}${adbName} devices > ${tempFile}'], true, true);
-
-			if (FileSystem.exists(tempFile))
-			{
-				output = File.getContent(tempFile);
-				FileSystem.deleteFile(tempFile);
-			}
+			/*
+			 * using System.runProcess on *NIX platforms for `adb devices` usually
+			 * hangs when adb also starts the server.
+			 * To avoid this, we start the server beforehand
+			 */
+			System.runCommand(adbPath, adbName, ["start-server"], true);
 		}
-		else
-		{
-			output = System.runProcess(adbPath, adbName, ["devices"], true, true);
-		}
+		output = System.runProcess(adbPath, adbName, ["devices"], true, true);
 
 		if (output != null && output != "")
 		{


### PR DESCRIPTION
The current implementation does not correctly work on non-Windows platforms because the `>` redirection operator must be interpreted by a shell, while the `System.runCommand()` function runs the command directly on the system with no shell involved.
This enables the stdout redirection used in `AndroidHelper.listDevices()` to work on non-Windows platforms too.

Tested on a Linux system running Haxe-4.2.1. If anyone could test it on a MacOS system too that would be useful.

PS: can anyone explain me why there's the need to redirect the command output to file in the first place, instead of reading it back as a String like the Windows codepath does?