### PR TITLE
For cross-compiling to Windows/macOS/Linux, respect -hl flag.

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1557,6 +1557,12 @@ class CommandLineTools
 			case "mac", "macos":
 				target = Platform.MAC;
 				overrides.haxedefs.set("macos", "");
+			case "windows":
+				target = Platform.WINDOWS;
+				overrides.haxedefs.set("windows", "");
+			case "linux":
+				target = Platform.LINUX;
+				overrides.haxedefs.set("linux", "");
 
 			case "rpi", "raspberrypi":
 				target = Platform.LINUX;

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -136,7 +136,7 @@ class LinuxPlatform extends PlatformTarget
 			is64 = false;
 		}
 
-		if (project.targetFlags.exists("neko") || project.target != cast System.hostPlatform)
+		if (project.targetFlags.exists("neko"))
 		{
 			targetType = "neko";
 		}
@@ -152,6 +152,10 @@ class LinuxPlatform extends PlatformTarget
 		else if (project.targetFlags.exists("java"))
 		{
 			targetType = "java";
+		}
+		else if (project.target != (cast System.hostPlatform))
+		{
+			targetType = "hl";
 		}
 		else
 		{

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -140,11 +140,6 @@ class LinuxPlatform extends PlatformTarget
 		{
 			targetType = "neko";
 		}
-		else if (project.targetFlags.exists("hl"))
-		{
-			targetType = "hl";
-			is64 = true;
-		}
 		else if (project.targetFlags.exists("nodejs"))
 		{
 			targetType = "nodejs";
@@ -153,9 +148,10 @@ class LinuxPlatform extends PlatformTarget
 		{
 			targetType = "java";
 		}
-		else if (project.target != (cast System.hostPlatform))
+		else if (project.targetFlags.exists("hl") || project.target != (cast System.hostPlatform))
 		{
 			targetType = "hl";
+			is64 = true;
 		}
 		else
 		{

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -130,7 +130,7 @@ class MacPlatform extends PlatformTarget
 			}
 		}
 
-		if (project.targetFlags.exists("neko") || project.target != cast System.hostPlatform)
+		if (project.targetFlags.exists("neko"))
 		{
 			targetType = "neko";
 		}
@@ -150,6 +150,10 @@ class MacPlatform extends PlatformTarget
 		else if (project.targetFlags.exists("cs"))
 		{
 			targetType = "cs";
+		}
+		else if (project.target != (cast System.hostPlatform))
+		{
+			targetType = "hl";
 		}
 		else
 		{

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -134,11 +134,6 @@ class MacPlatform extends PlatformTarget
 		{
 			targetType = "neko";
 		}
-		else if (project.targetFlags.exists("hl"))
-		{
-			targetType = "hl";
-			is64 = true;
-		}
 		else if (project.targetFlags.exists("java"))
 		{
 			targetType = "java";
@@ -151,9 +146,10 @@ class MacPlatform extends PlatformTarget
 		{
 			targetType = "cs";
 		}
-		else if (project.target != (cast System.hostPlatform))
+		else if (project.targetFlags.exists("hl") || project.target != (cast System.hostPlatform))
 		{
 			targetType = "hl";
+			is64 = true;
 		}
 		else
 		{

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -142,11 +142,6 @@ class WindowsPlatform extends PlatformTarget
 		{
 			targetType = "neko";
 		}
-		else if (project.targetFlags.exists("hl"))
-		{
-			targetType = "hl";
-			is64 = !project.flags.exists("32");
-		}
 		else if (project.targetFlags.exists("cppia"))
 		{
 			targetType = "cppia";
@@ -168,9 +163,10 @@ class WindowsPlatform extends PlatformTarget
 		{
 			targetType = "winrt";
 		}
-		else if (project.target != (cast System.hostPlatform))
+		else if (project.targetFlags.exists("hl") || project.target != (cast System.hostPlatform))
 		{
 			targetType = "hl";
+			is64 = !project.flags.exists("32");
 		}
 		else
 		{

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -138,7 +138,7 @@ class WindowsPlatform extends PlatformTarget
 		{
 			targetType = "winjs";
 		}
-		else if (project.targetFlags.exists("neko") || project.target != cast System.hostPlatform)
+		else if (project.targetFlags.exists("neko"))
 		{
 			targetType = "neko";
 		}
@@ -167,6 +167,10 @@ class WindowsPlatform extends PlatformTarget
 		else if (project.targetFlags.exists("winrt"))
 		{
 			targetType = "winrt";
+		}
+		else if (project.target != (cast System.hostPlatform))
+		{
+			targetType = "hl";
 		}
 		else
 		{


### PR DESCRIPTION
This changes the behaviour of `lime build <windows|mac|linux>` by respecting the users preference for HL or Neko (current behavior is to force Neko).

Also changes the default target for cross-compilation to HL.