### PR TITLE
Add support for include.hxp.

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -540,37 +540,48 @@ class HXProject extends Script
 		return HXProject.fromPath(path, userDefines);
 	}
 
-	public static function fromPath(path:String, userDefines:Map<String, Dynamic> = null):HXProject
+	public static function fromPath(directory:String, userDefines:Map<String, Dynamic> = null):HXProject
 	{
-		if (!FileSystem.exists(path) || !FileSystem.isDirectory(path))
+		if (!FileSystem.exists(directory) || !FileSystem.isDirectory(directory))
 		{
 			return null;
 		}
 
-		var files = ["include.lime", "include.nmml", "include.xml"];
+		var files = ["include.lime", "include.nmml", "include.xml", "include.hxp"];
 		var projectFile = null;
 
 		for (file in files)
 		{
-			if (projectFile == null && FileSystem.exists(Path.combine(path, file)))
+			if (FileSystem.exists(Path.combine(directory, file)))
 			{
-				projectFile = Path.combine(path, file);
+				projectFile = Path.combine(directory, file);
+				break;
 			}
 		}
+
+		var project = null;
 
 		if (projectFile != null)
 		{
-			var project = new ProjectXMLParser(projectFile, userDefines);
+			if (StringTools.endsWith(projectFile, ".hxp"))
+			{
+				var cwd = Sys.getCwd();
+				Sys.setCwd(directory);
+				project = HXProject.fromFile(projectFile, userDefines);
+				Sys.setCwd(cwd);
+			}
+			else
+			{
+				project = new ProjectXMLParser(projectFile, userDefines);
+			}
 
 			if (project.config.get("project.rebuild.path") == null)
 			{
-				project.config.set("project.rebuild.path", Path.combine(path, "project"));
+				project.config.set("project.rebuild.path", Path.combine(directory, "project"));
 			}
-
-			return project;
 		}
 
-		return null;
+		return project;
 	}
 
 	private function getHaxelibVersion(haxelib:Haxelib):String

--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1179,7 +1179,7 @@ class CommandLineTools
 					if ((extension == "lime" && file != "include.lime")
 						|| (extension == "nmml" && file != "include.nmml")
 						|| (extension == "xml" && file != "include.xml")
-						|| extension == "hxp")
+						|| (extension == "hxp" && file != "include.hxp"))
 					{
 						matches.get(extension).push(path);
 					}


### PR DESCRIPTION
I think I've mentioned before how included projects can't always get the data they need, and it came up again in #1486. It's incredibly easy to get the architectures in an HXP project, but there's just no way in XML, nor is there an elegant way to add support.

There's one issue to be aware of here: all paths in include.hxp will be relative to the main project, which is practically guaranteed to break local paths. So, you have to type out `Sys.getCwd() + "local/path"` each time. Not a deal-breaker, just something people will have to be aware of.

Oh yeah, I refactored a few things while I was at it. IMO, the whole function should have been named `fromDirectory()` in the first place, because otherwise it sounds the same as `fromFile()`. It's a little late to change that now, so I'll settle for making the arguments more explicit.