### PR TITLE
Add `exported="true"` to AndroidManifest.xml

### DIFF
--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
 		<meta-data android:name="SDL_ENV.SDL_IOS_ORIENTATIONS" android:value=  "LandscapeLeft LandscapeRight" />
 		::end::
 
-		<activity android:name="MainActivity" android:launchMode="singleTask" android:label="::APP_TITLE::" android:configChanges="keyboardHidden|orientation|screenSize|screenLayout"::if (WIN_ORIENTATION=="portrait"):: android:screenOrientation="sensorPortrait"::end::::if (WIN_ORIENTATION=="landscape"):: android:screenOrientation="sensorLandscape"::end::>
+		<activity android:name="MainActivity" android:exported="true" android:launchMode="singleTask" android:label="::APP_TITLE::" android:configChanges="keyboardHidden|orientation|screenSize|screenLayout"::if (WIN_ORIENTATION=="portrait"):: android:screenOrientation="sensorPortrait"::end::::if (WIN_ORIENTATION=="landscape"):: android:screenOrientation="sensorLandscape"::end::>
 			
 			<intent-filter>
 				


### PR DESCRIPTION
Otherwise it throws the following error on build:
"Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details."

To publish apps on Google Play everyone needs to target SDK 31+, which is Android 12+, so this is like a must now.
Works fine with older version of SDKs. (I've checked 28.)

If "true", the activity is accessible to any app, and is launchable by its exact class name.
If "false", the activity can be launched only by components of the same application, applications with the same user ID, or privileged system components. This is the default value when there are no intent filters.