### PR TITLE
Don't set AL.BYTE_OFFSET immediately after calling AL.sourcePlay

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -187,8 +187,6 @@ class NativeAudioSource
 		{
 			var time = completed ? 0 : getCurrentTime();
 
-			AL.sourcePlay(handle);
-
 			setCurrentTime(time);
 		}
 	}
@@ -417,7 +415,7 @@ class NativeAudioSource
 			else if (parent.buffer != null)
 			{
 				AL.sourceRewind(handle);
-				if (playing) AL.sourcePlay(handle);
+				
 				// AL.sourcef (handle, AL.SEC_OFFSET, (value + parent.offset) / 1000);
 
 				var secondOffset = (value + parent.offset) / 1000;
@@ -430,6 +428,7 @@ class NativeAudioSource
 				var totalOffset = Std.int(dataLength * ratio);
 
 				AL.sourcei(handle, AL.BYTE_OFFSET, totalOffset);
+				if (playing) AL.sourcePlay(handle);
 			}
 		}
 


### PR DESCRIPTION
This fixes the apparently iOS-only problem of sounds playing the first part multiple times, described here:
https://community.openfl.org/t/sounds-play-twice-on-ios/12163