### PR TITLE
Pass `-rpi` flag to svg.n.

### DIFF
--- a/src/lime/tools/ImageHelper.hx
+++ b/src/lime/tools/ImageHelper.hx
@@ -28,6 +28,7 @@ class ImageHelper
 			System.runCommand("", "neko", [
 				Path.combine(Haxelib.getPath(new Haxelib(#if lime "lime" #else "hxp" #end)), "svg.n"),
 				"process",
+				#if rpi "-rpi", #end
 				path,
 				Std.string(width),
 				Std.string(height),

--- a/tools/SVGExport.hx
+++ b/tools/SVGExport.hx
@@ -140,7 +140,7 @@ class SVGExport
 			{
 				Log.verbose = true;
 			}
-			else
+			else if (arg != "-rpi")
 			{
 				words.push(arg);
 			}


### PR DESCRIPTION
This hopefully fixes the issue @gepatto reported on Discord:

> so in the chat channel we discovered that when you build html5 on a Pi, 
> SVGExport fails because it runs neko in a regular linux context in stead of rpi .
> SVGExport is looking for a -rpi flag but that flag isn't appended when ImageHelper.hx calls 'neko process svg.n'