### PR TITLE
Fix `Main.cpp` template for `-static` `-debug` builds

### DIFF
--- a/templates/cpp/static/Main.cpp
+++ b/templates/cpp/static/Main.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-#ifdef HX_WINDOWS
+#if defined(HX_WINDOWS) && !defined(HXCPP_DEBUG)
 #include <windows.h>
 #endif
 
@@ -14,7 +14,7 @@ extern "C" int lime_openal_register_prims ();
 extern "C" int ::nameSafe::_register_prims ();::end::::end::
 
 
-#ifdef HX_WINDOWS
+#if defined(HX_WINDOWS) && !defined(HXCPP_DEBUG)
 int __stdcall WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
 #else
 extern "C" int main(int argc, char *argv[]) {


### PR DESCRIPTION
When building a Lime application in debug mode on Windows, the console subsystem is used and Windows looks for a `main` function. However, the `Main.cpp` file used when linking statically always defines a `WinMain` function regardless of whether the application is being built in debug mode.

This pull request adds an additional check in `Main.cpp` to define a `main` function instead of `WinMain` when building in debug mode.