### PR TITLE
Ensure removal of stale files from previous android asset updates

### DIFF
--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -43,6 +43,7 @@ class AssetHelper
 		}
 		else
 		{
+			System.markFileAsTouched(destination);
 			try
 			{
 				if (asset.encoding == AssetEncoding.BASE64)
@@ -73,12 +74,18 @@ class AssetHelper
 			{
 				System.copyFile(asset.sourcePath, destination, null, asset.type == TEMPLATE);
 			}
+			else
+			{
+				System.markFileAsTouched(destination);
+			}
 		}
 		else
 		{
 			System.mkdir(Path.directory(destination));
 
 			Log.info("", " - \x1b[1mWriting file:\x1b[0m " + destination);
+			
+			System.markFileAsTouched(destination);
 
 			try
 			{
@@ -129,6 +136,7 @@ class AssetHelper
 
 		if (targetPath != null)
 		{
+			System.markFileAsTouched(targetPath);
 			System.mkdir(Path.directory(targetPath));
 			Log.info("", " - \x1b[1mWriting asset manifest:\x1b[0m " + targetPath);
 			File.saveContent(targetPath, manifest.serialize());
@@ -184,6 +192,7 @@ class AssetHelper
 			{
 				targetPath = Path.combine(targetDirectory, manifest.name + ".json");
 				Log.info("", " - \x1b[1mWriting asset manifest:\x1b[0m " + targetPath);
+				System.markFileAsTouched(targetPath);
 				File.saveContent(targetPath, manifest.serialize());
 			}
 		}
@@ -466,6 +475,8 @@ class AssetHelper
 
 		if (handlers.length > 0)
 		{
+			System.markAllFilesStateAsUnknown();
+
 			var projectData = Serializer.run(project);
 			var temporaryFile = System.getTemporaryFile();
 

--- a/src/lime/tools/IconHelper.hx
+++ b/src/lime/tools/IconHelper.hx
@@ -34,6 +34,7 @@ class IconHelper
 				}
 			}
 
+			System.markFileAsTouched(targetPath);
 			return true;
 		}
 
@@ -53,6 +54,7 @@ class IconHelper
 			}
 
 			System.mkdir(Path.directory(targetPath));
+			System.markFileAsTouched(targetPath);
 			System.copyFile(icon.path, targetPath);
 			return true;
 		}
@@ -72,6 +74,7 @@ class IconHelper
 				if (bytes != null)
 				{
 					System.mkdir(Path.directory(targetPath));
+					System.markFileAsTouched(targetPath);
 					File.saveBytes(targetPath, bytes);
 					return true;
 				}
@@ -154,6 +157,7 @@ class IconHelper
 
 		if (bytes.length > 0)
 		{
+			System.markFileAsTouched(targetPath);
 			var file = File.write(targetPath, true);
 			file.bigEndian = true;
 
@@ -255,6 +259,7 @@ class IconHelper
 
 		if (images.length > 0)
 		{
+			System.markFileAsTouched(targetPath);
 			File.saveBytes(targetPath, icon);
 			return true;
 		}

--- a/src/lime/tools/ProjectHelper.hx
+++ b/src/lime/tools/ProjectHelper.hx
@@ -37,6 +37,7 @@ class ProjectHelper
 				Log.info("", " - \x1b[1mCopying library file:\x1b[0m " + path + " \x1b[3;37m->\x1b[0m " + targetPath);
 
 				System.mkdir(targetDirectory);
+				System.markFileAsTouched(targetPath);
 
 				try
 				{
@@ -91,6 +92,7 @@ class ProjectHelper
 			for (i in 0...paths.length)
 			{
 				itemDestination = Path.combine(destination, ProjectHelper.substitutePath(project, destinations[i]));
+				System.markFileAsTouched(itemDestination);
 				System.copyFile(paths[i], itemDestination, context, process);
 			}
 		}

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -385,6 +385,9 @@ class AndroidPlatform extends PlatformTarget
 
 	public override function update():Void
 	{
+		var destination = targetDirectory + "/bin";
+		System.markAllFilesInFolderAsUntouched(destination, ["app/build", "app/src/main/jniLibs"]);
+
 		AssetHelper.processLibraries(project, targetDirectory);
 
 		// project = project.clone ();
@@ -402,7 +405,6 @@ class AndroidPlatform extends PlatformTarget
 
 		// initialize (project);
 
-		var destination = targetDirectory + "/bin";
 		var sourceSet = destination + "/app/src/main";
 		System.mkdir(sourceSet);
 		System.mkdir(sourceSet + "/res/drawable-ldpi/");
@@ -591,6 +593,8 @@ class AndroidPlatform extends PlatformTarget
 				AssetHelper.copyAsset(asset, targetPath, context);
 			}
 		}
+
+		System.deleteUntouchedFiles();
 	}
 
 	public override function watch():Void


### PR DESCRIPTION
This is the lime part of a potential solution to [openfl/lime#1546 (Stale output from previous builds can cause errors)](https://github.com/openfl/lime/issues/1546), applied only to the android platform. This relies on https://github.com/openfl/hxp/pull/27.

`System.markFileAsTouched` is called as appropriate in AssetHelper, IconHelper, and ProjectHelper.

`app/src/main/jniLibs` is ignored because that folders isn't modified as part of the `update` step, but later on as part of the `build` step. `app/build` is ignored because that's the gradle build folder. We don't directly touch it ourselves, and gradle can hopefully be trusted to keep that in order as long as we provide the correct inputs to the gradle build.