### PR TITLE
Use `performance.now()` for HTML5 timing.

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Application.hx
+++ b/src/lime/_internal/backend/html5/HTML5Application.hx
@@ -325,7 +325,7 @@ class HTML5Application
 
 			if (!window.requestAnimationFrame)
 				window.requestAnimationFrame = function(callback, element) {
-					var currTime = new Date().getTime();
+					var currTime = window.performance.now();
 					var timeToCall = Math.max(0, 16 - (currTime - lastTime));
 					var id = window.setTimeout(function() { callback(currTime + timeToCall); },
 					  timeToCall);
@@ -341,7 +341,7 @@ class HTML5Application
 			window.requestAnimFrame = window.requestAnimationFrame;
 		");
 
-		lastUpdate = Date.now().getTime();
+		lastUpdate = Browser.window.performance.now();
 
 		handleApplicationEvent();
 
@@ -361,7 +361,7 @@ class HTML5Application
 
 		updateGameDevices();
 
-		currentUpdate = Date.now().getTime();
+		currentUpdate = Browser.window.performance.now();
 
 		if (currentUpdate >= nextUpdate)
 		{


### PR DESCRIPTION
This way, changing the computer clock can't mess up animations. Resolves #1367.

There is a fallback if `window.performance` isn't available, and I left that intact.

---

I was going to update `Timer.stamp()` to use `self.performance`, because that's available in web workers as well as normal windows. It would look like this:

```diff
#elseif js
-return Date.now().getTime() / 1000;
+return js.Browser.self.performance.now() / 1000;
#elseif cpp
```

However, I later realized that I was editing the standard library version of `Timer`, and my changes would be overwritten the next time we updated it. So I'm leaving the change out, but perhaps it could be submitted upstream.