### PR TITLE
Remove `@:generic` from `Promise` at macro time.

### DIFF
--- a/src/haxe/Timer.hx
+++ b/src/haxe/Timer.hx
@@ -1,6 +1,6 @@
 package haxe;
 
-#if !lime_cffi
+#if (!lime_cffi || macro)
 // Original haxe.Timer class
 
 /*

--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -89,7 +89,7 @@ class NativeApplication
 
 	private function advanceTimer():Void
 	{
-		#if lime_cffi
+		#if (lime_cffi && !macro)
 		if (pauseTimer > -1)
 		{
 			var offset = System.getTimer() - pauseTimer;
@@ -571,7 +571,7 @@ class NativeApplication
 
 	private function updateTimer():Void
 	{
-		#if lime_cffi
+		#if (lime_cffi && !macro)
 		if (Timer.sRunningTimers.length > 0)
 		{
 			var currentTime = System.getTimer();

--- a/src/lime/app/Promise.hx
+++ b/src/lime/app/Promise.hx
@@ -44,7 +44,7 @@ package lime.app;
 @:noDebug
 #end
 @:allow(lime.app.Future)
-#if (!hl && !js)
+#if (!hl && !js && !macro)
 @:generic
 #end
 class Promise<T>


### PR DESCRIPTION
This prevents an inconsistent "Field has no new expression" bug. A couple of us [spent hours trying to track this bug down](https://discord.com/channels/415681294446493696/457589935487189003/1096800407998709800), with limited success.

- It seems to be related to macros. For a while I thought it was specific to build macros, but eventually we confirmed that any macro can cause it.
- It seems to be related to [`WorkFunction.dispatch()`](https://github.com/openfl/lime/blob/45bc8c4aef6548a6fcb0f89555cab733052e80d8/src/lime/system/WorkOutput.hx#L263-L272) and [`JSAsync.async()`](https://github.com/openfl/lime/blob/45bc8c4aef6548a6fcb0f89555cab733052e80d8/src/lime/system/WorkOutput.hx#L391-L402), both of which are macros. Moving or changing these functions _sometimes_ fixes the issue.
- Commenting all calls to `WorkFunction.dispatch()` plus one specific call to `ThreadPool.createThread()` sometimes fixes the issue.
- Importing any of `lime.app.Promise`, `lime.system.ThreadPool`, `lime.system.WorkOutput`, `lime.system.System`, and `lime.graphics.Image` during a macro may cause this issue. (Note that most of these classes end up importing one another.)
- If importing `lime.graphics.Image` causes the error, importing `lime.ui.Gamepad` one line before `lime.graphics.Image` sometimes fixes it.
- If importing `lime.graphics.Image` causes the error, importing `lime.utils.Bytes` one line before `lime.graphics.Image` changes which file the error points to.

But despite all that, this proposed change always fixes it.

Perhaps since `Promise` is already part of a loop of classes that mutually import each other, and it's imported during macros, [generating generic versions of it](https://haxe.org/manual/type-system-generic.html) adds one layer of complexity too many. We didn't find a way to simplify the import loop or avoid running the macros, so all that's left is the generic versions.

(In my opinion, generating generics at macro time was a bad idea anyway. We're generating one set of `Promise` generics for use at runtime and another for use at macro time. And I'm not sure the macros actually use this second set of generics; if they do, it certainly isn't enough to make up for the extra time compiling them.)