### PR TITLE
Fix Segementation Faults When Canceling File/Directory browsing

### DIFF
--- a/src/lime/ui/FileDialog.hx
+++ b/src/lime/ui/FileDialog.hx
@@ -112,7 +112,10 @@ class FileDialog
 					var path = null;
 					#if hl
 					var bytes = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
-					path = @:privateAccess String.fromUTF8(cast bytes);
+					if (bytes != null)
+					{
+						path = @:privateAccess String.fromUTF8(cast bytes);
+					}
 					#else
 					path = NativeCFFI.lime_file_dialog_open_file(title, filter, defaultPath);
 					#end
@@ -149,7 +152,10 @@ class FileDialog
 					var path = null;
 					#if hl
 					var bytes = NativeCFFI.lime_file_dialog_open_directory(title, filter, defaultPath);
-					path = @:privateAccess String.fromUTF8(cast bytes);
+					if (bytes != null)
+					{
+						path = @:privateAccess String.fromUTF8(cast bytes);
+					}
 					#else
 					path = NativeCFFI.lime_file_dialog_open_directory(title, filter, defaultPath);
 					#end
@@ -164,7 +170,10 @@ class FileDialog
 					var path = null;
 					#if hl
 					var bytes = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
-					if (bytes != null) path = @:privateAccess String.fromUTF8(cast bytes);
+					if (bytes != null)
+					{
+						path = @:privateAccess String.fromUTF8(cast bytes);
+					}
 					#else
 					path = NativeCFFI.lime_file_dialog_save_file(title, filter, defaultPath);
 					#end


### PR DESCRIPTION
A while ago i made a pull request that fixed pretty much the same error, but i only fixed it for `SAVE`. This PR fixes this bug for `OPEN_FILE` and `OPEN_DIRECTORY` too. `OPEN_MULTIPLE` always had the null check, and never crashed.

**This error is Hashlink only.**

(stack trace of that error:)
```
Uncaught exception: Access violation
Called from $String.fromUTF8(C:\HaxeToolkit\haxe\std/hl/_std/String.hx:240)
Called from lime.ui.FileDialog.~browse.1(lime/ui/FileDialog.hx:152)
Called from lime.app._Event_Dynamic_Void.dispatch(lime/_internal/macros/EventMacro.hx:91)
Called from lime.system.BackgroundWorker.__doWork(lime/system/BackgroundWorker.hx:115)
Called from lime.system.BackgroundWorker.run(lime/system/BackgroundWorker.hx:67)
Called from lime.ui.FileDialog.browse(lime/ui/FileDialog.hx:212)
Called from openfl.filesystem.File.browseForDirectory(openfl/filesystem/File.hx:498)
Called from $Segment2.~__constructor__.0(Installer.hx:254)
Called from haxe.ui.tooltips.ToolTipManager.~stopCurrent.0(lime/app/Module.hx:0)
Called from haxe.ui.util.EventMap.invoke(haxe/ui/util/EventMap.hx:76)
Called from haxe.ui.core.ComponentEvents.dispatch(haxe/ui/core/ComponentEvents.hx:98)
Called from haxe.ui.core.ComponentEvents._onMappedEvent(haxe/ui/core/ComponentEvents.hx:127)
Called from haxe.ui.backend.ComponentImpl.__onMouseEvent(haxe/ui/backend/ComponentImpl.hx:343)
Called from openfl.text.TextField.~this_onMouseDown.2(lime/app/Module.hx:0)
Called from openfl.events.EventDispatcher.__dispatchEvent(openfl/events/EventDispatcher.hx:402)
Called from openfl.display.DisplayObject.__dispatch(openfl/display/DisplayObject.hx:1399)
Called from openfl.display.Stage.__dispatchStack(openfl/display/Stage.hx:1375)
Called from openfl.display.Stage.__onMouse(openfl/display/Stage.hx:2618)
Called from openfl.display.Stage.__onLimeMouseUp(openfl/display/Stage.hx:1982)
Called from openfl.display.Stage.~__onLimeCreateWindow.16(openfl/display/Stage.hx:1781)
Called from lime.app._Event_Float_Float_Int_Void.dispatch(lime/_internal/macros/EventMacro.hx:91)
Called from lime._internal.backend.native.NativeApplication.handleMouseEvent(lime/_internal/backend/native/NativeApplication.hx:341)
Called from lime._internal.backend.native.NativeApplication.exec(lime/_internal/backend/native/NativeApplication.hx:146)
Called from lime.app.Application.exec(lime/app/Application.hx:150)
Called from $ApplicationMain.create(ApplicationMain.hx:135)
Called from $ApplicationMain.main(ApplicationMain.hx:26)
Called from .init(?:1)
```