### PR TITLE
Add HTML5 support to `BackgroundWorker` and `ThreadPool`

### DIFF
--- a/docs/hxml/html5.hxml
+++ b/docs/hxml/html5.hxml
@@ -4,6 +4,7 @@
 -D html5
 -D doc_gen
 -D lime-doc-gen
+-D force_synchronous
 ImportAll
 -lib lime
 --no-output

--- a/include.xml
+++ b/include.xml
@@ -59,6 +59,7 @@
 
 	<haxedef name="force_synchronous" if="emscripten || display" />
 	<haxedef name="force_synchronous" if="html5" unless="lime-web-workers" />
+	<haxeflag name="--macro" value="lime.system.ThreadBase.processOutput()" if="html5" unless="force_synchronous" />
 
 	<section if="hxp" unless="lime-tools">
 

--- a/include.xml
+++ b/include.xml
@@ -58,6 +58,7 @@
 	<haxelib name="lime-console-pc" if="console-pc" />
 
 	<haxedef name="force_synchronous" if="emscripten || display" />
+	<haxedef name="force_synchronous" if="html5" unless="lime-web-workers" />
 
 	<section if="hxp" unless="lime-tools">
 

--- a/include.xml
+++ b/include.xml
@@ -57,6 +57,8 @@
 	<target name="console-pc" handler="lime-console-pc" />
 	<haxelib name="lime-console-pc" if="console-pc" />
 
+	<haxedef name="force_synchronous" if="emscripten || display" />
+
 	<section if="hxp" unless="lime-tools">
 
 		<target name="air" path="tools/platforms/AIRPlatform.hx" />

--- a/src/lime/app/Future.hx
+++ b/src/lime/app/Future.hx
@@ -328,7 +328,7 @@ import lime.utils.Log;
 	private static var promises:Map<Int, Promise<Dynamic>>;
 
 	@:allow(lime.app.Future)
-	private static function queue<T>(promise:Promise<T>, work:ThreadFunction<() -> T>):Void
+	private static function queue<T>(promise:Promise<T>, work:ThreadFunction<Void -> T>):Void
 	{
 		if (threadPool == null)
 		{
@@ -345,7 +345,7 @@ import lime.utils.Log;
 	}
 
 	// Event Handlers
-	private static function threadPool_doWork(state:{ id:Int, work:ThreadFunction<() -> Dynamic> }):Void
+	private static function threadPool_doWork(state:{ id:Int, work:ThreadFunction<Void -> Dynamic> }):Void
 	{
 		try
 		{

--- a/src/lime/app/Future.hx
+++ b/src/lime/app/Future.hx
@@ -317,11 +317,14 @@ import lime.utils.Log;
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
-@:dox(hide) private class FutureWork
+@:dox(hide) class FutureWork
 {
 	private static var threadPool:ThreadPool;
+	public static var minThreads(get, set):Int;
+	public static var maxThreads(get, set):Int;
 
-	public static function queue(state:Dynamic = null):Void
+	@:allow(lime.app.Future)
+	private static function queue(state:Dynamic = null):Void
 	{
 		if (threadPool == null)
 		{
@@ -356,5 +359,26 @@ import lime.utils.Log;
 	private static function threadPool_onError(state:Dynamic):Void
 	{
 		state.promise.error(state.error);
+	}
+
+	// Getters & Setters
+	@:noCompletion private static inline function get_minThreads():Int
+	{
+		return threadPool.minThreads;
+	}
+
+	@:noCompletion private static inline function set_minThreads(value:Int):Int
+	{
+		return threadPool.minThreads = value;
+	}
+
+	@:noCompletion private static inline function get_maxThreads():Int
+	{
+		return threadPool.maxThreads;
+	}
+
+	@:noCompletion private static inline function set_maxThreads(value:Int):Int
+	{
+		return threadPool.maxThreads = value;
 	}
 }

--- a/src/lime/media/AudioBuffer.hx
+++ b/src/lime/media/AudioBuffer.hx
@@ -333,7 +333,7 @@ class AudioBuffer
 			promise.error(null);
 		}
 		#else
-		promise.completeWith(new Future<AudioBuffer>(function() return fromFiles(paths), true));
+		promise.completeWith(new Future<AudioBuffer>(function() return fromFiles(paths), #if js false #else true #end));
 		#end
 
 		return promise.future;

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -179,6 +179,8 @@ class BackgroundWorker
 		{
 			__worker.terminate();
 			__worker = null;
+			URL.revokeObjectURL(__workerURL);
+			__workerURL = null;
 		}
 		#end
 	}
@@ -209,6 +211,7 @@ class BackgroundWorker
 			"this.onmessage = function(messageEvent) {\n"
 			+ "    this.onmessage = null;\n"
 			+ '    (async ${doWork.toString()})(messageEvent.data);\n'
+			+ "    this.close();\n"
 			+ "};";
 
 		__workerURL = URL.createObjectURL(new Blob([workerJS]));
@@ -358,12 +361,18 @@ class BackgroundWorker
 		{
 			canceled = true;
 			onError.dispatch(event.data.message);
+
+			URL.revokeObjectURL(__workerURL);
+			__workerURL = null;
 		}
 		else if (event.data.event == MESSAGE_COMPLETE)
 		{
 			completed = true;
 			canceled = true;
 			onComplete.dispatch(event.data.message);
+
+			URL.revokeObjectURL(__workerURL);
+			__workerURL = null;
 		}
 		else
 		{

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -238,9 +238,12 @@ class BackgroundWorker
 			// have to use implicit casts or type hints.
 		}
 
+		doWork.fixCommonJSErrors();
+
 		var workerJS:String =
 			"this.onmessage = function(messageEvent) {\n"
 			+ "    this.onmessage = null;\n"
+			+ "    var haxe_Log = { trace: console.log };\n"
 			+ '    (async $doWork)(messageEvent.data);\n'
 			+ "    this.close();\n"
 			+ "};";
@@ -490,7 +493,15 @@ abstract ThreadFunction(String) to String
 		this = null;
 	}
 
-	#if !js
+	#if js
+	@:noCompletion @:dox(hide) public inline function fixCommonJSErrors():Void
+	{
+		// Without analyzer-optimize, there's likely to be
+		// an unused reference to outside code.
+		this = cast ~/var _g?this = .+?;\s*postMessage/gm
+			.replace(this, "postMessage");
+	}
+	#else
 	public inline function bind(arg)
 	{
 		return this.bind(arg);

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -244,7 +244,7 @@ class BackgroundWorker
 			"this.onmessage = function(messageEvent) {\n"
 			+ "    this.onmessage = null;\n"
 			+ "    var haxe_Log = { trace: console.log };\n"
-			+ '    (async $doWork)(messageEvent.data);\n'
+			+ '    ($doWork)(messageEvent.data);\n'
 			+ "    this.close();\n"
 			+ "};";
 

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -400,26 +400,25 @@ class BackgroundWorker
 	/**
 		[Call this from the main thread.]
 
-		Creates the background thread.
+		Creates a background thread to run `doWork`. The
+		function will receive `message` as an argument, and
+		it can call `sendComplete()`, `sendError()`, and/or
+		`sendProgress()` to send data.
 
-		@param doWork A `Dynamic -> Void` function to run in
-		the background. It will receive `message` as its one
-		argument, and it can call `sendComplete()`,
-		`sendError()`, and/or `sendProgress()` to send data.
-
-		Caution: in HTML5, workers are almost completely
+		**Caution:** in HTML5, workers are almost completely
 		isolated from the main thread. They will have
 		access to three main things: (1) certain JavaScript
 		functions (see `DedicatedWorkerGlobalScope`), (2)
 		inline Haxe functions (including all three "send"
 		functions), and (3) the contents of `message`. To
 		inline as much as possible, turn on DCE and tag the
-		function with &commat;`:analyzer(optimize)`.
-
-		@param message (Optional) Data to pass to `doWork`.
+		function with `@:analyzer(optimize)`.
+		@param doWork A `Dynamic -> Void` function to run in
+		the background. (Optional only for backwards
+		compatibility. Treat this as a required argument.)
+		@param message Data to pass to `doWork`.
 	**/
-	// Don't advertise that `doWork` is optional.
-	public macro function run(self:Expr, doWork:ExprOf<Dynamic -> Void> #if !display = null #end, ?message:Expr):Expr
+	public macro function run(self:Expr, ?doWork:ExprOf<Dynamic -> Void>, ?message:Expr):Expr
 	{
 		#if display
 		return macro null;

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -216,8 +216,8 @@ class BackgroundWorker
 		@param doWork A `Dynamic -> Void` function to run in
 		the background. (Optional only for backwards
 		compatibility. Treat this as a required argument.)
-		@param message Data to pass to `doWork`. In HTML5, this
-		cannot include functions and certain other data types:
+		@param message Data to pass to `doWork`. HTML5
+		imposes several restrictions on this data:
 		https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 	**/
 	public function run(?doWork:ThreadFunction, ?message:Dynamic):Void

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -452,13 +452,13 @@ class BackgroundWorker
 	A single function that offers the same interface as
 	`lime.app.Event`, for backwards compatibility.
 **/
-abstract DoWork(Dynamic -> Void) from Dynamic -> Void to Dynamic -> Void {
+private abstract DoWork(Dynamic -> Void) from Dynamic -> Void to Dynamic -> Void {
 	/**
 		Adds the given callback function, to be run on the
 		other thread. Unlike with `lime.app.Event`, only one
 		callback can exist; `add()` overwrites the old one.
 	**/
-	#if (!js && !macro)
+	#if (display || !js && !macro)
 	public inline function add(callback:Dynamic -> Void):Void
 	{
 		this = callback;

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -37,7 +37,6 @@ class BackgroundWorker
 	#if !macro
 	private static inline var MESSAGE_COMPLETE = "__COMPLETE__";
 	private static inline var MESSAGE_ERROR = "__ERROR__";
-	private static inline var MESSAGE_CANCEL = "__CANCEL__";
 
 	/**
 		Indicates that `cancel()`, `sendComplete()`, or
@@ -419,7 +418,7 @@ class BackgroundWorker
 
 		if (isNull(doWork))
 		{
-			return macro $self.__run();
+			return macro $self.__run(null, null);
 		}
 
 		if (isNull(message))

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -154,7 +154,9 @@ class BackgroundWorker
 	**/
 	@:noCompletion @:dox(hide) public static var initializeWorker:String =
 		"'use strict';\n"
-		+ 'var haxe_Log = { trace: (v, infos) => console.log(infos.fileName + ":" + infos.lineNumber + ": " + v) };\n';
+		+ 'var haxe_Log = { trace: (v, infos) => console.log(infos.fileName + ":" + infos.lineNumber + ": " + v) };\n'
+		+ "var StringTools = { startsWith: (s, start) => s.startsWith(start), endsWith: (s, end) => s.endsWith(end), trim: s => s.trim() };\n"
+		+ "var HxOverrides = { substr: (s, pos, len) => s.substr(pos, len) };\n";
 
 	@:noCompletion private var __worker:Worker;
 	@:noCompletion private var __workerURL:String;

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -251,7 +251,7 @@ class BackgroundWorker
 		__worker.onmessage = __handleMessage;
 		__worker.postMessage(message);
 		#else
-		doWork(message);
+		doWork.dispatch(message);
 		#end
 	}
 

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -197,6 +197,8 @@ class BackgroundWorker
 			return;
 		}
 
+		cancel();
+
 		__runMessage = message;
 
 		#if (target.threaded || cpp || neko)

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -101,7 +101,6 @@ class BackgroundWorker
 	**/
 	public var onProgress = new Event<Dynamic->Void>();
 
-	@:noCompletion private var __alreadyRun:Bool = false;
 	@:noCompletion private var __runMessage:Dynamic;
 	#if (target.threaded || cpp || neko)
 	@:noCompletion private var __messageQueue:Deque<{ ?event:String, message:Dynamic }>;
@@ -148,11 +147,6 @@ class BackgroundWorker
 
 	@:noCompletion @:dox(hide) public function __run(doWork:Dynamic -> Void, message:Dynamic):Void
 	{
-		if (__alreadyRun)
-		{
-			return;
-		}
-
 		if (doWork != null)
 		{
 			this.doWork = doWork;
@@ -163,7 +157,6 @@ class BackgroundWorker
 			return;
 		}
 
-		__alreadyRun = true;
 		__runMessage = message;
 
 		#if (target.threaded || cpp || neko)
@@ -227,6 +220,8 @@ class BackgroundWorker
 	public function sendComplete(message:Dynamic = null):Void
 	{
 		#if (target.threaded || cpp || neko)
+		if (Thread.current() != __workerThread) return;
+
 		if (__messageQueue != null)
 		{
 			__messageQueue.add({
@@ -260,6 +255,8 @@ class BackgroundWorker
 	public function sendError(message:Dynamic = null):Void
 	{
 		#if (target.threaded || cpp || neko)
+		if (Thread.current() != __workerThread) return;
+
 		if (__messageQueue != null)
 		{
 			__messageQueue.add({
@@ -291,6 +288,8 @@ class BackgroundWorker
 	public function sendProgress(message:Dynamic = null):Void
 	{
 		#if (target.threaded || cpp || neko)
+		if (Thread.current() != __workerThread) return;
+
 		if (__messageQueue != null)
 		{
 			__messageQueue.add({

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -204,21 +204,21 @@ class BackgroundWorker
 		it can call `sendComplete()`, `sendError()`, and/or
 		`sendProgress()` to send data.
 
-		**Caution:** in HTML5, workers are almost completely
-		isolated from the main thread. They will have
-		access to three main things: (1) certain JavaScript
-		functions (see `DedicatedWorkerGlobalScope`), (2)
-		inline Haxe functions (including all three "send"
-		functions), and (3) the contents of `message`. To
-		inline as much as possible, turn on DCE and tag the
-		function with `@:analyzer(optimize)`.
+		**Caution:** if web workers are enabled, `doWork`
+		will be almost completely isolated from the main
+		thread. It will have access to three main things:
+		(1) common JavaScript functions, (2) inline
+		variables and functions (including all three "send"
+		functions), and (3) the contents of `message`. For
+		best results, tag your inline functions with the
+		`@:analyzer(optimize)` metadata.
 		@param doWork A `Dynamic -> Void` function to run in
 		the background. (Optional only for backwards
 		compatibility. Treat this as a required argument.)
-		@param message Data to pass to `doWork`. HTML5
-		imposes several restrictions on this data:
+		@param message Data to pass to `doWork`. Web workers
+		impose several restrictions on this data:
 		https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The worker thread will only receive these
 		if they're also included in `message`.
@@ -272,7 +272,7 @@ class BackgroundWorker
 		Dispatches `onComplete` on the main thread, passing
 		`message` along. After completion, all further
 		messages will be ignored.
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The main thread will only receive these
 		if they're also included in `message`.
@@ -312,7 +312,7 @@ class BackgroundWorker
 		Dispatches `onError` on the main thread, passing
 		`message` along. After an error, all further
 		messages will be ignored.
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The main thread will only receive these
 		if they're also included in `message`.
@@ -349,7 +349,7 @@ class BackgroundWorker
 
 		Dispatches `onProgress` on the main thread, passing
 		`message` along.
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The main thread will only receive these
 		if they're also included in `message`. Once

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -1,6 +1,5 @@
 package lime.system;
 
-#if !macro
 import lime.app.Application;
 import lime.app.Event;
 #if target.threaded
@@ -18,13 +17,6 @@ import js.html.MessageEvent;
 import js.html.URL;
 import js.html.Worker;
 import js.Syntax;
-#end
-#else
-import haxe.macro.Compiler;
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import haxe.macro.Type;
-import sys.io.File;
 #end
 
 /**
@@ -94,7 +86,6 @@ import sys.io.File;
 #end
 class BackgroundWorker
 {
-	#if !macro
 	private static inline var MESSAGE_COMPLETE = "__COMPLETE__";
 	private static inline var MESSAGE_ERROR = "__ERROR__";
 
@@ -418,165 +409,6 @@ class BackgroundWorker
 		{
 			onProgress.dispatch(event.data.message);
 		}
-	}
-	#end
-	#end // !macro
-}
-
-/**
-	A `Dynamic -> Void` function to be called on another
-	thread. On most targets, functions work as-is, but JS
-	requires converting to string and back.
-
-	`ThreadFunction` also provides an `Event`-like API for
-	backwards compatibility. However, it can only store one
-	function at once; `add()` overwrites the old function.
-**/
-#if !js
-abstract ThreadFunction<T:haxe.Constraints.Function>(T) from T to T
-#else
-// Excluding "from String" to help `run()` disambiguate.
-abstract ThreadFunction<T>(String) to String
-#end
-{
-	#if (js || macro)
-	private static inline var TAG:String = "/* lime.system.ThreadFunction */";
-	private static var TAG_ESCAPED:String = EReg.escape(TAG);
-
-	// Other macros can call this statically, if needed.
-	@:noCompletion @:dox(hide) #if !macro @:from #end
-	public static #if !macro macro #end function fromFunction(func:ExprOf<haxe.Constraints.Function>)
-	{
-		cleanAfterGenerate();
-		return macro js.Syntax.code($v{TAG + "{0}.toString()" + TAG}, $func);
-	}
-	#end
-
-	/**
-		Adds the given callback function, to be run on the
-		other thread. Unlike with `lime.app.Event`, only one
-		callback can exist; `add()` overwrites the old one.
-	**/
-	public inline function add(callback:ThreadFunction<T>):Void
-	{
-		this = callback;
-	}
-
-	/**
-		Executes this function on the current thread.
-	**/
-	public macro function dispatch(self:Expr, args:Array<Expr>):Expr
-	{
-		if (!Context.defined("js"))
-		{
-			return macro $self != null ? (cast $self:haxe.Constraints.Function)($a{args}) : null;
-		}
-		else
-		{
-			var argSyntax:Array<String> = [for (i in 1...(args.length + 1)) '{$i}'];
-			var syntax:String = 'Function.apply(this, {0})(${argSyntax.join(", ")})';
-			args = [macro $v{syntax}, macro paramsAndBody].concat(args);
-
-			return macro if ($self != null)
-			{
-				var paramsAndBody:Array<String> = js.Syntax.code("/function\\((.+?)\\)\\s*\\{\\s*(.+)\\s*\\}/.exec({0})", $self);
-				if (paramsAndBody == null)
-					js.Syntax.code('throw "Malformatted ThreadFunction: " + {0}', $self);
-
-				var body = paramsAndBody.pop();
-				paramsAndBody = paramsAndBody[1].split(js.Syntax.code("/, */"));
-				paramsAndBody.push(body);
-
-				js.Syntax.code($a{args});
-			}
-			else null;
-		}
-	}
-
-	@:noCompletion @:dox(hide) public inline function has(callback:ThreadFunction<T>):Bool
-	{
-		#if !js
-		return Reflect.compareMethods(this, callback);
-		#else
-		return this == callback;
-		#end
-	}
-
-	@:noCompletion @:dox(hide) public inline function remove(callback:ThreadFunction<T>):Void
-	{
-		if (has(callback))
-		{
-			this = null;
-		}
-	}
-
-	@:noCompletion @:dox(hide) public inline function removeAll():Void
-	{
-		this = null;
-	}
-
-	#if js
-	/**
-		Makes sure the JS string is suitable for making a
-		`Worker`. Fixes issues when possible and throws
-		errors if not.
-	**/
-	@:noCompletion @:dox(hide) public inline function checkJS():Void
-	{
-		if (this.indexOf("[native code]") >= 0)
-		{
-			throw "Haxe automatically binds instance functions in JS, making them incompatible with js.html.Worker. ThreadFunction tries to remove this binding; the sooner you convert to ThreadFunction, the more likely it will work. Failing that, try a static function.";
-			// Addendum: explicit casts will NOT work. You
-			// have to use implicit casts or type hints.
-		}
-
-		// Without analyzer-optimize, there's likely to be
-		// an unused reference to outside code.
-		this = cast ~/var _g?this = .+?;\s*(.+?postMessage)/gs
-			.replace(this, "$1");
-	}
-	#end
-
-	#if macro
-	private static var callbacksRegistered:Bool = false;
-
-	#if !haxe4
-	private static function resetCallbacksRegistered():Bool
-	{
-		callbacksRegistered = false;
-		return true;
-	}
-	#end
-
-	/**
-		Adds an `onAfterGenerate()` listener to read the JS
-		file and clean up any bound functions.
-	**/
-	private static function cleanAfterGenerate():Void
-	{
-		if (callbacksRegistered || !Context.defined("js") || Context.defined("display"))
-		{
-			return;
-		}
-		callbacksRegistered = true;
-
-		#if !haxe4
-		Context.onMacroContextReused(resetCallbacksRegistered);
-		#end
-
-		#if !lime_suppress_onAfterGenerate
-		Context.onAfterGenerate(function():Void
-		{
-			var outputFile:String = Compiler.getOutput();
-			var outputContent:String = File.getContent(outputFile);
-
-			outputContent = new EReg(TAG_ESCAPED + "\\$bind\\(this,(.+?)\\)\\.toString\\(\\)" + TAG_ESCAPED, "gm")
-				.replace(outputContent, "$1.toString()");
-			outputContent = new EReg(TAG_ESCAPED, "g").replace(outputContent, "");
-
-			File.saveContent(outputFile, outputContent);
-		});
-		#end
 	}
 	#end
 }

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -438,7 +438,7 @@ abstract ThreadFunction(String) to String
 {
 	#if (js || macro)
 	private static inline var TAG:String = "/* lime.system.ThreadFunction */";
-	private static var TAG_ESCAPED:String = ~/([\/\*])/g.replace(TAG, "\\$1");
+	private static var TAG_ESCAPED:String = EReg.escape(TAG);
 
 	// Other macros can call this statically, if needed.
 	@:noCompletion @:dox(hide) #if !macro @:from #end
@@ -558,7 +558,7 @@ abstract ThreadFunction(String) to String
 
 			outputContent = new EReg(TAG_ESCAPED + "\\$bind\\(this,(.+?)\\)\\.toString\\(\\)" + TAG_ESCAPED, "gm")
 				.replace(outputContent, "$1.toString()");
-				outputContent = new EReg(TAG_ESCAPED, "g").replace(outputContent, "");
+			outputContent = new EReg(TAG_ESCAPED, "g").replace(outputContent, "");
 
 			File.saveContent(outputFile, outputContent);
 		});

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -424,7 +424,7 @@ class BackgroundWorker
 		inline Haxe functions (including all three "send"
 		functions), and (3) the contents of `message`. To
 		inline as much as possible, turn on DCE and tag the
-		function with `@:analyzer(optimize)`.
+		function with &commat;`:analyzer(optimize)`.
 
 		@param message (Optional) Data to pass to `doWork`.
 	**/

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -68,12 +68,12 @@ class BackgroundWorker
 
 	public function sendComplete(message:Dynamic = null):Void
 	{
-		completed = true;
-
 		#if (target.threaded || cpp || neko)
 		__messageQueue.add(MESSAGE_COMPLETE);
 		__messageQueue.add(message);
 		#else
+		completed = true;
+
 		if (!canceled)
 		{
 			canceled = true;
@@ -147,6 +147,7 @@ class BackgroundWorker
 			}
 			else if (message == MESSAGE_COMPLETE)
 			{
+				completed = true;
 				Application.current.onUpdate.remove(__update);
 
 				if (!canceled)

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -369,7 +369,7 @@ class BackgroundWorker
 			}
 			else if (data.event == MESSAGE_COMPLETE)
 			{
-				complete = true;
+				completed = true;
 				cancel();
 				onComplete.dispatch(data.message);
 			}

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -431,6 +431,9 @@ class BackgroundWorker
 	// Don't advertise that `doWork` is optional.
 	public macro function run(self:Expr, doWork:ExprOf<Dynamic -> Void> #if !display = null #end, ?message:Expr):Expr
 	{
+		#if display
+		return macro null;
+		#else
 		function isNull(expr:Expr)
 		{
 			switch(expr.expr)
@@ -470,6 +473,7 @@ class BackgroundWorker
 
 			$self.__run(doWork, $message);
 		}
+		#end
 	}
 }
 

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -401,7 +401,9 @@ class BackgroundWorker
 		@param doWork A `Dynamic -> Void` function to run in
 		the background. (Optional only for backwards
 		compatibility. Treat this as a required argument.)
-		@param message Data to pass to `doWork`.
+		@param message Data to pass to `doWork`. In HTML5, this
+		cannot include functions and certain other data types:
+		https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 	**/
 	public macro function run(self:Expr, ?doWork:ExprOf<Dynamic -> Void>, ?message:Expr):Expr
 	{

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -2,8 +2,7 @@ package lime.system;
 
 import lime.app.Application;
 import lime.app.Event;
-#if sys
-#if haxe4
+#if target.threaded
 import sys.thread.Deque;
 import sys.thread.Thread;
 #elseif cpp
@@ -12,7 +11,6 @@ import cpp.vm.Thread;
 #elseif neko
 import neko.vm.Deque;
 import neko.vm.Thread;
-#end
 #end
 #if !lime_debug
 @:fileXml('tags="haxe,release"')
@@ -31,7 +29,7 @@ class BackgroundWorker
 	public var onProgress = new Event<Dynamic->Void>();
 
 	@:noCompletion private var __runMessage:Dynamic;
-	#if (cpp || neko)
+	#if (target.threaded || cpp || neko)
 	@:noCompletion private var __messageQueue:Deque<Dynamic>;
 	@:noCompletion private var __workerThread:Thread;
 	#end
@@ -42,7 +40,7 @@ class BackgroundWorker
 	{
 		canceled = true;
 
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		__workerThread = null;
 		#end
 	}
@@ -53,7 +51,7 @@ class BackgroundWorker
 		completed = false;
 		__runMessage = message;
 
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		__messageQueue = new Deque<Dynamic>();
 		__workerThread = Thread.create(__doWork);
 
@@ -72,7 +70,7 @@ class BackgroundWorker
 	{
 		completed = true;
 
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		__messageQueue.add(MESSAGE_COMPLETE);
 		__messageQueue.add(message);
 		#else
@@ -86,7 +84,7 @@ class BackgroundWorker
 
 	public function sendError(message:Dynamic = null):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		__messageQueue.add(MESSAGE_ERROR);
 		__messageQueue.add(message);
 		#else
@@ -100,7 +98,7 @@ class BackgroundWorker
 
 	public function sendProgress(message:Dynamic = null):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		__messageQueue.add(message);
 		#else
 		if (!canceled)
@@ -114,7 +112,7 @@ class BackgroundWorker
 	{
 		doWork.dispatch(__runMessage);
 
-		// #if (cpp || neko)
+		// #if (target.threaded || cpp || neko)
 		//
 		// __messageQueue.add (MESSAGE_COMPLETE);
 		//
@@ -132,7 +130,7 @@ class BackgroundWorker
 
 	@:noCompletion private function __update(deltaTime:Int):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		var message = __messageQueue.pop(false);
 
 		if (message != null)

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -254,7 +254,6 @@ class BackgroundWorker
 			"this.onmessage = function(messageEvent) {\n",
 			"    this.onmessage = null;\n",
 			'    ($doWork)(messageEvent.data);\n',
-			"    this.close();\n",
 			"};"
 		]));
 
@@ -415,20 +414,14 @@ class BackgroundWorker
 		}
 		else if (event.data.event == MESSAGE_ERROR)
 		{
-			canceled = true;
+			cancel();
 			onError.dispatch(event.data.message);
-
-			URL.revokeObjectURL(__workerURL);
-			__workerURL = null;
 		}
 		else if (event.data.event == MESSAGE_COMPLETE)
 		{
 			completed = true;
-			canceled = true;
+			cancel();
 			onComplete.dispatch(event.data.message);
-
-			URL.revokeObjectURL(__workerURL);
-			__workerURL = null;
 		}
 		else
 		{

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -252,7 +252,7 @@ class BackgroundWorker extends ThreadBase
 
 	#if (!js || force_synchronous)
 	@:inheritDoc
-	public function sendError(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
+	public override function sendError(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)
 		if (Thread.current() == __workerThread)
@@ -271,7 +271,7 @@ class BackgroundWorker extends ThreadBase
 
 	#if (!js || force_synchronous)
 	@:inheritDoc
-	public function sendProgress(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
+	public override function sendProgress(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)
 		if (Thread.current() != __workerThread)
@@ -294,19 +294,19 @@ class BackgroundWorker extends ThreadBase
 
 		if (threadEvent != null)
 		{
-			switch (threadEvent.type)
+			switch (threadEvent.event)
 			{
 				case ERROR:
 					cancel();
-					onError.dispatch(data.message);
+					onError.dispatch(threadEvent.message);
 
 				case COMPLETE:
 					completed = true;
 					cancel();
-					onComplete.dispatch(data.message);
+					onComplete.dispatch(threadEvent.message);
 
 				case PROGRESS:
-					onProgress.dispatch(data.message);
+					onProgress.dispatch(threadEvent.message);
 
 				default:
 			}

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -470,7 +470,7 @@ class BackgroundWorker
 	A single function that offers the same interface as
 	`lime.app.Event`, for backwards compatibility.
 **/
-private abstract DoWork(Dynamic -> Void) from Dynamic -> Void to Dynamic -> Void {
+abstract DoWork(Dynamic -> Void) from Dynamic -> Void to Dynamic -> Void {
 	/**
 		Adds the given callback function, to be run on the
 		other thread. Unlike with `lime.app.Event`, only one

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -64,6 +64,8 @@ class BackgroundWorker
 		canceled = true;
 
 		#if (target.threaded || cpp || neko)
+		Application.current.onUpdate.remove(__update);
+
 		if (__workerThread != null)
 		{
 			// Canceling `doWork` causes the background

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -117,7 +117,7 @@ class BackgroundWorker
 	**/
 	public var completed(default, null):Bool;
 
-	@:noCompletion public var doWork(default, null):DoWork;
+	@:noCompletion public var doWork(default, null):ThreadFunction;
 
 	/**
 		Dispatched on the main thread when the background
@@ -185,7 +185,7 @@ class BackgroundWorker
 		#end
 	}
 
-	@:noCompletion @:dox(hide) public function __run(doWork:DoWork, message:Dynamic):Void
+	@:noCompletion @:dox(hide) public function __run(doWork:ThreadFunction, message:Dynamic):Void
 	{
 		if (doWork == null)
 		{
@@ -443,7 +443,7 @@ class BackgroundWorker
 
 			// Set `doWork = $doWork`, with some extra
 			// JS-specific checks.
-			${DoWork.add(macro doWork, doWork)};
+			${ThreadFunction.add(macro doWork, doWork)};
 
 			$self.__run(doWork, $message);
 		}
@@ -452,10 +452,16 @@ class BackgroundWorker
 }
 
 /**
-	A single function that offers the same interface as
-	`lime.app.Event`, for backwards compatibility.
+	A function that can be called on another thread. In
+	JavaScript, calling a function on another thread
+	requires extra work, which is performed automatically.
+
+	`ThreadFunction` also provides an `Event`-like API for
+	backwards compatibility. However, it can only store one
+	function at once; `add()` overwrites the old function.
 **/
-abstract DoWork(Dynamic -> Void) from Dynamic -> Void to Dynamic -> Void {
+abstract ThreadFunction(Dynamic -> Void) from Dynamic -> Void to Dynamic -> Void
+{
 	/**
 		Adds the given callback function, to be run on the
 		other thread. Unlike with `lime.app.Event`, only one

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -193,6 +193,7 @@ class BackgroundWorker
 		}
 
 		cancel();
+		canceled = false;
 
 		#if (target.threaded || cpp || neko)
 		__messageQueue = new Deque();

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -18,8 +18,8 @@ import neko.vm.Thread;
 #end
 class BackgroundWorker
 {
-	private static var MESSAGE_COMPLETE = "__COMPLETE__";
-	private static var MESSAGE_ERROR = "__ERROR__";
+	private static inline var MESSAGE_COMPLETE = "__COMPLETE__";
+	private static inline var MESSAGE_ERROR = "__ERROR__";
 
 	public var canceled(default, null):Bool;
 	public var completed(default, null):Bool;

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -218,8 +218,12 @@ class BackgroundWorker
 		@param message Data to pass to `doWork`. HTML5
 		imposes several restrictions on this data:
 		https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+		@param transferList (JavaScript only) Zero or more
+		buffers to transfer using an efficient zero-copy
+		operation. The worker thread will only receive these
+		if they're also included in `message`.
 	**/
-	public function run(?doWork:ThreadFunction<Dynamic->Void>, ?message:Dynamic):Void
+	public function run(?doWork:ThreadFunction<Dynamic->Void>, ?message:Dynamic, transferList:Array<ArrayBuffer> = null):Void
 	{
 		if (doWork == null)
 		{
@@ -256,7 +260,7 @@ class BackgroundWorker
 
 		__worker = new Worker(__workerURL);
 		__worker.onmessage = __handleMessage;
-		__worker.postMessage(message);
+		__worker.postMessage(message, transferList);
 		#else
 		doWork.dispatch(message);
 		#end

--- a/src/lime/system/BackgroundWorker.hx
+++ b/src/lime/system/BackgroundWorker.hx
@@ -127,9 +127,9 @@ class BackgroundWorker
 
 		__workerURL = URL.createObjectURL(new Blob([workerJS]));
 
-		__worker = new Worker(workerURL);
-		__worker.postMessage(__runMessage);
+		__worker = new Worker(__workerURL);
 		__worker.onmessage = __handleMessage;
+		__worker.postMessage(__runMessage);
 		#else
 		__doWork();
 		#end

--- a/src/lime/system/ThreadBase.hx
+++ b/src/lime/system/ThreadBase.hx
@@ -129,7 +129,7 @@ class ThreadBase {
 		than copied to the main thread. For details, see
 		https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects
 	**/
-	#if js inline #end
+	#if (js && !force_synchronous) inline #end
 	public function sendComplete(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)
@@ -159,7 +159,7 @@ class ThreadBase {
 		than copied to the main thread. For details, see
 		https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects
 	**/
-	#if js inline #end
+	#if (js && !force_synchronous) inline #end
 	public function sendError(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)
@@ -187,7 +187,7 @@ class ThreadBase {
 		than copied to the main thread. For details, see
 		https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects
 	**/
-	#if js inline #end
+	#if (js && !force_synchronous) inline #end
 	public function sendProgress(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)

--- a/src/lime/system/ThreadBase.hx
+++ b/src/lime/system/ThreadBase.hx
@@ -52,8 +52,9 @@ class ThreadBase {
 			defaultHeaderCode = [
 				'"use strict";',
 				Syntax.code("$extend.toString()"),
-				'var haxe_Log = { trace: (v, infos) => console.log(infos.fileName + ":" + infos.lineNumber + ": " + v) };',
-				"var haxe_Exception = { caught: (value) => value, thrown: (value) => (value.get_native) ? value.get_native() : value };"
+				"var haxe_NativeStackTrace = haxe_NativeStackTrace || {};",
+				'var haxe_Log = haxe_Log || { trace: (v, infos) => console.log(infos.fileName + ":" + infos.lineNumber + ": " + v) };',
+				"var haxe_Exception = haxe_Exception || { caught: (value) => value, thrown: (value) => (value.get_native) ? value.get_native() : value };"
 			];
 			defaultHeaderCode.addClass(StringTools);
 			defaultHeaderCode.addClass(HxOverrides);
@@ -130,6 +131,12 @@ class ThreadBase {
 		Dispatches `onComplete` on the main thread, with the
 		given message. The background function should send
 		no further messages after calling this.
+
+		If using web workers, you can call this despite not
+		having access to the `BackgroundWorker` or
+		`ThreadPool` instance. However, to avoid causing an
+		error, you must enable `@:analyzer(optimize)` on the
+		function calling this.
 		@param transferList (Web workers only) A list of
 		buffers in `message` that should be moved rather
 		than copied to the main thread. For details, see
@@ -160,6 +167,12 @@ class ThreadBase {
 		given message. The background function should
 		return promptly after calling this, freeing up the
 		thread for more work.
+
+		If using web workers, you can call this despite not
+		having access to the `BackgroundWorker` or
+		`ThreadPool` instance. However, to avoid causing an
+		error, you must enable `@:analyzer(optimize)` on the
+		function calling this.
 		@param transferList (Web workers only) A list of
 		buffers in `message` that should be moved rather
 		than copied to the main thread. For details, see
@@ -188,6 +201,12 @@ class ThreadBase {
 
 		Dispatches `onProgress` on the main thread, with the
 		given message.
+
+		If using web workers, you can call this despite not
+		having access to the `BackgroundWorker` or
+		`ThreadPool` instance. However, to avoid causing an
+		error, you must enable `@:analyzer(optimize)` on the
+		function calling this.
 		@param transferList (Web workers only) A list of
 		buffers in `message` that should be moved rather
 		than copied to the main thread. For details, see

--- a/src/lime/system/ThreadBase.hx
+++ b/src/lime/system/ThreadBase.hx
@@ -1,0 +1,241 @@
+package lime.system;
+
+import lime.app.Event;
+import lime.utils.ArrayBuffer;
+
+#if !force_synchronous
+#if target.threaded
+import sys.thread.Deque;
+import sys.thread.Thread;
+#elseif cpp
+import cpp.vm.Deque;
+import cpp.vm.Thread;
+#elseif neko
+import neko.vm.Deque;
+import neko.vm.Thread;
+#elseif js
+import haxe.Json;
+import js.Lib;
+import js.lib.Function;
+import js.lib.Object;
+import js.Syntax;
+#end
+#end
+
+/**
+	Common functionality between `BackgroundWorker` and
+	`ThreadPool`.
+
+	@see `lime.system.ThreadBase.HeaderCode`
+**/
+class ThreadBase {
+	#if (js && !force_synchronous)
+	/**
+		(Only available if using web workers.)
+
+		The default value for `headerCode`, applied when
+		creating a new `BackgroundWorker` or `ThreadPool`.
+		Modifying this won't affect already-existing
+		`BackgroundWorker`s and `ThreadPool`s.
+	**/
+	public static var defaultHeaderCode(get, default):HeaderCode;
+	private static function get_defaultHeaderCode():HeaderCode {
+		if(defaultHeaderCode == null) {
+			defaultHeaderCode = [
+				'"use strict";',
+				Syntax.code("$extend.toString()"),
+				'var haxe_Log = { trace: (v, infos) => console.log(infos.fileName + ":" + infos.lineNumber + ": " + v) };',
+				"var haxe_Exception = { caught: (value) => value, thrown: (value) => (value.get_native) ? value.get_native() : value };",
+				"var StringTools = { startsWith: (s, start) => s.startsWith(start), endsWith: (s, end) => s.endsWith(end), trim: s => s.trim() };",
+				"var HxOverrides = { substr: (s, pos, len) => s.substr(pos, len) };"
+			];
+		}
+
+		return defaultHeaderCode;
+	}
+
+	/**
+		(Only available if using web workers.)
+
+		Whenever this `BackgroundWorker` or `ThreadPool`
+		creates a new web worker, it will insert this code
+		at the beginning of the JavaScript file, making the
+		functions available to the worker.
+	**/
+	public var headerCode:HeaderCode;
+	#end
+
+	/**
+		Dispatched on the main thread when any background
+		thread calls `sendComplete()`. Indicates that the
+		thread is done.
+
+		For best results, add all listeners before starting
+		the new thread.
+	**/
+	public var onComplete = new Event<Dynamic->Void>();
+	/**
+		Dispatched on the main thread when any background
+		thread calls `sendError()`. Indicates that the
+		thread has failed and won't attempt to continue.
+
+		For best results, add all listeners before starting
+		the new thread.
+	**/
+	public var onError = new Event<Dynamic->Void>();
+	/**
+		Dispatched on the main thread when any background
+		thread calls `sendProgress()`. May be dispatched any
+		number of times per thread.
+
+		For best results, add all listeners before starting
+		the new thread.
+	**/
+	public var onProgress = new Event<Dynamic->Void>();
+
+	@:noCompletion @:dox(hide) public var doWork:ThreadFunction<Dynamic->Void>;
+
+	#if ((target.threaded || cpp || neko) && !force_synchronous)
+	@:noCompletion private var __synchronous:Bool = false;
+	@:noCompletion private var __workResult = new Deque<ThreadEvent>();
+	#end
+
+	/**
+		@param doWork The function to be run on a background
+		thread. Takes a single user-defined argument. Must
+		call either `sendComplete()` or `sendError()` (but
+		not both) when finished.
+	**/
+	public function new(doWork:ThreadFunction<Dynamic->Void>)
+	{
+		#if js
+		headerCode = defaultHeaderCode.copy();
+		#end
+
+		this.doWork = doWork;
+	}
+
+	/**
+		[Call this from a background thread.]
+
+		Dispatches `onComplete` on the main thread, with the
+		given message. The background function should send
+		no further messages after calling this.
+		@param transferList (Web workers only) A list of
+		buffers in `message` that should be moved rather
+		than copied to the main thread. For details, see
+		https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects
+	**/
+	#if js inline #end
+	public function sendComplete(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
+	{
+		#if ((target.threaded || cpp || neko) && !force_synchronous)
+		if (!__synchronous)
+		{
+			__workResult.add(new ThreadEvent(COMPLETE, message));
+			return;
+		}
+		#end
+
+		#if (js && !force_synchronous)
+		Syntax.code("postMessage({0}, {1})", new ThreadEvent(COMPLETE, message), transferList);
+		#else
+		onComplete.dispatch(message);
+		#end
+	}
+
+	/**
+		[Call this from a background thread.]
+
+		Dispatches `onError` on the main thread, with the
+		given message. The background function should
+		return promptly after calling this, freeing up the
+		thread for more work.
+		@param transferList (Web workers only) A list of
+		buffers in `message` that should be moved rather
+		than copied to the main thread. For details, see
+		https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects
+	**/
+	#if js inline #end
+	public function sendError(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
+	{
+		#if ((target.threaded || cpp || neko) && !force_synchronous)
+		if (!__synchronous)
+		{
+			__workResult.add(new ThreadEvent(ERROR, message));
+			return;
+		}
+		#end
+
+		#if (js && !force_synchronous)
+		Syntax.code("postMessage({0}, {1})", new ThreadEvent(ERROR, message), transferList);
+		#else
+		onError.dispatch(message);
+		#end
+	}
+
+	/**
+		[Call this from a background thread.]
+
+		Dispatches `onProgress` on the main thread, with the
+		given message.
+		@param transferList (Web workers only) A list of
+		buffers in `message` that should be moved rather
+		than copied to the main thread. For details, see
+		https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects
+	**/
+	#if js inline #end
+	public function sendProgress(message:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
+	{
+		#if ((target.threaded || cpp || neko) && !force_synchronous)
+		if (!__synchronous)
+		{
+			__workResult.add(new ThreadEvent(PROGRESS, message));
+			return;
+		}
+		#end
+
+		#if (js && !force_synchronous)
+		Syntax.code("postMessage({0}, {1})", new ThreadEvent(PROGRESS, message), transferList);
+		#else
+		onProgress.dispatch(message);
+		#end
+	}
+}
+
+@:enum abstract ThreadEventType(String)
+{
+	var COMPLETE = "COMPLETE";
+	var ERROR = "ERROR";
+	var EXIT = "EXIT";
+	var PROGRESS = "PROGRESS";
+	var WORK = "WORK";
+}
+
+@:forward
+abstract ThreadEvent({ message:Dynamic, event:ThreadEventType })
+{
+	public inline function new(event:ThreadEventType, message:Dynamic)
+	{
+		this = {
+			event: event,
+			message: message
+		};
+	}
+}
+
+#if (js && !force_synchronous)
+/**
+	JavaScript code to be run when a web worker starts. The
+	variables and functions declared here will be available
+	to the `doWork` function.
+**/
+@:forward
+abstract HeaderCode(Array<String>) from Array<String> to Array<String>
+{
+	public inline function toString():String
+	{
+		return this.join("\n") + "\n";
+	}
+}
+#end

--- a/src/lime/system/ThreadBase.hx
+++ b/src/lime/system/ThreadBase.hx
@@ -501,15 +501,12 @@ abstract HeaderCode(Array<String>) from Array<String>
 
 		for (entry in Object.entries(cls))
 		{
-			if (entry.key == "__super__" || entry.key == "__interfaces__")
+			if (entry.key == "__super__" || entry.key == "__interfaces__"
+				|| Syntax.typeof(entry.value) != "function")
 				continue;
 
-			var value:String = "" + cast entry.value;
-			if (Syntax.typeof(entry.value) == "string")
-			{
-				value = '"$value"';
-			}
-			else if (value.indexOf("[native code]") >= 0 || value.indexOf("[object Object]") >= 0)
+			var value:String = (entry.value:Function).toString();
+			if (value.indexOf("[native code]") >= 0)
 			{
 				continue;
 			}

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -35,7 +35,6 @@ using haxe.macro.TypeTools;
 	stored as strings, making it easier to pass them to
 	worker threads. You can also print their value at
 	runtime to see the JavaScript source code.
-
 **/
 #if (!js || force_synchronous)
 abstract ThreadFunction<T:haxe.Constraints.Function>(T) from T to T

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -27,7 +27,6 @@ abstract ThreadFunction<T>(String) to String
 {
 	#if (js || macro)
 	private static inline var TAG:String = "/* lime.system.ThreadFunction */";
-	private static var TAG_ESCAPED:String = EReg.escape(TAG);
 
 	// Other macros can call this statically, if needed.
 	@:noCompletion @:dox(hide) #if !macro @:from #end
@@ -164,10 +163,11 @@ abstract ThreadFunction<T>(String) to String
 		{
 			var outputFile:String = Compiler.getOutput();
 			var outputContent:String = File.getContent(outputFile);
+			var escapedTag:String = EReg.escape(TAG);
 
-			outputContent = new EReg(TAG_ESCAPED + "\\$bind\\(this,(.+?)\\)\\.toString\\(\\)" + TAG_ESCAPED, "gm")
+			outputContent = new EReg(escapedTag + "\\$bind\\(this,(.+?)\\)\\.toString\\(\\)" + escapedTag, "gm")
 				.replace(outputContent, "$1.toString()");
-			outputContent = new EReg(TAG_ESCAPED, "g").replace(outputContent, "");
+			outputContent = new EReg(escapedTag, "g").replace(outputContent, "");
 
 			File.saveContent(outputFile, outputContent);
 		});

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -195,6 +195,9 @@ abstract ThreadFunction<T>(String) to String
 		// an unused reference to outside code.
 		this = #if haxe4 js.Syntax.code #else untyped __js__ #end
 			('{0}.replace(/var _g?this = .+?;\\s*(.+?postMessage)/gs, "$1")', this);
+
+		this = #if haxe4 js.Syntax.code #else untyped __js__ #end
+			('{0}.replace(/haxe_NativeStackTrace\\.lastError = \\w+;\\s*var (\\w+) = haxe_Exception\\.caught\\((\\w+)\\)\\.unwrap\\(\\);/gs, "var $1 = \'\' + $2;")', this);
 	}
 	#end
 

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -180,7 +180,7 @@ abstract ThreadFunction<T>(String) to String
 			var outputContent:String = File.getContent(outputFile);
 			var escapedTag:String = EReg.escape(TAG);
 
-			outputContent = new EReg(escapedTag + "\\$bind\\(this,(.+?)\\)\\.toString\\(\\)" + escapedTag, "gm")
+			outputContent = new EReg(escapedTag + "\\$bind\\(\\w*this,(.+?)\\)\\.toString\\(\\)" + escapedTag, "gs")
 				.replace(outputContent, "$1.toString()");
 			outputContent = new EReg(escapedTag, "g").replace(outputContent, "");
 

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -256,11 +256,10 @@ abstract ThreadFunction<T>(String) to String
 
 			// Find and remove tagged `$bind()` calls.
 			var escapedTag:String = EReg.escape(TAG);
-			outputContent = new EReg(escapedTag + "\\$bind\\(\\w*this,(.+?)\\)\\.toString\\(\\)" + escapedTag, "gs")
-				.replace(outputContent, "$1.toString()");
-
-			// Clean up any remaining tags.
-			outputContent = new EReg(escapedTag, "g").replace(outputContent, "");
+			outputContent = new EReg(escapedTag + "(.+?)" + escapedTag, "gs")
+				.map(outputContent, function(match) {
+					return ~/\$bind\(.+?,(.+?)\)/s.replace(match.matched(1), "$1");
+				});
 
 			File.saveContent(outputFile, outputContent);
 		});

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -260,13 +260,25 @@ abstract ThreadFunction<T>(String) to String
 		{
 			#if haxe4 js.Syntax.code #else untyped __js__ #end
 			("throw {0}",
-				"Haxe automatically binds some functions, "
-				+ "making them incompatible with workers. "
-				+ "ThreadFunction tries to undo this, but "
-				+ "successfully undoing it requires "
-				+ "converting to ThreadFunction as soon as "
-				+ "possible. If that isn't an option, try "
-				+ "a static function.");
+				"error: Could not extract function source "
+				+ "code. This can have multiple causes:\n"
+				+ "1. If your previous build targeted "
+				+ "anything other than JavaScript, this "
+				+ "JavaScript build may have skipped "
+				+ "important macros. To solve this, modify "
+				+ "any file and retry.\n"
+				+ "2. If you call .bind() on a function, "
+				+ "it becomes impossible to extract source "
+				+ "code. Try declaring a new function "
+				+ "instead.\n"
+				+ "3. If you assign an instance function "
+				+ "to a variable, it may become impossible "
+				+ "to extract source code. To avoid this, "
+				+ "the variable must be of type "
+				+ "ThreadFunction.\n"
+				+ "4. As a last resort, use static "
+				+ "functions instead of instance functions."
+			);
 
 			// Addendum: explicit casts will NOT work. You
 			// have to use implicit casts or type hints.

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -65,7 +65,7 @@ abstract ThreadFunction<T>(String) to String
 
 			return macro if ($self != null)
 			{
-				var paramsAndBody:Array<String> = js.Syntax.code("/function\\((.+?)\\)\\s*\\{\\s*(.+)\\s*\\}/.exec({0})", $self);
+				var paramsAndBody:Array<String> = js.Syntax.code("/function\\((.*?)\\)\\s*\\{\\s*(.+)\\s*\\}/.exec({0})", $self);
 				if (paramsAndBody == null)
 					js.Syntax.code('throw "Malformatted ThreadFunction: " + {0}', $self);
 

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -88,8 +88,14 @@ abstract ThreadFunction<T>(String) to String
 	/**
 		Executes this function on the current thread.
 
-		Note: the JavaScript implementation requires all
-		arguments, even optional ones.
+		Note: the JavaScript implementation has multiple
+		limitations.
+
+		- The function can only access the global scope,
+		even if run on the main thread.
+		- On background threads, it's further limited to
+		inline variables and whatever arguments it receives.
+		- You must supply all arguments, even optional ones.
 	**/
 	public macro function dispatch(self:Expr, args:Array<Expr>):Expr
 	{

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -13,16 +13,29 @@ using haxe.macro.TypeTools;
 
 /**
 	A function to be called on another thread. This behaves
-	as a perfectly normal function on most targets, but in
-	JavaScript it will convert to string and back.
+	as a perfectly normal function on most targets, but it
+	also provides an `Event`-like API for compatibility,
+	offering functions like `add()` and `dispatch()`.
+	Unlike `Event`, it can only represent a single function
+	at a time; `add()` overwrites the old function.
 
-	Since it is stored as a string in JavaScript, you can
-	print the value at runtime to see the JavaScript code.
+	In JavaScript, web workers can be enabled in two ways:
 
-	`ThreadFunction` also provides an `Event`-like API for
-	backwards compatibility. Unlike `Event`, it can only
-	represent a single function at a time; `add()`
-	overwrites the old function.
+	```xml
+	<!-- Option 1: before including Lime -->
+	<haxedef name="lime-web-workers" />
+
+	<haxelib name="lime" />
+
+	<!-- Option 2: after including Lime -->
+	<unset name="force_synchronous" if="html5" />
+	```
+
+	If web workers are enabled, `ThreadFunction`s will be
+	stored as strings, making it easier to pass them to
+	worker threads. You can also print their value at
+	runtime to see the JavaScript source code.
+
 **/
 #if (!js || force_synchronous)
 abstract ThreadFunction<T:haxe.Constraints.Function>(T) from T to T

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -1,0 +1,168 @@
+package lime.system;
+
+#if macro
+import haxe.macro.Compiler;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+import sys.io.File;
+#end
+
+/**
+	A function to be called on another thread. This behaves
+	as a perfectly normal function on most targets, but in
+	JavaScript it will convert to string and back.
+
+	`ThreadFunction` also provides an `Event`-like API for
+	backwards compatibility. Unlike `Event`, it can only
+	represent a single function at a time; `add()`
+	overwrites the old function.
+**/
+#if !js
+abstract ThreadFunction<T:haxe.Constraints.Function>(T) from T to T
+#else
+// Excluding "from String" to help `run()` disambiguate.
+abstract ThreadFunction<T>(String) to String
+#end
+{
+	#if (js || macro)
+	private static inline var TAG:String = "/* lime.system.ThreadFunction */";
+	private static var TAG_ESCAPED:String = EReg.escape(TAG);
+
+	// Other macros can call this statically, if needed.
+	@:noCompletion @:dox(hide) #if !macro @:from #end
+	public static #if !macro macro #end function fromFunction(func:ExprOf<haxe.Constraints.Function>)
+	{
+		cleanAfterGenerate();
+		return macro js.Syntax.code($v{TAG + "{0}.toString()" + TAG}, $func);
+	}
+	#end
+
+	/**
+		Adds the given callback function, to be run on the
+		other thread. Unlike with `lime.app.Event`, only one
+		callback can exist; `add()` overwrites the old one.
+	**/
+	public inline function add(callback:ThreadFunction<T>):Void
+	{
+		this = callback;
+	}
+
+	/**
+		Executes this function on the current thread.
+	**/
+	public macro function dispatch(self:Expr, args:Array<Expr>):Expr
+	{
+		if (!Context.defined("js"))
+		{
+			return macro $self != null ? (cast $self:haxe.Constraints.Function)($a{args}) : null;
+		}
+		else
+		{
+			var argSyntax:Array<String> = [for (i in 1...(args.length + 1)) '{$i}'];
+			var syntax:String = 'Function.apply(this, {0})(${argSyntax.join(", ")})';
+			args = [macro $v{syntax}, macro paramsAndBody].concat(args);
+
+			return macro if ($self != null)
+			{
+				var paramsAndBody:Array<String> = js.Syntax.code("/function\\((.+?)\\)\\s*\\{\\s*(.+)\\s*\\}/.exec({0})", $self);
+				if (paramsAndBody == null)
+					js.Syntax.code('throw "Malformatted ThreadFunction: " + {0}', $self);
+
+				var body = paramsAndBody.pop();
+				paramsAndBody = paramsAndBody[1].split(js.Syntax.code("/, */"));
+				paramsAndBody.push(body);
+
+				js.Syntax.code($a{args});
+			}
+			else null;
+		}
+	}
+
+	@:noCompletion @:dox(hide) public inline function has(callback:ThreadFunction<T>):Bool
+	{
+		#if !js
+		return Reflect.compareMethods(this, callback);
+		#else
+		return this == callback;
+		#end
+	}
+
+	@:noCompletion @:dox(hide) public inline function remove(callback:ThreadFunction<T>):Void
+	{
+		if (has(callback))
+		{
+			this = null;
+		}
+	}
+
+	@:noCompletion @:dox(hide) public inline function removeAll():Void
+	{
+		this = null;
+	}
+
+	#if js
+	/**
+		Makes sure the JS string is suitable for making a
+		`Worker`. Fixes issues when possible and throws
+		errors if not.
+	**/
+	@:noCompletion @:dox(hide) public inline function checkJS():Void
+	{
+		if (this.indexOf("[native code]") >= 0)
+		{
+			throw "Haxe automatically binds instance functions in JS, making them incompatible with js.html.Worker. ThreadFunction tries to remove this binding; the sooner you convert to ThreadFunction, the more likely it will work. Failing that, try a static function.";
+			// Addendum: explicit casts will NOT work. You
+			// have to use implicit casts or type hints.
+		}
+
+		// Without analyzer-optimize, there's likely to be
+		// an unused reference to outside code.
+		this = cast ~/var _g?this = .+?;\s*(.+?postMessage)/gs
+			.replace(this, "$1");
+	}
+	#end
+
+	#if macro
+	private static var callbacksRegistered:Bool = false;
+
+	#if !haxe4
+	private static function resetCallbacksRegistered():Bool
+	{
+		callbacksRegistered = false;
+		return true;
+	}
+	#end
+
+	/**
+		Adds an `onAfterGenerate()` listener to read the JS
+		file and clean up any bound functions.
+	**/
+	private static function cleanAfterGenerate():Void
+	{
+		if (callbacksRegistered || !Context.defined("js") || Context.defined("display"))
+		{
+			return;
+		}
+		callbacksRegistered = true;
+
+		#if !haxe4
+		Context.onMacroContextReused(resetCallbacksRegistered);
+		#end
+
+		#if !lime_suppress_onAfterGenerate
+		Context.onAfterGenerate(function():Void
+		{
+			var outputFile:String = Compiler.getOutput();
+			var outputContent:String = File.getContent(outputFile);
+
+			outputContent = new EReg(TAG_ESCAPED + "\\$bind\\(this,(.+?)\\)\\.toString\\(\\)" + TAG_ESCAPED, "gm")
+				.replace(outputContent, "$1.toString()");
+			outputContent = new EReg(TAG_ESCAPED, "g").replace(outputContent, "");
+
+			File.saveContent(outputFile, outputContent);
+		});
+		#end
+	}
+	#end
+}

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -363,3 +363,27 @@ abstract ThreadFunction<T>(String) to String
 	}
 	#end
 }
+
+/**
+	As with functions, if you try to pass an enum to or from
+	a web worker, you'll get a "could not be cloned" error.
+	Converting to `ThreadEnum` fixes this.
+
+	This only applies to standard enums; abstracts are fine.
+**/
+abstract ThreadEnum<T:EnumValue>(T) to T
+{
+	/**
+		Permanently deletes this enum value's `toString()`
+		function, making it safe to pass to a web worker. If
+		you still need to get the name, call `Std.string()`
+		instead of `toString()`.
+	**/
+	@:from public static inline function convert<T:EnumValue>(enumValue:T):ThreadEnum<T>
+	{
+		#if (js && !force_synchronous)
+		js.Syntax.code("delete {0}.toString", enumValue);
+		#end
+		return cast enumValue;
+	}
+}

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -24,7 +24,7 @@ using haxe.macro.TypeTools;
 	represent a single function at a time; `add()`
 	overwrites the old function.
 **/
-#if !js
+#if (!js || display)
 abstract ThreadFunction<T:haxe.Constraints.Function>(T) from T to T
 #else
 // Excluding "from String" to help `run()` disambiguate.
@@ -67,7 +67,7 @@ abstract ThreadFunction<T>(String) to String
 	// `@:from` would cause errors during the macro phase.
 	// Disabling `macro` during the macro phase allows other
 	// macros to call this statically.
-	@:noCompletion @:dox(hide) #if !macro @:from #end
+	@:noCompletion @:dox(hide) #if (!macro && !display) @:from #end
 	public static #if !macro macro #end function fromFunction(func:ExprOf<haxe.Constraints.Function>)
 	{
 		cleanAfterGenerate();
@@ -179,6 +179,7 @@ abstract ThreadFunction<T>(String) to String
 	**/
 	@:noCompletion @:dox(hide) public inline function checkJS():Void
 	{
+		#if !display
 		// Break the string up so it won't match its own
 		// source code.
 		if (this.indexOf("[" + "native code" + "]") >= 0)
@@ -204,6 +205,7 @@ abstract ThreadFunction<T>(String) to String
 
 		this = #if haxe4 js.Syntax.code #else untyped __js__ #end
 			('{0}.replace(/haxe_NativeStackTrace\\.lastError = \\w+;\\s*var (\\w+) = haxe_Exception\\.caught\\((\\w+)\\)\\.unwrap\\(\\);/gs, "var $1 = \'\' + $2;")', this);
+		#end
 	}
 	#end
 

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -42,7 +42,7 @@ abstract ThreadFunction<T>(String) to String
 		other thread. Unlike with `lime.app.Event`, only one
 		callback can exist; `add()` overwrites the old one.
 	**/
-	public inline function add(callback:ThreadFunction<T>):Void
+	@:noCompletion @:dox(hide) public inline function add(callback:ThreadFunction<T>):Void
 	{
 		this = callback;
 	}

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -115,6 +115,8 @@ abstract ThreadFunction<T>(String) to String
 
 			return macro if ($self != null)
 			{
+				$self.checkJS();
+
 				var paramsAndBody:Array<String> = $SYNTAX($v{'/$regex/s.exec({0})'}, $self);
 				if (paramsAndBody == null)
 					$SYNTAX('throw "Wrong number of arguments. Attempting to pass " + {0} + " arguments to this function:\\n" + {1}', $v{args.length}, $self);
@@ -165,6 +167,9 @@ abstract ThreadFunction<T>(String) to String
 		Makes sure the JS string is suitable for making a
 		`Worker`. Fixes issues when possible and throws
 		errors if not.
+
+		This is automatically called by `dispatch()`, so
+		you typically don't need to call it yourself.
 	**/
 	@:noCompletion @:dox(hide) public inline function checkJS():Void
 	{

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -249,12 +249,8 @@ abstract ThreadFunction<T>(String) to String
 
 	#if (js && !force_synchronous)
 	/**
-		Makes sure the JS string is suitable for making a
-		`Worker`. Fixes issues when possible and throws
-		errors if not.
-
-		This is automatically called by `dispatch()`, so
-		you typically don't need to call it yourself.
+		Makes sure the JS string can be turned back into a
+		function, and throws an informative error if not.
 	**/
 	@:noCompletion @:dox(hide) public inline function checkJS():Void
 	{
@@ -282,14 +278,6 @@ abstract ThreadFunction<T>(String) to String
 			// Addendum: explicit casts will NOT work. You
 			// have to use implicit casts or type hints.
 		}
-
-		// Without analyzer-optimize, there's likely to be
-		// an unused reference to outside code.
-		this = #if haxe4 js.Syntax.code #else untyped __js__ #end
-			('{0}.replace(/var _g?this = .+?;\\s*(.+?postMessage)/gs, "$1")', this);
-
-		this = #if haxe4 js.Syntax.code #else untyped __js__ #end
-			('{0}.replace(/haxe_NativeStackTrace\\.lastError = \\w+;\\s*var (\\w+) = haxe_Exception\\.caught\\((\\w+)\\)\\.unwrap\\(\\);/gs, "var $1 = \'\' + $2;")', this);
 	}
 	#end
 

--- a/src/lime/system/ThreadFunction.hx
+++ b/src/lime/system/ThreadFunction.hx
@@ -109,17 +109,26 @@ abstract ThreadFunction<T>(String) to String
 	**/
 	@:noCompletion @:dox(hide) public inline function checkJS():Void
 	{
-		if (this.indexOf("[native code]") >= 0)
+		// Break the string up so it won't match its own
+		// source code.
+		if (this.indexOf("[" + "native code" + "]") >= 0)
 		{
-			throw "Haxe automatically binds instance functions in JS, making them incompatible with js.html.Worker. ThreadFunction tries to remove this binding; the sooner you convert to ThreadFunction, the more likely it will work. Failing that, try a static function.";
+			js.Syntax.code("throw {0}",
+				"Haxe automatically binds some functions, "
+				+ "making them incompatible with workers. "
+				+ "ThreadFunction tries to undo this, but "
+				+ "successfully undoing it requires "
+				+ "converting to ThreadFunction as soon as "
+				+ "possible. If that isn't an option, try "
+				+ "a static function.");
+
 			// Addendum: explicit casts will NOT work. You
 			// have to use implicit casts or type hints.
 		}
 
 		// Without analyzer-optimize, there's likely to be
 		// an unused reference to outside code.
-		this = cast ~/var _g?this = .+?;\s*(.+?postMessage)/gs
-			.replace(this, "$1");
+		this = js.Syntax.code('{0}.replace(/var _g?this = .+?;\\s*(.+?postMessage)/gs, "$1")', this);
 	}
 	#end
 

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -3,8 +3,7 @@ package lime.system;
 import haxe.Constraints.Function;
 import lime.app.Application;
 import lime.app.Event;
-#if sys
-#if haxe4
+#if target.threaded
 import sys.thread.Deque;
 import sys.thread.Thread;
 #elseif cpp
@@ -13,7 +12,6 @@ import cpp.vm.Thread;
 #elseif neko
 import neko.vm.Deque;
 import neko.vm.Thread;
-#end
 #end
 #if !lime_debug
 @:fileXml('tags="haxe,release"')
@@ -30,7 +28,7 @@ class ThreadPool
 	public var onProgress = new Event<Dynamic->Void>();
 	public var onRun = new Event<Dynamic->Void>();
 
-	#if (cpp || neko)
+	#if (target.threaded || cpp || neko)
 	@:noCompletion private var __synchronous:Bool;
 	@:noCompletion private var __workCompleted:Int;
 	@:noCompletion private var __workIncoming = new Deque<ThreadPoolMessage>();
@@ -45,7 +43,7 @@ class ThreadPool
 
 		currentThreads = 0;
 
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		__workQueued = 0;
 		__workCompleted = 0;
 		#end
@@ -67,7 +65,7 @@ class ThreadPool
 	// }
 	public function queue(state:Dynamic = null):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		// TODO: Better way to handle this?
 
 		if (Application.current != null && Application.current.window != null && !__synchronous)
@@ -98,7 +96,7 @@ class ThreadPool
 
 	public function sendComplete(state:Dynamic = null):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		if (!__synchronous)
 		{
 			__workResult.add(new ThreadPoolMessage(COMPLETE, state));
@@ -111,7 +109,7 @@ class ThreadPool
 
 	public function sendError(state:Dynamic = null):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		if (!__synchronous)
 		{
 			__workResult.add(new ThreadPoolMessage(ERROR, state));
@@ -124,7 +122,7 @@ class ThreadPool
 
 	public function sendProgress(state:Dynamic = null):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		if (!__synchronous)
 		{
 			__workResult.add(new ThreadPoolMessage(PROGRESS, state));
@@ -137,7 +135,7 @@ class ThreadPool
 
 	@:noCompletion private function runWork(state:Dynamic = null):Void
 	{
-		#if (cpp || neko)
+		#if (target.threaded || cpp || neko)
 		if (!__synchronous)
 		{
 			__workResult.add(new ThreadPoolMessage(WORK, state));
@@ -150,7 +148,7 @@ class ThreadPool
 		doWork.dispatch(state);
 	}
 
-	#if (cpp || neko)
+	#if (target.threaded || cpp || neko)
 	@:noCompletion private function __doWork():Void
 	{
 		while (true)

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -132,20 +132,20 @@ class ThreadPool
 		becomes available. The thread will receive `state`
 		as an argument.
 
-		**Caution:** in HTML5, workers are almost completely
-		isolated from the main thread. They will have
-		access to three main things: (1) certain JavaScript
-		functions (see `DedicatedWorkerGlobalScope`), (2)
-		inline Haxe functions (including all three "send"
-		functions), and (3) the contents of `state`. To
-		inline as much as possible, turn on DCE and tag the
-		function with `@:analyzer(optimize)`.
+		**Caution:** if web workers are enabled, `doWork`
+		will be almost completely isolated from the main
+		thread. It will have access to three main things:
+		(1) common JavaScript functions, (2) inline
+		variables and functions (including all three "send"
+		functions), and (3) the contents of `message`. For
+		best results, tag your inline functions with the
+		`@:analyzer(optimize)` metadata.
 		@param state Data to pass to the background thread.
 		HTML5 imposes several restrictions on this data:
 		https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 		If you need a function, try a `ThreadFunction`,
 		keeping in mind that it will be isolated.
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The main thread will only receive these
 		if they're also included in `state`.
@@ -195,7 +195,7 @@ class ThreadPool
 		given argument. The background function should
 		return promptly after calling this, freeing up the
 		thread for more work.
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The main thread will only receive these
 		if they're also included in `state`.
@@ -225,7 +225,7 @@ class ThreadPool
 		given argument. The background function should
 		return promptly after calling this, freeing up the
 		thread for more work.
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The main thread will only receive these
 		if they're also included in `state`.
@@ -253,7 +253,7 @@ class ThreadPool
 
 		Dispatches `onProgress` on the main thread, with the
 		given argument.
-		@param transferList (JavaScript only) Zero or more
+		@param transferList (Web workers only) Zero or more
 		buffers to transfer using an efficient zero-copy
 		operation. The main thread will only receive these
 		if they're also included in `state`. Once

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -459,7 +459,8 @@ class ThreadPool
 			currentThreads--;
 
 			#if (target.threaded || cpp || neko)
-			__workIncoming.add(new ThreadPoolMessage(EXIT, null));
+			// `EXIT` messages take priority over `WORK`.
+			__workIncoming.push(new ThreadPoolMessage(EXIT, null));
 			#elseif js
 			var worker = __idleWorkers.pop();
 			if (worker != null)

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -3,7 +3,6 @@ package lime.system;
 import haxe.Constraints.Function;
 import lime.app.Application;
 import lime.app.Event;
-import lime.system.BackgroundWorker.ThreadFunction;
 #if target.threaded
 import sys.thread.Deque;
 import sys.thread.Thread;

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -3,7 +3,7 @@ package lime.system;
 import haxe.Constraints.Function;
 import lime.app.Application;
 import lime.app.Event;
-import lime.system.BackgroundWorker.DoWork;
+import lime.system.BackgroundWorker.ThreadFunction;
 #if target.threaded
 import sys.thread.Deque;
 import sys.thread.Thread;
@@ -21,7 +21,7 @@ import neko.vm.Thread;
 class ThreadPool
 {
 	public var currentThreads(default, null):Int;
-	public var doWork:DoWork;
+	public var doWork:ThreadFunction;
 	public var maxThreads:Int;
 	public var minThreads:Int;
 	public var onComplete = new Event<Dynamic->Void>();

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -104,13 +104,12 @@ class ThreadPool
 		{
 			doWork.checkJS();
 
-			var workerJS:String =
-				"var haxe_Log = { trace: console.log };\n"
-				+ "this.onmessage = function(messageEvent) {\n"
-				+ '    ($doWork)(messageEvent.data);\n'
-				+ "};";
-
-			var workerURL:String = URL.createObjectURL(new Blob([workerJS]));
+			var workerURL:String = URL.createObjectURL(new Blob([
+				BackgroundWorker.initializeWorker,
+				"this.onmessage = function(messageEvent) {\n",
+				'    ($doWork)(messageEvent.data);\n',
+				"};"
+			]));
 
 			var worker:Worker = new Worker(workerURL);
 			worker.onmessage = __handleMessage.bind(worker, workerURL);

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -57,7 +57,7 @@ class ThreadPool
 		This is public for backwards compatibility, but it
 		should now be set via the constructor.
 	**/
-	@:noCompletion @:dox(hide) public var doWork:ThreadFunction;
+	@:noCompletion @:dox(hide) public var doWork:ThreadFunction<Dynamic->Void>;
 	/**
 		The maximum number of threads this pool will create.
 
@@ -114,7 +114,7 @@ class ThreadPool
 		background. It will run once for each time `queue()`
 		is called, each time receiving a different argument.
 	**/
-	public function new(?doWork:ThreadFunction, minThreads:Int = 0, maxThreads:Int = 1)
+	public function new(?doWork:ThreadFunction<Dynamic->Void>, minThreads:Int = 0, maxThreads:Int = 1)
 	{
 		this.doWork = doWork;
 		this.minThreads = minThreads;

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -3,6 +3,7 @@ package lime.system;
 import haxe.Constraints.Function;
 import lime.app.Application;
 import lime.app.Event;
+import lime.utils.ArrayBuffer;
 #if !force_synchronous
 #if target.threaded
 import sys.thread.Deque;
@@ -190,9 +191,13 @@ class ThreadPool
 		given argument. The background function should
 		return promptly after calling this, freeing up the
 		thread for more work.
+		@param transferList (JavaScript only) Zero or more
+		buffers to transfer using an efficient zero-copy
+		operation. The main thread will only receive these
+		if they're also included in `state`.
 	**/
 	#if js inline #end
-	public function sendComplete(state:Dynamic = null):Void
+	public function sendComplete(state:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)
 		if (!__synchronous)
@@ -203,7 +208,7 @@ class ThreadPool
 		#end
 
 		#if (js && !force_synchronous)
-		Syntax.code("postMessage({0})", new ThreadPoolMessage(COMPLETE, state));
+		Syntax.code("postMessage({0}, {1})", new ThreadPoolMessage(COMPLETE, state), transferList);
 		#else
 		onComplete.dispatch(state);
 		#end
@@ -216,9 +221,13 @@ class ThreadPool
 		given argument. The background function should
 		return promptly after calling this, freeing up the
 		thread for more work.
+		@param transferList (JavaScript only) Zero or more
+		buffers to transfer using an efficient zero-copy
+		operation. The main thread will only receive these
+		if they're also included in `state`.
 	**/
 	#if js inline #end
-	public function sendError(state:Dynamic = null):Void
+	public function sendError(state:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)
 		if (!__synchronous)
@@ -229,7 +238,7 @@ class ThreadPool
 		#end
 
 		#if (js && !force_synchronous)
-		Syntax.code("postMessage({0})", new ThreadPoolMessage(ERROR, state));
+		Syntax.code("postMessage({0}, {1})", new ThreadPoolMessage(ERROR, state), transferList);
 		#else
 		onError.dispatch(state);
 		#end
@@ -240,9 +249,15 @@ class ThreadPool
 
 		Dispatches `onProgress` on the main thread, with the
 		given argument.
+		@param transferList (JavaScript only) Zero or more
+		buffers to transfer using an efficient zero-copy
+		operation. The main thread will only receive these
+		if they're also included in `state`. Once
+		transferred, they will become inaccessible to the
+		background thread.
 	**/
 	#if js inline #end
-	public function sendProgress(state:Dynamic = null):Void
+	public function sendProgress(state:Dynamic = null, transferList:Array<ArrayBuffer> = null):Void
 	{
 		#if ((target.threaded || cpp || neko) && !force_synchronous)
 		if (!__synchronous)
@@ -253,7 +268,7 @@ class ThreadPool
 		#end
 
 		#if (js && !force_synchronous)
-		Syntax.code("postMessage({0})", new ThreadPoolMessage(PROGRESS, state));
+		Syntax.code("postMessage({0}, {1})", new ThreadPoolMessage(PROGRESS, state), transferList);
 		#else
 		onProgress.dispatch(state);
 		#end

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -3,6 +3,7 @@ package lime.system;
 import haxe.Constraints.Function;
 import lime.app.Application;
 import lime.app.Event;
+import lime.system.BackgroundWorker.DoWork;
 #if target.threaded
 import sys.thread.Deque;
 import sys.thread.Thread;
@@ -20,7 +21,7 @@ import neko.vm.Thread;
 class ThreadPool
 {
 	public var currentThreads(default, null):Int;
-	public var doWork = new Event<Dynamic->Void>();
+	public var doWork:DoWork;
 	public var maxThreads:Int;
 	public var minThreads:Int;
 	public var onComplete = new Event<Dynamic->Void>();

--- a/src/lime/ui/FileDialog.hx
+++ b/src/lime/ui/FileDialog.hx
@@ -103,7 +103,43 @@ class FileDialog
 		#if desktop
 		var worker = new BackgroundWorker();
 
-		worker.doWork.add(function(_)
+		worker.onComplete.add(function(result)
+		{
+			switch (type)
+			{
+				case OPEN, OPEN_DIRECTORY, SAVE:
+					var path:String = cast result;
+
+					if (path != null)
+					{
+						// Makes sure the filename ends with extension
+						if (type == SAVE && filter != null && path.indexOf(".") == -1)
+						{
+							path += "." + filter;
+						}
+
+						onSelect.dispatch(path);
+					}
+					else
+					{
+						onCancel.dispatch();
+					}
+
+				case OPEN_MULTIPLE:
+					var paths:Array<String> = cast result;
+
+					if (paths != null && paths.length > 0)
+					{
+						onSelectMultiple.dispatch(paths);
+					}
+					else
+					{
+						onCancel.dispatch();
+					}
+			}
+		});
+
+		worker.run(function(_)
 		{
 			switch (type)
 			{
@@ -176,44 +212,6 @@ class FileDialog
 			}
 		});
 
-		worker.onComplete.add(function(result)
-		{
-			switch (type)
-			{
-				case OPEN, OPEN_DIRECTORY, SAVE:
-					var path:String = cast result;
-
-					if (path != null)
-					{
-						// Makes sure the filename ends with extension
-						if (type == SAVE && filter != null && path.indexOf(".") == -1)
-						{
-							path += "." + filter;
-						}
-
-						onSelect.dispatch(path);
-					}
-					else
-					{
-						onCancel.dispatch();
-					}
-
-				case OPEN_MULTIPLE:
-					var paths:Array<String> = cast result;
-
-					if (paths != null && paths.length > 0)
-					{
-						onSelectMultiple.dispatch(paths);
-					}
-					else
-					{
-						onCancel.dispatch();
-					}
-			}
-		});
-
-		worker.run();
-
 		return true;
 		#else
 		onCancel.dispatch();
@@ -237,23 +235,6 @@ class FileDialog
 		#if desktop
 		var worker = new BackgroundWorker();
 
-		worker.doWork.add(function(_)
-		{
-			#if linux
-			if (title == null) title = "Open File";
-			#end
-
-			var path = null;
-			#if hl
-			var bytes = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
-			path = @:privateAccess String.fromUTF8(cast bytes);
-			#else
-			path = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
-			#end
-
-			worker.sendComplete(path);
-		});
-
 		worker.onComplete.add(function(path:String)
 		{
 			if (path != null)
@@ -270,7 +251,22 @@ class FileDialog
 			onCancel.dispatch();
 		});
 
-		worker.run();
+		worker.run(function(_)
+		{
+			#if linux
+			if (title == null) title = "Open File";
+			#end
+
+			var path = null;
+			#if hl
+			var bytes = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
+			path = @:privateAccess String.fromUTF8(cast bytes);
+			#else
+			path = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
+			#end
+
+			worker.sendComplete(path);
+		});
 
 		return true;
 		#else
@@ -305,23 +301,6 @@ class FileDialog
 		#if desktop
 		var worker = new BackgroundWorker();
 
-		worker.doWork.add(function(_)
-		{
-			#if linux
-			if (title == null) title = "Save File";
-			#end
-
-			var path = null;
-			#if hl
-			var bytes = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
-			path = @:privateAccess String.fromUTF8(cast bytes);
-			#else
-			path = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
-			#end
-
-			worker.sendComplete(path);
-		});
-
 		worker.onComplete.add(function(path:String)
 		{
 			if (path != null)
@@ -338,7 +317,22 @@ class FileDialog
 			onCancel.dispatch();
 		});
 
-		worker.run();
+		worker.run(function(_)
+		{
+			#if linux
+			if (title == null) title = "Save File";
+			#end
+
+			var path = null;
+			#if hl
+			var bytes = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
+			path = @:privateAccess String.fromUTF8(cast bytes);
+			#else
+			path = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
+			#end
+
+			worker.sendComplete(path);
+		});
 
 		return true;
 		#elseif (js && html5)


### PR DESCRIPTION
This request fulfills #1081, addresses the issues in #1502, and adds documentation.

It will also break existing code, because `js.html.Worker` runs its functions in complete isolation. Many functions that work fine with `sys.thread.Thread` will fail because they can no longer access outside variables and functions. This will break someone's code if (and only if) they relied on the "fall back to synchronous execution" behavior. Fortunately, they can restore the old behavior using `<haxedef name="force_synchronous" if="js" />`.