### PR TITLE
Don't expect Android extensions to use ndlls

### DIFF
--- a/templates/extension/include.xml
+++ b/templates/extension/include.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project>
 	
-	<ndll name="::extensionLowerCase::" />
+	<ndll name="::extensionLowerCase::" unless="android" />
 	
 	<!-- Use the following for an Android Java extension, not needed otherwise -->
 	


### PR DESCRIPTION
I can't think of any practical reasons for an Android extension to compile an ndll. All of Android's system functions require Java, not C++, and you can get the speed of C++ just by writing Haxe code.

I surveyed several Android extensions on lib.haxe.org, and not one of them used ndlls when targeting Android.