### PR TITLE
[wip] Audio 3D position/panning changes (add panning, both panning and position off by default)

### DIFF
--- a/src/lime/_internal/backend/flash/FlashAudioSource.hx
+++ b/src/lime/_internal/backend/flash/FlashAudioSource.hx
@@ -114,6 +114,15 @@ class FlashAudioSource
 		return loops = value;
 	}
 
+	public function setPan(value:Float):Float
+	{
+		var soundTransform = channel.soundTransform;
+		soundTransform.pan = value;
+		channel.soundTransform = soundTransform;
+
+		return value;
+	}
+
 	public function getPitch():Float
 	{
 		lime.utils.Log.verbose("Pitch is not supported in Flash.");

--- a/src/lime/_internal/backend/flash/FlashAudioSource.hx
+++ b/src/lime/_internal/backend/flash/FlashAudioSource.hx
@@ -14,13 +14,10 @@ class FlashAudioSource
 	private var parent:AudioSource;
 	private var pauseTime:Int;
 	private var playing:Bool;
-	private var position:Vector4;
 
 	public function new(parent:AudioSource)
 	{
 		this.parent = parent;
-
-		position = new Vector4();
 	}
 
 	public function dispose():Void {}
@@ -128,24 +125,12 @@ class FlashAudioSource
 		return getPitch();
 	}
 
-	public function getPosition():Vector4
-	{
-		position.x = channel.soundTransform.pan;
-
-		return position;
-	}
-
 	public function setPosition(value:Vector4):Vector4
 	{
-		position.x = value.x;
-		position.y = value.y;
-		position.z = value.z;
-		position.w = value.w;
-
 		var soundTransform = channel.soundTransform;
-		soundTransform.pan = position.x;
+		soundTransform.pan = value.x;
 		channel.soundTransform = soundTransform;
 
-		return position;
+		return value;
 	}
 }

--- a/src/lime/_internal/backend/html5/HTML5AudioSource.hx
+++ b/src/lime/_internal/backend/html5/HTML5AudioSource.hx
@@ -48,6 +48,7 @@ class HTML5AudioSource
 		untyped parent.buffer.__srcHowl._volume = cacheVolume;
 		// setGain (parent.gain);
 
+		if(parent.pan != null) setPan(parent.pan);
 		if(parent.position != null) setPosition(parent.position);
 
 		parent.buffer.__srcHowl.on("end", howl_onEnd, id);
@@ -200,6 +201,15 @@ class HTML5AudioSource
 	public function setLoops(value:Int):Int
 	{
 		return loops = value;
+	}
+
+	public function setPan(value:Float):Float
+	{
+		#if lime_howlerjs
+		if (parent.buffer.__srcHowl != null && parent.buffer.__srcHowl.stereo != null) parent.buffer.__srcHowl.stereo(value, id);
+		#end
+
+		return value;
 	}
 
 	public function getPitch():Float

--- a/src/lime/_internal/backend/html5/HTML5AudioSource.hx
+++ b/src/lime/_internal/backend/html5/HTML5AudioSource.hx
@@ -13,7 +13,6 @@ class HTML5AudioSource
 	private var loops:Int;
 	private var parent:AudioSource;
 	private var playing:Bool;
-	private var position:Vector4;
 
 	public function new(parent:AudioSource)
 	{
@@ -21,7 +20,6 @@ class HTML5AudioSource
 
 		id = -1;
 		gain = 1;
-		position = new Vector4();
 	}
 
 	public function dispose():Void {}
@@ -50,7 +48,7 @@ class HTML5AudioSource
 		untyped parent.buffer.__srcHowl._volume = cacheVolume;
 		// setGain (parent.gain);
 
-		setPosition(parent.position);
+		if(parent.position != null) setPosition(parent.position);
 
 		parent.buffer.__srcHowl.on("end", howl_onEnd, id);
 
@@ -221,35 +219,14 @@ class HTML5AudioSource
 		
 		return getPitch();
 	}
-	
-
-	public function getPosition():Vector4
-	{
-		#if lime_howlerjs
-		// This should work, but it returns null (But checking the inside of the howl, the _pos is actually null... so ¯\_(ツ)_/¯)
-		/*
-			var arr = parent.buffer.__srcHowl.pos())
-			position.x = arr[0];
-			position.y = arr[1];
-			position.z = arr[2];
-		 */
-		#end
-
-		return position;
-	}
 
 	public function setPosition(value:Vector4):Vector4
 	{
-		position.x = value.x;
-		position.y = value.y;
-		position.z = value.z;
-		position.w = value.w;
-
 		#if lime_howlerjs
-		if (parent.buffer.__srcHowl != null && parent.buffer.__srcHowl.pos != null) parent.buffer.__srcHowl.pos(position.x, position.y, position.z, id);
+		if (parent.buffer.__srcHowl != null && parent.buffer.__srcHowl.pos != null) parent.buffer.__srcHowl.pos(value.x, value.y, value.z, id);
 		// There are more settings to the position of the sound on the "pannerAttr()" function of howler. Maybe somebody who understands sound should look into it?
 		#end
 
-		return position;
+		return value;
 	}
 }

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -518,6 +518,17 @@ class NativeAudioSource
 		return loops = value;
 	}
 
+	public function setPan(value:Float):Float
+	{
+		if (handle != null)
+		{
+			AL.distanceModel(AL.NONE);
+			AL.source3f(handle, AL.POSITION, value, 0, -1 * Math.sqrt(1 - Math.pow(value, 2)));
+		}
+
+		return value;
+	}
+
 	public function getPitch():Float
 	{
 		if (handle != null)

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -36,7 +36,6 @@ class NativeAudioSource
 	private var loops:Int;
 	private var parent:AudioSource;
 	private var playing:Bool;
-	private var position:Vector4;
 	private var samples:Int;
 	private var stream:Bool;
 	private var streamTimer:Timer;
@@ -45,8 +44,6 @@ class NativeAudioSource
 	public function new(parent:AudioSource)
 	{
 		this.parent = parent;
-
-		position = new Vector4();
 	}
 
 	public function dispose():Void
@@ -559,34 +556,14 @@ class NativeAudioSource
 		return value;
 	}
 
-	public function getPosition():Vector4
-	{
-		if (handle != null)
-		{
-			#if !emscripten
-			var value = AL.getSource3f(handle, AL.POSITION);
-			position.x = value[0];
-			position.y = value[1];
-			position.z = value[2];
-			#end
-		}
-
-		return position;
-	}
-
 	public function setPosition(value:Vector4):Vector4
 	{
-		position.x = value.x;
-		position.y = value.y;
-		position.z = value.z;
-		position.w = value.w;
-
 		if (handle != null)
 		{
 			AL.distanceModel(AL.NONE);
-			AL.source3f(handle, AL.POSITION, position.x, position.y, position.z);
+			AL.source3f(handle, AL.POSITION, value.x, value.y, value.z);
 		}
 
-		return position;
+		return value;
 	}
 }

--- a/src/lime/media/AudioSource.hx
+++ b/src/lime/media/AudioSource.hx
@@ -19,7 +19,9 @@ class AudioSource
 	public var loops(get, set):Int;
 	public var pitch(get, set):Float;
 	public var offset:Int;
-	public var position(get, set):Vector4;
+	public var position(get, set):Null<Vector4>;
+
+	public var _position:Null<Vector4>;
 
 	@:noCompletion private var __backend:AudioSourceBackend;
 
@@ -119,14 +121,21 @@ class AudioSource
 		return __backend.setPitch(value);
 	}
 
-	@:noCompletion private function get_position():Vector4
+	@:noCompletion private function get_position():Null<Vector4>
 	{
-		return __backend.getPosition();
+		return _position;
 	}
 
-	@:noCompletion private function set_position(value:Vector4):Vector4
+	@:noCompletion private function set_position(value:Null<Vector4>):Null<Vector4>
 	{
-		return __backend.setPosition(value);
+		if(value == null)
+		{
+			_position = __backend.setPosition(new Vector4(0, 0, 0, 0));
+		}
+
+		_position = __backend.setPosition(value);
+
+		return _position;
 	}
 }
 

--- a/src/lime/media/AudioSource.hx
+++ b/src/lime/media/AudioSource.hx
@@ -19,8 +19,10 @@ class AudioSource
 	public var loops(get, set):Int;
 	public var pitch(get, set):Float;
 	public var offset:Int;
+	public var pan(get, set):Null<Float>;
 	public var position(get, set):Null<Vector4>;
 
+	public var _pan:Null<Float>;
 	public var _position:Null<Vector4>;
 
 	@:noCompletion private var __backend:AudioSourceBackend;
@@ -111,6 +113,29 @@ class AudioSource
 		return __backend.setLoops(value);
 	}
 
+	@:noCompletion private function get_pan():Null<Float>
+	{
+		return _pan;
+	}
+
+	@:noCompletion private function set_pan(value:Null<Float>):Null<Float>
+	{
+		if(_position != null)
+		{
+			trace("Can't set pan on a spatial sound.");
+			return _pan;
+		}
+
+		if(value == null)
+		{
+			_pan = __backend.setPan(0);
+		}
+
+		_pan = __backend.setPan(value);
+
+		return _pan;
+	}
+
 	@:noCompletion private function get_pitch():Float
 	{
 		return __backend.getPitch();
@@ -128,6 +153,12 @@ class AudioSource
 
 	@:noCompletion private function set_position(value:Null<Vector4>):Null<Vector4>
 	{
+		if(_pan != null)
+		{
+			trace("Can't set position on a panned sound.");
+			return _position;
+		}
+
 		if(value == null)
 		{
 			_position = __backend.setPosition(new Vector4(0, 0, 0, 0));


### PR DESCRIPTION
There are a few issues with sound position that this PR aims to improve.

- 3D position is used to simulate panning on non-Flash targets. This is ok for native, where we use OpenAL and there's no alternative for panning. On HTML5, however, howler has a stereo mode for playing sounds. That gives a better result than using the awkwardly simulated panning based on 3D audio.

- Using 3D audio at all on HTML5 can lead to serious degradation of audio quality ("muffled" sounds).
  [Stencyl Issue Tracker: Muffled Sounds On HTML5](https://community.stencyl.com/index.php?issue=1509.0)

- Using 3D audio positioning at all can lead to extra audio processing code being run, even if the position is (0, 0, 0), so it should be avoided if not desired.

This makes position a nullable value, null by default, which is a change to the AudioSource API.