### PR TITLE
Stop linking with liblinuxcompat.a

### DIFF
--- a/templates/cpp/static/BuildMain.xml
+++ b/templates/cpp/static/BuildMain.xml
@@ -40,7 +40,6 @@
 
 		<section if="linux">
 
-			<lib name="${HXCPP}/lib/${BINDIR}/liblinuxcompat.a" />
 			<lib name="-lpthread" />
 			<lib name="-lrt" />
 


### PR DESCRIPTION
This library used to be provided by Hxcpp, but it was [removed in version 3.4.185](https://github.com/HaxeFoundation/hxcpp/blob/aebf08f737c254c5baa75fb8d6c4386aa2294fac/Changes.md#34185). Fortunately, it doesn't seem to be necessary, so this pull request stops Lime from attempting to link with it.

This has been tested on Arch Linux with Haxe 4.2.5 and Hxcpp 4.2.1.

Also see the [discussion on Discord](https://discord.com/channels/415681294446493696/457589935487189003/1047544950658711673).