### PR TITLE
Test using NDK r21e.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,7 +215,7 @@ jobs:
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r15c
+          ndk-version: r21e
 
       - uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
hxcpp 4.3.2 introduced an error when using GCC to compile projects. By switching to an NDK >= 20, we can make it use Clang instead, and hopefully avoid the error.

We might want to do this anyway, since NDK 15 is so old.