### PR TITLE
Use macOS 11 for testing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           if-no-files-found: error
 
   macos-ndll:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: actions/checkout@v2
@@ -200,7 +200,7 @@ jobs:
 
   android-ndll:
     needs: macos-ndll
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: actions/checkout@v2
@@ -268,7 +268,7 @@ jobs:
 
   ios-ndll:
     needs: macos-ndll
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: actions/checkout@v2
@@ -318,7 +318,7 @@ jobs:
 
   package-haxelib:
     needs: [linux-ndll, macos-ndll, windows-ndll, android-ndll, ios-ndll]
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: actions/checkout@v2
@@ -416,7 +416,7 @@ jobs:
           if-no-files-found: error
 
   docs:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: actions/checkout@v2
@@ -449,7 +449,7 @@ jobs:
 
   android-samples:
     needs: package-haxelib
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - name: Install Android NDK
@@ -513,7 +513,7 @@ jobs:
 
   flash-samples:
     needs: package-haxelib
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: krdlab/setup-haxe@v1
@@ -554,7 +554,7 @@ jobs:
     needs: package-haxelib
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-18.04, macos-11, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -619,7 +619,7 @@ jobs:
 
   html5-samples:
     needs: package-haxelib
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: krdlab/setup-haxe@v1
@@ -658,7 +658,7 @@ jobs:
 
   ios-samples:
     needs: package-haxelib
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: krdlab/setup-haxe@v1
@@ -755,7 +755,7 @@ jobs:
 
   macos-samples:
     needs: package-haxelib
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
 
       - uses: krdlab/setup-haxe@v1
@@ -803,7 +803,7 @@ jobs:
     needs: package-haxelib
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-18.04, macos-11, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
GitHub has officially begun to [drop macOS 10.15 support](https://github.com/actions/runner-images/issues/5583), causing workflows to fail.