### PR TITLE
Added timestamp to KeyDown and KeyUp events.

### DIFF
--- a/project/include/ui/KeyEvent.h
+++ b/project/include/ui/KeyEvent.h
@@ -25,6 +25,7 @@ namespace lime {
 		int modifier;
 		KeyEventType type;
 		int windowID;
+		int timestamp;
 
 		static ValuePointer* callback;
 		static ValuePointer* eventObject;

--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -575,6 +575,7 @@ namespace lime {
 			keyEvent.keyCode = event->key.keysym.sym;
 			keyEvent.modifier = event->key.keysym.mod;
 			keyEvent.windowID = event->key.windowID;
+			keyEvent.timestamp = event->key.timestamp;
 
 			if (keyEvent.type == KEY_DOWN) {
 

--- a/project/src/ui/KeyEvent.cpp
+++ b/project/src/ui/KeyEvent.cpp
@@ -12,6 +12,7 @@ namespace lime {
 	static int id_modifier;
 	static int id_type;
 	static int id_windowID;
+	static int id_timestamp;
 	static bool init = false;
 
 
@@ -21,6 +22,7 @@ namespace lime {
 		modifier = 0;
 		type = KEY_DOWN;
 		windowID = 0;
+		timestamp = 0;
 
 	}
 
@@ -37,6 +39,7 @@ namespace lime {
 					id_modifier = val_id ("modifier");
 					id_type = val_id ("type");
 					id_windowID = val_id ("windowID");
+					id_timestamp = val_id ("timestamp");
 					init = true;
 
 				}
@@ -47,6 +50,7 @@ namespace lime {
 				alloc_field (object, id_modifier, alloc_int (event->modifier));
 				alloc_field (object, id_type, alloc_int (event->type));
 				alloc_field (object, id_windowID, alloc_int (event->windowID));
+				alloc_field (object, id_timestamp, alloc_int (event->timestamp));
 
 			} else {
 
@@ -56,6 +60,7 @@ namespace lime {
 				eventObject->modifier = event->modifier;
 				eventObject->type = event->type;
 				eventObject->windowID = event->windowID;
+				eventObject->timestamp = event->timestamp;
 
 			}
 

--- a/src/lime/_internal/backend/html5/HTML5Application.hx
+++ b/src/lime/_internal/backend/html5/HTML5Application.hx
@@ -412,10 +412,11 @@ class HTML5Application
 
 			var keyCode = cast convertKeyCode(event.keyCode != null ? event.keyCode : event.which);
 			var modifier = (event.shiftKey ? (KeyModifier.SHIFT) : 0) | (event.ctrlKey ? (KeyModifier.CTRL) : 0) | (event.altKey ? (KeyModifier.ALT) : 0) | (event.metaKey ? (KeyModifier.META) : 0);
+			var timestamp = event.timeStamp;
 
 			if (event.type == "keydown")
 			{
-				parent.window.onKeyDown.dispatch(keyCode, modifier);
+				parent.window.onKeyDown.dispatch(keyCode, modifier, timestamp);
 
 				if (parent.window.onKeyDown.canceled && event.cancelable)
 				{
@@ -424,7 +425,7 @@ class HTML5Application
 			}
 			else
 			{
-				parent.window.onKeyUp.dispatch(keyCode, modifier);
+				parent.window.onKeyUp.dispatch(keyCode, modifier, timestamp);
 
 				if (parent.window.onKeyUp.canceled && event.cancelable)
 				{

--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -257,14 +257,15 @@ class NativeApplication
 			var int32:Float = keyEventInfo.keyCode;
 			var keyCode:KeyCode = Std.int(int32);
 			var modifier:KeyModifier = keyEventInfo.modifier;
+			var timestamp:Int = keyEventInfo.timestamp;
 
 			switch (type)
 			{
 				case KEY_DOWN:
-					window.onKeyDown.dispatch(keyCode, modifier);
+					window.onKeyDown.dispatch(keyCode, modifier, timestamp);
 
 				case KEY_UP:
-					window.onKeyUp.dispatch(keyCode, modifier);
+					window.onKeyUp.dispatch(keyCode, modifier, timestamp);
 			}
 
 			#if (windows || linux)
@@ -755,18 +756,20 @@ class NativeApplication
 	public var modifier:Int;
 	public var type:KeyEventType;
 	public var windowID:Int;
+	public var timestamp:Int;
 
-	public function new(type:KeyEventType = null, windowID:Int = 0, keyCode: Float = 0, modifier:Int = 0)
+	public function new(type:KeyEventType = null, windowID:Int = 0, keyCode: Float = 0, modifier:Int = 0, timestamp:Int = 0)
 	{
 		this.type = type;
 		this.windowID = windowID;
 		this.keyCode = keyCode;
 		this.modifier = modifier;
+		this.timestamp = timestamp;
 	}
 
 	public function clone():KeyEventInfo
 	{
-		return new KeyEventInfo(type, windowID, keyCode, modifier);
+		return new KeyEventInfo(type, windowID, keyCode, modifier, timestamp);
 	}
 }
 

--- a/src/lime/app/Application.hx
+++ b/src/lime/app/Application.hx
@@ -239,15 +239,17 @@ class Application extends Module
 		Called when a key down event is fired on the primary window
 		@param	keyCode	The code of the key that was pressed
 		@param	modifier	The modifier of the key that was pressed
+		@param  timestamp   A preceise timestamp for the event
 	**/
-	public function onKeyDown(keyCode:KeyCode, modifier:KeyModifier):Void {}
+	public function onKeyDown(keyCode:KeyCode, modifier:KeyModifier, timestamp:Int):Void {}
 
 	/**
 		Called when a key up event is fired on the primary window
 		@param	keyCode	The code of the key that was released
 		@param	modifier	The modifier of the key that was released
+		@param  timestamp   A preceise timestamp for the event
 	**/
-	public function onKeyUp(keyCode:KeyCode, modifier:KeyModifier):Void {}
+	public function onKeyUp(keyCode:KeyCode, modifier:KeyModifier, timestamp:Int):Void {}
 
 	/**
 		Called when the module is exiting

--- a/src/lime/ui/Window.hx
+++ b/src/lime/ui/Window.hx
@@ -62,8 +62,8 @@ class Window
 	public var onFocusIn(default, null) = new Event<Void->Void>();
 	public var onFocusOut(default, null) = new Event<Void->Void>();
 	public var onFullscreen(default, null) = new Event<Void->Void>();
-	public var onKeyDown(default, null) = new Event<KeyCode->KeyModifier->Void>();
-	public var onKeyUp(default, null) = new Event<KeyCode->KeyModifier->Void>();
+	public var onKeyDown(default, null) = new Event<KeyCode->KeyModifier->Int->Void>();
+	public var onKeyUp(default, null) = new Event<KeyCode->KeyModifier->Int->Void>();
 	public var onLeave(default, null) = new Event<Void->Void>();
 	public var onMaximize(default, null) = new Event<Void->Void>();
 	public var onMinimize(default, null) = new Event<Void->Void>();


### PR DESCRIPTION
I am looking into methods of retrieving a highly precise timestamp corresponding with a user's keypress. This is important for applications which need to know exactly when a given key was pressed (which, among other things, includes video games such as rhythm games or fighting games, which demand precise inputs).

If each key event includes a precise hardware timestamp, recorded before any of the processing required to call event listeners is done, then said processing can be compensated for by retrieving a new timestamp and calculating the difference.

I discovered in my research that the `SDL_KeyboardEvent` which Lime receives (on native) does include such a timestamp, however the value is not retained, so I made this pull request to include it.

The pull request is a draft pending the resolution of the following issues:
- The change to the method signature of `lime.app.Application.onKeyDown` is a breaking change which affects OpenFL, Flixel, and other dependent libraries, is there a more stable method to make this change?
- The value provided in the `SDL_KeyboardEvent` is millisecond accurate, and is the value of `SDL_GetTicks` function, which is based on the duration since SDL was initialized, but there is not currently an accessible method to retrieve this value in Lime to perform comparison with.
- HTML5 platforms also have a timestamp associated with keyboard events, but the timestamp value is an absolute epoch time instead. How should this discrepancy be handled?