### PR TITLE
Allow running native apps from other directories.

### DIFF
--- a/src/lime/system/CFFI.hx
+++ b/src/lime/system/CFFI.hx
@@ -1,6 +1,7 @@
 package lime.system;
 
 #if (!lime_doc_gen || lime_cffi)
+import haxe.io.Path;
 import lime._internal.macros.CFFIMacro;
 #if (sys && !macro)
 import sys.io.Process;
@@ -135,11 +136,16 @@ class CFFI
 
 			__moduleNames.set(library, library);
 
-			result = __tryLoad("./" + library, library, method, args);
+			var programPath:String = ".";
+			#if sys
+			programPath = Path.directory(Sys.programPath());
+			#end
+
+			result = __tryLoad(programPath + "/" + library, library, method, args);
 
 			if (result == null)
 			{
-				result = __tryLoad(".\\" + library, library, method, args);
+				result = __tryLoad(programPath + "\\" + library, library, method, args);
 			}
 
 			if (result == null)

--- a/templates/haxe/ManifestResources.hx
+++ b/templates/haxe/ManifestResources.hx
@@ -3,6 +3,7 @@ package;
 
 
 import haxe.io.Bytes;
+import haxe.io.Path;
 import lime.utils.AssetBundle;
 import lime.utils.AssetLibrary;
 import lime.utils.AssetManifest;
@@ -44,6 +45,8 @@ import sys.FileSystem;
 			rootPath = "";
 			#elseif console
 			rootPath = lime.system.System.applicationDirectory;
+			#elseif sys
+			rootPath = Path.directory(Sys.programPath()) + "/";
 			#else
 			rootPath = "./";
 			#end


### PR DESCRIPTION
It isn't always safe to assume `./` is the app directory, and removing that assumption opens up options.

`Sys.programPath()` requires at least Haxe 3.4, but I don't think Lime supports 3.3 anyway.

Resolves #1284.