### PR TITLE
Fix OpenAL binding AL.filteri for hashlink

### DIFF
--- a/project/src/media/openal/OpenALBindings.cpp
+++ b/project/src/media/openal/OpenALBindings.cpp
@@ -3659,7 +3659,7 @@ namespace lime {
 	DEFINE_HL_PRIM (_VOID, hl_al_effecti, _TCFFIPOINTER _I32 _I32);
 	DEFINE_HL_PRIM (_VOID, hl_al_effectiv, _TCFFIPOINTER _I32 _ARR);
 	DEFINE_HL_PRIM (_VOID, hl_al_enable, _I32);
-	DEFINE_HL_PRIM (_VOID, hl_al_filteri, _TCFFIPOINTER _I32 _DYN);
+	DEFINE_HL_PRIM (_VOID, hl_al_filteri, _TCFFIPOINTER _I32 _I32);
 	DEFINE_HL_PRIM (_VOID, hl_al_filterf, _TCFFIPOINTER _I32 _F32);
 	DEFINE_HL_PRIM (_TCFFIPOINTER, hl_al_gen_aux, _NO_ARG);
 	DEFINE_HL_PRIM (_TCFFIPOINTER, hl_al_gen_buffer, _NO_ARG);

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -2271,7 +2271,7 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_al_filteri") private static function lime_al_filteri(filter:CFFIPointer, param:Int, value:Dynamic):Void {}
+	@:hlNative("lime", "hl_al_filteri") private static function lime_al_filteri(filter:CFFIPointer, param:Int, value:Int):Void {}
 
 	@:hlNative("lime", "hl_al_filterf") private static function lime_al_filterf(filter:CFFIPointer, param:Int, value:hl.F32):Void {}
 


### PR DESCRIPTION
When calling `AL.filteri` with hashlink target we can see the error `INVALID_VALUE: Invalid parameter value` when checking for errors with `AL.getErrorString()`. This pull request fixes it.


## Reproduce the error

There's a repo here which can be used to recreate the problem - https://github.com/jobf/lime-openal-efx-invalid-param-test

Run the project with `lime test hl` and click the lime window to hear the sound. Check the console to see the following

```
NativeAudioSource.hx:144: shadow source play
NativeAudioSource.hx:160: createFilter error ? 
NativeAudioSource.hx:163: filteri error ? INVALID_VALUE: Invalid parameter value
NativeAudioSource.hx:166: filterf LOWPASS_GAIN error ?INVALID_ENUM: Invalid enum value
NativeAudioSource.hx:169: filterf LOWPASS_GAINHF error ?INVALID_ENUM: Invalid enum value
```

## Confirm the changes prevent the error

Once the fix is applied, rebuild the lime hdlls with `lime rebuild hl`.

Now when you run the sample project and click the window the console output should be as follows.

```
NativeAudioSource.hx:144: shadow source play
NativeAudioSource.hx:160: createFilter error ? 
NativeAudioSource.hx:163: filteri error ? 
NativeAudioSource.hx:166: filterf LOWPASS_GAIN error ?
NativeAudioSource.hx:169: filterf LOWPASS_GAINHF error ?
```