### PR TITLE
Use forward slashes to load lime.ndll.

### DIFF
--- a/src/lime/system/CFFI.hx
+++ b/src/lime/system/CFFI.hx
@@ -149,16 +149,15 @@ class CFFI
 
 			if (result == null)
 			{
-				var slash = (__sysName().substr(7).toLowerCase() == "windows") ? "\\" : "/";
 				var haxelib = __findHaxelib("lime");
 
 				if (haxelib != "")
 				{
-					result = __tryLoad(haxelib + slash + "ndll" + slash + __sysName() + slash + library, library, method, args);
+					result = __tryLoad(haxelib + "/ndll/" + __sysName() + "/" + library, library, method, args);
 
 					if (result == null)
 					{
-						result = __tryLoad(haxelib + slash + "ndll" + slash + __sysName() + "64" + slash + library, library, method, args);
+						result = __tryLoad(haxelib + "/ndll/" + __sysName() + "64/" + library, library, method, args);
 					}
 				}
 			}


### PR DESCRIPTION
`substr(7)` returns the substring _starting_ at character 7, which will never be "windows". The author meant to type `substr(0, 7)` instead, to get the substring ending at 7.

We could easily make this change, but given that the code has been successfully using forward slashes for several years, I prefer to simplify.