### PR TITLE
Don't prioritize SVG icons.

### DIFF
--- a/src/lime/tools/IconHelper.hx
+++ b/src/lime/tools/IconHelper.hx
@@ -298,9 +298,11 @@ class IconHelper
 		for (icon in icons)
 		{
 			var iconDifference = icon.width - width + icon.height - height;
-			if (Path.extension(icon.path) == "svg")
+
+			// If size is unspecified, accept it as an almost-perfect match
+			if (icon.width == 0 && icon.height == 0)
 			{
-				iconDifference = 0;
+				iconDifference = 1;
 			}
 
 			if (iconDifference < 0 && !acceptSmaller)


### PR DESCRIPTION
Instead, assume that any icon without a specified size can scale freely. (This will typically still include SVGs.)

This change is meant to address #1576 and similar situations, where a low-priority SVG overrides a high-priority PNG. With this change, the image types are treated equally, so priority becomes the deciding factor.