### PR TITLE
Delete stale templates after each build.

### DIFF
--- a/src/lime/tools/PlatformTarget.hx
+++ b/src/lime/tools/PlatformTarget.hx
@@ -96,6 +96,10 @@ class PlatformTarget
 			// AssetHelper.processLibraries (project, targetDirectory);
 			// #end
 			update();
+
+			#if (hxp > "1.2.2")
+			System.deleteStaleTemplates(targetDirectory);
+			#end
 		}
 
 		if ((!Reflect.hasField(metaFields, "build") || !Reflect.hasField(metaFields.build, "ignore"))


### PR DESCRIPTION
Template files have a habit of sticking around in the output folder, even if the project no longer needs or wants them. Clearing old templates can improve app stability.

Like #1547, this is one half of a potential solution to #1546. (The other half is openfl/hxp#28.) And I'd argue it's a better solution, requiring less maintenance and not forcing users to update hxp at the same time as Lime.