### PR TITLE
Work around unreliable clipboard on Linux.

### DIFF
--- a/src/lime/system/Clipboard.hx
+++ b/src/lime/system/Clipboard.hx
@@ -52,16 +52,20 @@ class Clipboard
 	// Get & Set Methods
 	private static function get_text():String
 	{
-		// Native clipboard calls __update when clipboard changes
+		// Native clipboard (except Xorg) calls __update when clipboard changes.
 
 		#if (flash || js || html5)
 		__update();
 		#elseif linux
-		// Hack: SDL won't start calling __update until set_text()
-		// is called once.
+		// Xorg won't call __update until we call set_text at least once.
+		// Details: SDL_x11clipboard.c calls X11_XSetSelectionOwner,
+		// registering this app to receive clipboard events.
 		if (_text == null)
 		{
 			__update();
+
+			// Call set_text while changing as little as possible. (Rich text
+			// formatting will unavoidably be lost.)
 			set_text(_text);
 		}
 		#end

--- a/src/lime/system/Clipboard.hx
+++ b/src/lime/system/Clipboard.hx
@@ -56,6 +56,14 @@ class Clipboard
 
 		#if (flash || js || html5)
 		__update();
+		#elseif linux
+		// Hack: SDL won't start calling __update until set_text()
+		// is called once.
+		if (_text == null)
+		{
+			__update();
+			set_text(_text);
+		}
 		#end
 
 		return _text;


### PR DESCRIPTION
As reported in multiple issues, the Linux clipboard isn't very reliable. Based on my testing, it only starts working properly after `set_text()` is called, so I figured the easiest option was to ensure that that gets called without actually changing the text.

Downside is that it'll turn any rich text into plaintext, but that's why I modified `get_text()` rather than making an `__init__()` function. That way, we only overwrite the clipboard if the app actually needs it.

Closes #1298 and #1464.