### PR TITLE
Allow cross compiling Windows projects with MinGW

### DIFF
--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -32,9 +32,9 @@ import sys.io.Process;
 @:access(lime._internal.backend.native.NativeCFFI)
 @:access(lime.system.Display)
 @:access(lime.system.DisplayMode)
-#if (cpp && windows && !HXCPP_MINGW && !lime_disable_gpu_hint)
+#if (cpp && windows && !lime_disable_gpu_hint)
 @:cppFileCode('
-#if defined(HX_WINDOWS)
+#if defined(HX_WINDOWS) && !defined(__MINGW32__)
 extern "C" {
 	_declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
 	_declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;

--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -128,7 +128,7 @@ class ProjectXMLParser extends HXProject
 		{
 			defines.set("native", "1");
 
-			if (target == Platform.WINDOWS)
+			if (target == Platform.WINDOWS && targetFlags.exists("mingw"))
 			{
 				defines.set("targetType", "cpp");
 				defines.set("cpp", "1");

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -138,7 +138,7 @@ class WindowsPlatform extends PlatformTarget
 		{
 			targetType = "winjs";
 		}
-		else if (project.targetFlags.exists("neko") || project.target != cast System.hostPlatform)
+		else if (project.targetFlags.exists("neko"))
 		{
 			targetType = "neko";
 		}

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -496,6 +496,24 @@ class WindowsPlatform extends PlatformTarget
 					CPPHelper.compile(project, targetDirectory + "/obj", flags);
 
 					System.copyFile(targetDirectory + "/obj/ApplicationMain" + (project.debug ? "-debug" : "") + ".exe", executablePath);
+
+					if (project.targetFlags.exists("mingw"))
+					{
+						var libraries = ["libwinpthread-1.dll", "libstdc++-6.dll"];
+						if (is64)
+						{
+							libraries.push("libgcc_s_seh-1.dll");
+						}
+						else
+						{
+							libraries.push("libgcc_s_dw2-1.dll");
+						}
+
+						for (library in libraries)
+						{
+							System.copyIfNewer(targetDirectory + "/obj/" + library, Path.combine(applicationDirectory, library));
+						}
+					}
 				}
 				else
 				{


### PR DESCRIPTION
If the `-mingw` flag is set when compiling the `windows` target from another host OS, it will now use MinGW instead of neko.