### PR TITLE
Suppress `uiMode` configuration changes.

### DIFF
--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
 		<meta-data android:name="SDL_ENV.SDL_IOS_ORIENTATIONS" android:value=  "LandscapeLeft LandscapeRight" />
 		::end::
 
-		<activity android:name="MainActivity" android:exported="true" android:launchMode="singleTask" android:label="::APP_TITLE::" android:configChanges="keyboardHidden|orientation|screenSize|screenLayout"::if (WIN_ORIENTATION=="portrait"):: android:screenOrientation="sensorPortrait"::end::::if (WIN_ORIENTATION=="landscape"):: android:screenOrientation="sensorLandscape"::end::>
+		<activity android:name="MainActivity" android:exported="true" android:launchMode="singleTask" android:label="::APP_TITLE::" android:configChanges="keyboardHidden|orientation|screenSize|screenLayout|uiMode"::if (WIN_ORIENTATION=="portrait"):: android:screenOrientation="sensorPortrait"::end::::if (WIN_ORIENTATION=="landscape"):: android:screenOrientation="sensorLandscape"::end::>
 			
 			<intent-filter>
 				


### PR DESCRIPTION
When the user switches between dark and light themes, Android destroys and recreates the activity. However, Lime activities can't be recreated like this, and just close instead.

Since we don't actually use the system theme, there's no reason for Android to do this. Simplest solution is to suppress it. The only question is, should we expose [`onConfigurationChanged()`](https://developer.android.com/reference/android/app/Activity#onConfigurationChanged\(android.content.res.Configuration\)) to extensions, or is this too niche to be worth it?

References:
https://developer.android.com/guide/topics/resources/runtime-changes
https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#config-changes

Closes #1532.