### PR TITLE
fix wierd audio stuttering on windows

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -186,6 +186,8 @@ class NativeAudioSource
 		else
 		{
 			var time = completed ? 0 : getCurrentTime();
+			
+			AL.sourcePlay(handle);
 
 			setCurrentTime(time);
 		}

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -416,7 +416,7 @@ class NativeAudioSource
 			{
 				AL.sourceRewind(handle);
 
-				// AL.sourcef (handle, AL.SEC_OFFSET, (value + parent.offset) / 1000);
+				if (playing) AL.sourcePlay(handle);
 
 				var secondOffset = (value + parent.offset) / 1000;
 				var totalSeconds = samples / parent.buffer.sampleRate;
@@ -428,7 +428,6 @@ class NativeAudioSource
 				var totalOffset = Std.int(dataLength * ratio);
 
 				AL.sourcei(handle, AL.BYTE_OFFSET, totalOffset);
-				if (playing) AL.sourcePlay(handle);
 			}
 		}
 


### PR DESCRIPTION
after updating to lime 8.0.1 yesterday, i was experiencing weird audio issues where it would stutter for a tiny bit at random points, reverting  #1558  *seems* to fix it
After some testing with this change I haven't really had any issues 