### PR TITLE
make html5 behavior of onDropFile same as native

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -14,6 +14,7 @@ import js.html.MouseEvent;
 import js.html.Node;
 import js.html.TextAreaElement;
 import js.html.TouchEvent;
+import js.html.URL;
 import js.html.ClipboardEvent;
 import js.Browser;
 import lime._internal.graphics.ImageCanvasUtil;
@@ -444,7 +445,7 @@ class HTML5Window
 				{
 					for (file in event.dataTransfer.files)
 					{
-						parent.onDropFile.dispatch(js.html.URL.createObjectURL(file));
+						parent.onDropFile.dispatch(URL.createObjectURL(file));
 					}
 					event.preventDefault();
 					return false;

--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -442,7 +442,10 @@ class HTML5Window
 				// TODO: Create a formal API that supports HTML5 file objects
 				if (event.dataTransfer != null && event.dataTransfer.files.length > 0)
 				{
-					parent.onDropFile.dispatch(cast event.dataTransfer.files);
+					for (file in event.dataTransfer.files)
+					{
+						parent.onDropFile.dispatch(js.html.URL.createObjectURL(file));
+					}
 					event.preventDefault();
 					return false;
 				}


### PR DESCRIPTION
**onDropFile** is dispatched for each files on native with the full path of the file as a parameter.
But in html5 it is only dispatched once with a FileList as a parameter which is an array.
Also this array doesn't give the full path, it is mandatory to call` js.html.URL.createObjectURL(file)` to get the full path.

So this commit allows to make the behavior across targets consistent.
Now `onDropFile `in the html5 target  is dispatched for each files and the full path is passed as a parameter like in the native target.