### PR TITLE
Parse JNI class names more intelligently.

### DIFF
--- a/src/lime/system/JNI.hx
+++ b/src/lime/system/JNI.hx
@@ -176,8 +176,10 @@ class JNI
 		@param className A string in the format `"com/package/ClassName"` or
 		`"com/package/ClassName$NestedClass"`. If dots are used instead, `JNI`
 		will attempt to replace them with the correct symbols.
-		@param memberName The static method's name.
-		@param signature A Java VM type signature.
+		@param memberName The static method's name. To get a constructor, use
+		`<init>` as the method name.
+		@param signature A Java VM type signature. To get a constructor, use `V`
+		as the function's return value.
 		@param useArray Set this to create a function that takes a single
 		`Array<Dynamic>` argument, instead of multiple `Dynamic` arguments.
 		@param quietFail Set this to suppress the "method not found" error.

--- a/src/lime/system/JNI.hx
+++ b/src/lime/system/JNI.hx
@@ -96,6 +96,14 @@ class JNI
 		}
 	}
 
+	/**
+		@param className A string in the format `"com/package/ClassName"` or
+		`"com/package/ClassName$NestedClass"`. If dots are used instead, `JNI`
+		will attempt to replace them with the correct symbols.
+		@param memberName The member field's name.
+		@param signature A Java VM type signature.
+		@see Java VM type signatures: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/types.html#wp16432
+	**/
 	public static function createMemberField(className:String, memberName:String, signature:String):JNIMemberField
 	{
 		init();
@@ -108,6 +116,17 @@ class JNI
 		#end
 	}
 
+	/**
+		@param className A string in the format `"com/package/ClassName"` or
+		`"com/package/ClassName$NestedClass"`. If dots are used instead, `JNI`
+		will attempt to replace them with the correct symbols.
+		@param memberName The member method's name.
+		@param signature A Java VM type signature.
+		@param useArray Set this to create a function that takes a single
+		`Array<Dynamic>` argument, instead of multiple `Dynamic` arguments.
+		@param quietFail Set this to suppress the "method not found" error.
+		@see Java VM type signatures: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/types.html#wp16432
+	**/
 	public static function createMemberMethod(className:String, memberName:String, signature:String, useArray:Bool = false, quietFail:Bool = false):Dynamic
 	{
 		init();
@@ -133,6 +152,14 @@ class JNI
 		#end
 	}
 
+	/**
+		@param className A string in the format `"com/package/ClassName"` or
+		`"com/package/ClassName$NestedClass"`. If dots are used instead, `JNI`
+		will attempt to replace them with the correct symbols.
+		@param memberName The static field's name.
+		@param signature A Java VM type signature.
+		@see Java VM type signatures: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/types.html#wp16432
+	**/
 	public static function createStaticField(className:String, memberName:String, signature:String):JNIStaticField
 	{
 		init();
@@ -145,6 +172,17 @@ class JNI
 		#end
 	}
 
+	/**
+		@param className A string in the format `"com/package/ClassName"` or
+		`"com/package/ClassName$NestedClass"`. If dots are used instead, `JNI`
+		will attempt to replace them with the correct symbols.
+		@param memberName The static method's name.
+		@param signature A Java VM type signature.
+		@param useArray Set this to create a function that takes a single
+		`Array<Dynamic>` argument, instead of multiple `Dynamic` arguments.
+		@param quietFail Set this to suppress the "method not found" error.
+		@see Java VM type signatures: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/types.html#wp16432
+	**/
 	public static function createStaticMethod(className:String, memberName:String, signature:String, useArray:Bool = false, quietFail:Bool = false):Dynamic
 	{
 		init();

--- a/src/lime/system/JNI.hx
+++ b/src/lime/system/JNI.hx
@@ -3,6 +3,8 @@ package lime.system;
 #if (!lime_doc_gen || android)
 import lime._internal.backend.native.NativeCFFI;
 
+using StringTools;
+
 /**
 	The Java Native Interface (JNI) allows C++ code to call Java functions, and
 	vice versa. On Android, Haxe code compiles to C++, but only Java code can
@@ -30,6 +32,19 @@ class JNI
 {
 	private static var alreadyCreated = new Map<String, Bool>();
 	private static var initialized = false;
+
+	private static function transformClassName(className:String):String
+	{
+		var parts:Array<String> = className.split(".");
+		if (parts.length <= 1)
+			return className;
+
+		var nestedClassName:String = "";
+		if (~/^[A-Z]/.match(parts[parts.length - 2]))
+			nestedClassName = "$" + parts.pop();
+
+		return parts.join("/") + nestedClassName;
+	}
 
 	public static function callMember(method:Dynamic, jobject:Dynamic, a:Array<Dynamic>):Dynamic
 	{
@@ -86,6 +101,7 @@ class JNI
 		init();
 
 		#if (android && lime_cffi && !macro)
+		className = transformClassName(className);
 		return new JNIMemberField(NativeCFFI.lime_jni_create_field(className, memberName, signature, false));
 		#else
 		return null;
@@ -97,7 +113,7 @@ class JNI
 		init();
 
 		#if (android && lime_cffi && !macro)
-		className = className.split(".").join("/");
+		className = transformClassName(className);
 		var handle = NativeCFFI.lime_jni_create_method(className, memberName, signature, false, quietFail);
 
 		if (handle == null)
@@ -122,6 +138,7 @@ class JNI
 		init();
 
 		#if (android && lime_cffi && !macro)
+		className = transformClassName(className);
 		return new JNIStaticField(NativeCFFI.lime_jni_create_field(className, memberName, signature, true));
 		#else
 		return null;
@@ -133,7 +150,7 @@ class JNI
 		init();
 
 		#if (android && lime_cffi && !macro)
-		className = className.split(".").join("/");
+		className = transformClassName(className);
 		var handle = NativeCFFI.lime_jni_create_method(className, memberName, signature, true, quietFail);
 
 		if (handle == null)


### PR DESCRIPTION
Plus, add documentation to help avoid the sort of confusion we saw in #1295. Also, closes #1295.