### PR TITLE
Update actions/setup-java

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,8 +217,9 @@ jobs:
         with:
           ndk-version: r15c
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: "zulu"
           java-version: 8
 
       - uses: krdlab/setup-haxe@v1
@@ -462,8 +463,9 @@ jobs:
         with:
           ndk-version: r15c
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: "zulu"
           java-version: 8
 
       - uses: krdlab/setup-haxe@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,7 +217,7 @@ jobs:
         with:
           ndk-version: r15c
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: 8
@@ -463,7 +463,7 @@ jobs:
         with:
           ndk-version: r15c
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: 8


### PR DESCRIPTION
[GitHub is deprecating Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), forcing us to update any actions that rely on it.

actions/setup-java now [requires us to specify a distribution](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md). v1 used Zulu, so we'll just stick with that for now.