### PR TITLE
Fix openFile not working on Linux.

### DIFF
--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -298,7 +298,7 @@ class System
 			#elseif mac
 			Sys.command("/usr/bin/open", [path]);
 			#elseif linux
-			Sys.command("/usr/bin/xdg-open", [path, "&"]);
+			Sys.command("/usr/bin/xdg-open", [path]);
 			#elseif (js && html5)
 			Browser.window.open(path, "_blank");
 			#elseif flash


### PR DESCRIPTION
Thanks to LeotomasMC for some assistance with this.

I noticed and was quite confused by the fact that certain things in Flixel failed to work on Linux, such as FlxG.openURL, which returned "xdg-open: unexpected argument '&'". This appears to fix that and seems to work quite fine, with that segment of Flixel now working once more.

May be good to have someone more qualified than I check this out before er... merging, as I'm not exactly the best programmer around.