### PR TITLE
Implement `Icon` priorities.

### DIFF
--- a/src/lime/tools/Icon.hx
+++ b/src/lime/tools/Icon.hx
@@ -12,7 +12,7 @@ class Icon
 	{
 		this.path = path;
 		this.size = height = width = size;
-		this.priority = 0;
+		this.priority = priority;
 	}
 
 	public function clone():Icon

--- a/src/lime/tools/Icon.hx
+++ b/src/lime/tools/Icon.hx
@@ -6,11 +6,13 @@ class Icon
 	public var path:String;
 	public var size:Int;
 	public var width:Int;
+	public var priority:Int;
 
-	public function new(path:String, size:Int = 0)
+	public function new(path:String, size:Int = 0, priority:Int = 0)
 	{
 		this.path = path;
 		this.size = height = width = size;
+		this.priority = 0;
 	}
 
 	public function clone():Icon

--- a/src/lime/tools/IconHelper.hx
+++ b/src/lime/tools/IconHelper.hx
@@ -290,27 +290,41 @@ class IconHelper
 		return match;
 	}
 
-	public static function findNearestMatch(icons:Array<Icon>, width:Int, height:Int):Icon
+	public static function findNearestMatch(icons:Array<Icon>, width:Int, height:Int, ?acceptSmaller:Bool = false):Icon
 	{
 		var match:Icon = null;
 		var matchDifference = Math.POSITIVE_INFINITY;
 
 		for (icon in icons)
 		{
-			var iconDifference = Math.abs(icon.width - width) + Math.abs(icon.height - height);
+			var iconDifference = icon.width - width + icon.height - height;
 			if (Path.extension(icon.path) == "svg")
 			{
 				iconDifference = 0;
 			}
 
-			if (iconDifference < matchDifference || iconDifference == matchDifference && icon.priority >= match.priority)
+			if (iconDifference < 0 && !acceptSmaller)
+			{
+				continue;
+			}
+
+			if (Math.abs(iconDifference) < Math.abs(matchDifference)
+				|| iconDifference == matchDifference && icon.priority >= match.priority)
 			{
 				match = icon;
 				matchDifference = iconDifference;
 			}
 		}
 
-		return match;
+		if (match == null && !acceptSmaller)
+		{
+			// Try again but accept any icon
+			return findNearestMatch(icons, width, height, true);
+		}
+		else
+		{
+			return match;
+		}
 	}
 
 	private static function getIconImage(icons:Array<Icon>, width:Int, height:Int,

--- a/src/lime/tools/IconHelper.hx
+++ b/src/lime/tools/IconHelper.hx
@@ -281,7 +281,7 @@ class IconHelper
 
 		for (icon in icons)
 		{
-			if ((icon.width == 0 && icon.height == 0) || (icon.width == width && icon.height == height))
+			if (icon.width == width && icon.height == height && (match == null || match.priority < icon.priority))
 			{
 				match = icon;
 			}
@@ -292,33 +292,21 @@ class IconHelper
 
 	public static function findNearestMatch(icons:Array<Icon>, width:Int, height:Int):Icon
 	{
-		var match = null;
+		var match:Icon = null;
+		var matchDifference = Math.POSITIVE_INFINITY;
 
 		for (icon in icons)
 		{
-			if (icon.width > width / 2 && icon.height > height / 2)
+			var iconDifference = Math.abs(icon.width - width) + Math.abs(icon.height - height);
+			if (Path.extension(icon.path) == "svg")
 			{
-				if (match == null)
-				{
-					match = icon;
-				}
-				else
-				{
-					if (icon.width > match.width && icon.height > match.height)
-					{
-						if (match.width < width || match.height < height)
-						{
-							match = icon;
-						}
-					}
-					else
-					{
-						if (icon.width > width && icon.height > height)
-						{
-							match = icon;
-						}
-					}
-				}
+				iconDifference = 0;
+			}
+
+			if (iconDifference < matchDifference || iconDifference == matchDifference && icon.priority > match.priority)
+			{
+				match = icon;
+				matchDifference = iconDifference;
 			}
 		}
 

--- a/src/lime/tools/IconHelper.hx
+++ b/src/lime/tools/IconHelper.hx
@@ -277,7 +277,7 @@ class IconHelper
 
 	public static function findMatch(icons:Array<Icon>, width:Int, height:Int):Icon
 	{
-		var match = null;
+		var match:Icon = null;
 
 		for (icon in icons)
 		{

--- a/src/lime/tools/IconHelper.hx
+++ b/src/lime/tools/IconHelper.hx
@@ -281,7 +281,7 @@ class IconHelper
 
 		for (icon in icons)
 		{
-			if (icon.width == width && icon.height == height && (match == null || match.priority < icon.priority))
+			if (icon.width == width && icon.height == height && (match == null || match.priority <= icon.priority))
 			{
 				match = icon;
 			}
@@ -303,7 +303,7 @@ class IconHelper
 				iconDifference = 0;
 			}
 
-			if (iconDifference < matchDifference || iconDifference == matchDifference && icon.priority > match.priority)
+			if (iconDifference < matchDifference || iconDifference == matchDifference && icon.priority >= match.priority)
 			{
 				match = icon;
 				matchDifference = iconDifference;

--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -1478,6 +1478,11 @@ class ProjectXMLParser extends HXProject
 							icon.height = Std.parseInt(substitute(element.att.height));
 						}
 
+						if (element.has.priority)
+						{
+							icon.priority = Std.parseInt(substitute(element.att.priority));
+						}
+
 						icons.push(icon);
 
 					case "source", "classpath":


### PR DESCRIPTION
With this, a library can set a "default" icon, to be used only if the user doesn't provide a better one. Closes #1508.