### PR TITLE
Display preloader progress for packed asset libraries.

### DIFF
--- a/src/lime/utils/PackedAssetLibrary.hx
+++ b/src/lime/utils/PackedAssetLibrary.hx
@@ -182,11 +182,17 @@ import flash.media.Sound;
 
 				switch (types.get(id))
 				{
-					case BINARY, FONT, IMAGE, MUSIC, SOUND, TEXT:
+					case BINARY, FONT, IMAGE, TEXT:
 						assetsTotal++;
 
 					case MUSIC, SOUND:
+						Log.verbose("Preloading asset: " + id + " [" + types.get(id) + "]");
 						assetsTotal++;
+
+						var future = loadAudioBuffer(id);
+						future.onProgress(load_onProgress.bind(id));
+						future.onError(loadAudioBuffer_onError.bind(id));
+						future.onComplete(loadAudioBuffer_onComplete.bind(id));
 
 					default:
 				}
@@ -203,35 +209,31 @@ import flash.media.Sound;
 				{
 					if (!preload.get(id)) continue;
 
-					Log.verbose("Preloading asset: " + id + " [" + types.get(id) + "]");
-
 					switch (types.get(id))
 					{
 						case BINARY:
+							Log.verbose("Preloading asset: " + id + " [" + types.get(id) + "]");
 							var future = loadBytes(id);
 							// future.onProgress (load_onProgress.bind (id));
 							future.onError(load_onError.bind(id));
 							future.onComplete(loadBytes_onComplete.bind(id));
 
 						case FONT:
+							Log.verbose("Preloading asset: " + id + " [" + types.get(id) + "]");
 							var future = loadFont(id);
 							// future.onProgress (load_onProgress.bind (id));
 							future.onError(load_onError.bind(id));
 							future.onComplete(loadFont_onComplete.bind(id));
 
 						case IMAGE:
+							Log.verbose("Preloading asset: " + id + " [" + types.get(id) + "]");
 							var future = loadImage(id);
 							// future.onProgress (load_onProgress.bind (id));
 							future.onError(load_onError.bind(id));
 							future.onComplete(loadImage_onComplete.bind(id));
 
-						case MUSIC, SOUND:
-							var future = loadAudioBuffer(id);
-							// future.onProgress (load_onProgress.bind (id));
-							future.onError(load_onError.bind(id));
-							future.onComplete(loadAudioBuffer_onComplete.bind(id));
-
 						case TEXT:
+							Log.verbose("Preloading asset: " + id + " [" + types.get(id) + "]");
 							var future = loadText(id);
 							// future.onProgress (load_onProgress.bind (id));
 							future.onError(load_onError.bind(id));


### PR DESCRIPTION
Before this change, packed asset libraries don't incrementally update the preloader progress bar. This can make it seem like loading has stalled, especially on online targets with large asset packs being delivered over slow connections.

With this change, the download progress of the asset pack is tracked. Additionally, the unpacking progress of each individual asset in the pack is also tracked, though it's assumed to be a much smaller portion of the total time spent loading the asset pack.

Since audio files are not included in packet asset libraries, audio files are loaded separately from other asset types, the same way they would be loaded in a non-packed asset library.