### PR TITLE
Use `applicationDirectory` to locate assets on Mac.

### DIFF
--- a/templates/haxe/ManifestResources.hx
+++ b/templates/haxe/ManifestResources.hx
@@ -59,10 +59,8 @@ import sys.FileSystem;
 			rootPath = "assets/";
 			#elseif android
 			rootPath = "";
-			#elseif console
+			#elseif (console || sys)
 			rootPath = lime.system.System.applicationDirectory;
-			#elseif sys
-			rootPath = Path.directory(Sys.programPath()) + "/";
 			#else
 			rootPath = "./";
 			#end


### PR DESCRIPTION
`programPath()` returns the directory of the executable, but as @joshtynjala pointed out (see #1538), that isn't where assets go in Mac apps.

Lime's `applicationDirectory` variable seems to be designed to return the information we actually want. I say "seems to be" because it isn't actually documented. But in general, I'd expect Lime to take app file structure into account, and Haxe not to.