### PR TITLE
Fix SIZEOF_SIZE_T in jpeg for RaspberryPi

### DIFF
--- a/project/lib/custom/jpeg/jconfigint.h
+++ b/project/lib/custom/jpeg/jconfigint.h
@@ -23,7 +23,11 @@
 #define VERSION  "2.0.7"
 
 /* The size of `size_t', as computed by sizeof. */
+#if defined(RASPBERRYPI)
+#define SIZEOF_SIZE_T  4
+#else
 #define SIZEOF_SIZE_T  8
+#endif
 
 /* Define if your compiler has __builtin_ctzl() and sizeof(unsigned long) == sizeof(size_t). */
 #ifndef HX_WINDOWS


### PR DESCRIPTION
SIZEOF_SIZE_T  needs to be 4  for Raspberrypi in lib/custom/jpeg/jconfigint.h
instead of 8 for other platforms, otherwise jpegs are not decoded properly.

This commit adds a conditional
```
#if defined(RASPBERRYPI)
  #define SIZEOF_SIZE_T  4
#else
  #define SIZEOF_SIZE_T  8
#endif
```
