### PR TITLE
Fix NativeHTTPRequest.loadText

### DIFF
--- a/src/lime/_internal/backend/native/NativeHTTPRequest.hx
+++ b/src/lime/_internal/backend/native/NativeHTTPRequest.hx
@@ -349,7 +349,6 @@ class NativeHTTPRequest
 
 		future.onComplete(function(bytes)
 		{
-			bytes = buildBuffer();
 			if (bytes == null)
 			{
 				promise.complete(null);


### PR DESCRIPTION
Followup to these two commits:
02617a854d02777ebb0e9534c1d59642938e8aef
ad3a632927c06e5ed7d4b14ca3a6dd95a2e6c720

In the second commit, the `buildBuffer` call in `HTTPRequest` was found to conflict with the way local requests are made, with the bytes being set directly. So `buildBuffer` was moved to `NativeHTTPRequest` instead. Upon promise completion, now, the value of bytes should always be correct, and `buildBuffer` need not be called.

But `buildBuffer` is called again in `NativeHTTPRequest.loadText`. For local requests, this will lead to the same problem that the second commit fixed (presumably), and for network requests, this leads to the nulled out buffer being accessed a second time, resulting in a crash.

So since the received value of bytes is already correct and `buildBuffer` is harmful, the `buildBuffer` call is removed from `loadText`. Both local and network requests are happy now!