### PR TITLE
Remove conflicting files.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,11 +95,11 @@ jobs:
         run: |
           pushd project/lib/hashlink
           brew update
-          export HOMEBREW_BUNDLE_BREW_SKIP=python python@3.10
-          export HOMEBREW_BUNDLE_CASK_SKIP=python python@3.10
-          export HOMEBREW_BUNDLE_MAS_SKIP=python python@3.10
-          export HOMEBREW_BUNDLE_WHALEBREW_SKIP=python python@3.11
-          export HOMEBREW_BUNDLE_TAP_SKIP=python python@3.11
+          export HOMEBREW_BUNDLE_BREW_SKIP='python python@3.10'
+          export HOMEBREW_BUNDLE_CASK_SKIP='python python@3.10'
+          export HOMEBREW_BUNDLE_MAS_SKIP='python python@3.10'
+          export HOMEBREW_BUNDLE_WHALEBREW_SKIP='python python@3.11'
+          export HOMEBREW_BUNDLE_TAP_SKIP='python python@3.11'
           brew bundle
           popd
           haxelib install hxcpp --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,9 +94,7 @@ jobs:
       - name: Install Haxe dependencies
         run: |
           pushd project/lib/hashlink
-          rm /usr/local/bin/2to3*
-          rm /usr/local/bin/idle3*
-          brew update
+          brew update --force
           brew bundle
           popd
           haxelib install hxcpp --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,12 @@ jobs:
         run: |
           pushd project/lib/hashlink
           brew update
-          HOMEBREW_BUNDLE_BREW_SKIP=python brew bundle
+          export HOMEBREW_BUNDLE_BREW_SKIP=python python@3.10
+          export HOMEBREW_BUNDLE_CASK_SKIP=python python@3.10
+          export HOMEBREW_BUNDLE_MAS_SKIP=python python@3.10
+          export HOMEBREW_BUNDLE_WHALEBREW_SKIP=python python@3.11
+          export HOMEBREW_BUNDLE_TAP_SKIP=python python@3.11
+          brew bundle
           popd
           haxelib install hxcpp --quiet
           haxelib install format --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,11 +95,9 @@ jobs:
         run: |
           pushd project/lib/hashlink
           brew update
-          export HOMEBREW_BUNDLE_BREW_SKIP='python python@3.10'
-          export HOMEBREW_BUNDLE_CASK_SKIP='python python@3.10'
-          export HOMEBREW_BUNDLE_MAS_SKIP='python python@3.10'
-          export HOMEBREW_BUNDLE_WHALEBREW_SKIP='python python@3.11'
-          export HOMEBREW_BUNDLE_TAP_SKIP='python python@3.11'
+          rm /usr/local/bin/2to3*
+          rm /usr/local/bin/idle3*
+          rm /usr/local/bin/pydoc3*
           brew bundle
           popd
           haxelib install hxcpp --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,9 +95,10 @@ jobs:
         run: |
           pushd project/lib/hashlink
           brew update
-          # `brew bundle` is going to install these versions of python without specifying `--overwrite`
-          brew install --overwrite python@3.10
-          brew install --overwrite python@3.11
+          rm /usr/local/bin/2to3*
+          rm /usr/local/bin/idle3*
+          rm /usr/local/bin/pydoc3*
+          rm /usr/local/bin/python3*
           brew bundle
           popd
           haxelib install hxcpp --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Install Haxe dependencies
         run: |
           pushd project/lib/hashlink
+          rm /usr/local/bin/2to3
+          rm /usr/local/bin/2to3-3.11
           brew update
           brew bundle
           popd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,9 +95,9 @@ jobs:
         run: |
           pushd project/lib/hashlink
           brew update
-          rm /usr/local/bin/2to3*
-          rm /usr/local/bin/idle3*
-          rm /usr/local/bin/pydoc3*
+          # `brew bundle` is going to install these versions of python without specifying `--overwrite`
+          brew install --overwrite python@3.10
+          brew install --overwrite python@3.11
           brew bundle
           popd
           haxelib install hxcpp --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Install Haxe dependencies
         run: |
           pushd project/lib/hashlink
-          brew update --force
-          brew bundle
+          brew update
+          HOMEBREW_BUNDLE_BREW_SKIP=python brew bundle
           popd
           haxelib install hxcpp --quiet
           haxelib install format --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Install Haxe dependencies
         run: |
           pushd project/lib/hashlink
-          rm /usr/local/bin/2to3
-          rm /usr/local/bin/2to3-3.11
+          rm /usr/local/bin/2to3*
+          rm /usr/local/bin/idle3*
           brew update
           brew bundle
           popd


### PR DESCRIPTION
As explained in #1601, GitHub is dropping support for macos-10.15, so we switched to macos-11. Now, however, there's a file conflict when Homebrew tries to install Python as a dependency of SQLite. The files in question are not the sort that get used in a CI run, so the simplest solution may be to delete them.