### PR TITLE
Only call `buildBuffer()` when needed.

### DIFF
--- a/src/lime/_internal/backend/native/NativeHTTPRequest.hx
+++ b/src/lime/_internal/backend/native/NativeHTTPRequest.hx
@@ -42,7 +42,7 @@ class NativeHTTPRequest
 	private static var multiAddHandle:Deque<CURL>;
 	#end
 	private static var cookieList:Array<String>;
-	
+
 	private var buffer:BytesBuffer = new BytesBuffer();
 	private var bytes:Bytes;
 	private var bytesLoaded:Int;
@@ -362,12 +362,12 @@ class NativeHTTPRequest
 
 		return promise.future;
 	}
-	
+
 	private function buildBuffer()	{
 		bytes = buffer.getBytes();
 		return bytes;
 	}
-	
+
 	// Event Handlers
 	private function curl_onHeader(curl:CURL, header:String):Void
 	{

--- a/src/lime/_internal/backend/native/NativeHTTPRequest.hx
+++ b/src/lime/_internal/backend/native/NativeHTTPRequest.hx
@@ -571,7 +571,7 @@ class NativeHTTPRequest
 				{
 					if (!instance.promise.isError)
 					{
-						instance.promise.complete(instance.bytes);
+						instance.promise.complete(instance.buildBuffer());
 					}
 				}
 				else if (instance.bytes != null)

--- a/src/lime/net/HTTPRequest.hx
+++ b/src/lime/net/HTTPRequest.hx
@@ -110,10 +110,6 @@ public function load(uri:String = null):Future<T>
 
 		future.onComplete(function(bytes)
 		{
-			#if sys
-			bytes = @:privateAccess __backend.buildBuffer();
-			#end
-			
 			responseData = fromBytes(bytes);
 			promise.complete(responseData);
 		});


### PR DESCRIPTION
Turns out, [`HTTPRequest`'s call](https://github.com/openfl/lime/blob/02617a854d02777ebb0e9534c1d59642938e8aef/src/lime/net/HTTPRequest.hx#L114) is only needed for internet requests. Files on the local machine will be [loaded directly into `bytes`](https://github.com/openfl/lime/blob/02617a854d02777ebb0e9534c1d59642938e8aef/src/lime/_internal/backend/native/NativeHTTPRequest.hx#L427), leaving `buffer` empty. Calling `buildBuffer()` will then delete the data.