### PR TITLE
Fixing FileDialog Crashes on HL & A Crash when building for HL

### DIFF
--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -739,12 +739,12 @@ class NativeApplication
 
 @:keep /*private*/ class KeyEventInfo
 {
-	public var keyCode:Float;
+	public var keyCode: #if neko Float #else Int #end;
 	public var modifier:Int;
 	public var type:KeyEventType;
 	public var windowID:Int;
 
-	public function new(type:KeyEventType = null, windowID:Int = 0, keyCode:Float = 0, modifier:Int = 0)
+	public function new(type:KeyEventType = null, windowID:Int = 0, keyCode:#if neko Float #else Int #end = 0, modifier:Int = 0)
 	{
 		this.type = type;
 		this.windowID = windowID;

--- a/src/lime/ui/FileDialog.hx
+++ b/src/lime/ui/FileDialog.hx
@@ -167,7 +167,7 @@ class FileDialog
 					var path = null;
 					#if hl
 					var bytes = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
-					path = @:privateAccess String.fromUTF8(cast bytes);
+					path = if (bytes != null) @:privateAccess String.fromUTF8(cast bytes) else "";
 					#else
 					path = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
 					#end
@@ -246,7 +246,7 @@ class FileDialog
 			var path = null;
 			#if hl
 			var bytes = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
-			path = @:privateAccess String.fromUTF8(cast bytes);
+			path = if (bytes != null) @:privateAccess String.fromUTF8(cast bytes) else "";
 			#else
 			path = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
 			#end


### PR DESCRIPTION
i downloaded the latest lime git version for the fixed `FileDialog` but it still had some issues. those issues were very annoying, but pretty simple to fix. ill explain the changes - 

### NativeApplication

when entering the app, this error popped up:
```
src\module.c(465) : FATAL ERROR : Invalid signature for function lime@lime_key_event_manager_register : PP_vOdiii__v required but PP_vOiiii__v found in hdll
```
i managed to fix it by adding a conditional block to a change at `KeyEventInfo` that was ment to fix issues with the `neko` target

### FileDialog

when pressing `cancel` or the `X` button, an `Access Violation` error popped up:
```
Called from $String.fromUTF8 (C:\Users\shaha\Desktop\Everything HaxeFlixel\haxe\std/hl/_std/String.hx line 240)
Called from lime.ui.FileDialog.~open.0 (lime/ui/FileDialog.hx line 251)
Called from lime.app._Event_Dynamic_Void.dispatch (lime/_internal/macros/EventMacro.hx line 91)
Called from lime.system.BackgroundWorker.__doWork (lime/system/BackgroundWorker.hx line 115)
Called from lime.system.BackgroundWorker.run (lime/system/BackgroundWorker.hx line 67)
Called from lime.ui.FileDialog.open (lime/ui/FileDialog.hx line 275)
Called from menu.AppMenu.onScanWS (menu/AppMenu.hx line 141)
Called from worksheetScanner.$PageEditor.~__constructor__.1 (lime/app/Module.hx line 0)
Called from openfl.events.EventDispatcher.__dispatchEvent (openfl/events/EventDispatcher.hx line 402)
Called from openfl.display.DisplayObject.__dispatch (openfl/display/DisplayObject.hx line 1399)
Called from openfl.display.Stage.__dispatchStack (openfl/display/Stage.hx line 1293)
Called from openfl.display.Stage.__dispatchStack (openfl/display/Stage.hx line 1263)
Access violation
Uncaught exception: Access violation
Called from haxe.$NativeStackTrace.callStack(C:\Users\shaha\Desktop\Everything HaxeFlixel\haxe\std/hl/_std/haxe/NativeStackTrace.hx:25)
Called from haxe.$NativeStackTrace.callStack(C:\Users\shaha\Desktop\Everything HaxeFlixel\haxe\std/hl/_std/haxe/NativeStackTrace.hx:24)
Called from haxe._CallStack.$CallStack_Impl_.callStack(C:\Users\shaha\Desktop\Everything HaxeFlixel\haxe\std/haxe/CallStack.hx:52)
Called from haxe._CallStack.$CallStack_Impl_.exceptionStack(C:\Users\shaha\Desktop\Everything HaxeFlixel\haxe\std/haxe/CallStack.hx:65)
Called from openfl.display.Stage.__handleError(openfl/display/Stage.hx:1416)
Called from openfl.display.Stage.__dispatchStack(openfl/display/Stage.hx:1323)
Called from openfl.display.Stage.__onMouse(openfl/display/Stage.hx:2493)
Called from openfl.display.Stage.__onLimeMouseUp(openfl/display/Stage.hx:1894)
Called from openfl.display.Stage.~__onLimeCreateWindow.16(openfl/display/Stage.hx:1709)
Called from lime.app._Event_Float_Float_Int_Void.dispatch(lime/_internal/macros/EventMacro.hx:91)
Called from lime._internal.backend.native.NativeApplication.handleMouseEvent(lime/_internal/backend/native/NativeApplication.hx:341)
Called from lime.app.Application.exec(lime/app/Application.hx:150)
Called from $ApplicationMain.create(ApplicationMain.hx:130)
Called from $ApplicationMain.main(ApplicationMain.hx:25)
Called from fun$10604(?:1)
```

I suspected it was because of a null value (no file was being selected in the `FileDialog`). by adding a ` if ( bytes != null) ... else ""` to the `path` fields at lines 170 and 250 (i think those are the lines) the error was fixed.

those are pretty simple and straight-forward solutions.