### PR TITLE
Use "password" text input only on Android.

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -1119,7 +1119,7 @@ class HTML5Window
 				textInput.type = 'text';
 				#else
 				// use password instead of text to avoid IME issues on Android
-				textInput.type = 'password';
+				textInput.type = Browser.navigator.userAgent.indexOf("Android") >= 0 ? 'password' : 'text';
 				#end
 				textInput.style.position = 'absolute';
 				textInput.style.opacity = "0";


### PR DESCRIPTION
Using `userAgent` to tell whether the app is running on Android. This isn't foolproof, but will work more often than the previous approach (where you chose at compile time and your choice applied to all devices). Resolves #1655.