### PR TITLE
Fixed JS Image issue when using the genes library to compile ES modules

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
+++ b/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
@@ -444,11 +444,7 @@ class HTML5HTTPRequest
 
 	private static function __loadImage(uri:String, promise:Promise<Image>, options:Int):Void
 	{
-		#if (openfljs || genes)
-		var image:JSImage = untyped #if haxe4 js.Syntax.code #else __js__ #end ('new window.Image ()');
-		#else
-		var image = new JSImage();
-		#end
+		var image:JSImage = #if haxe4 js.Syntax.code #else __js__ #end ('new window.Image ()');
 
 		if (!__isSameOrigin(uri))
 		{

--- a/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
+++ b/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
@@ -444,7 +444,11 @@ class HTML5HTTPRequest
 
 	private static function __loadImage(uri:String, promise:Promise<Image>, options:Int):Void
 	{
+		#if (openfljs || genes)
+		var image:JSImage = untyped #if haxe4 js.Syntax.code #else __js__ #end ('new window.Image ()');
+		#else
 		var image = new JSImage();
+		#end
 
 		if (!__isSameOrigin(uri))
 		{

--- a/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
+++ b/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
@@ -444,7 +444,7 @@ class HTML5HTTPRequest
 
 	private static function __loadImage(uri:String, promise:Promise<Image>, options:Int):Void
 	{
-		var image:JSImage = #if haxe4 js.Syntax.code #else __js__ #end ('new window.Image ()');
+		var image:JSImage = untyped #if haxe4 js.Syntax.code #else __js__ #end ('new window.Image ()');
 
 		if (!__isSameOrigin(uri))
 		{

--- a/src/lime/graphics/Image.hx
+++ b/src/lime/graphics/Image.hx
@@ -1438,11 +1438,7 @@ class Image
 	@:noCompletion private function __fromBase64(base64:String, type:String, onload:Image->Void = null):Void
 	{
 		#if (js && html5)
-		#if (openfljs || genes)
 		var image:JSImage = untyped #if haxe4 js.Syntax.code #else __js__ #end ('new window.Image ()');
-		#else
-		var image = new JSImage();
-		#end
 
 		var image_onLoaded = function(event)
 		{
@@ -1574,11 +1570,7 @@ class Image
 			catch (e:Dynamic) {}
 		});
 		#elseif (js && html5)
-		#if (openfljs || genes)
 		var image:JSImage = untyped #if haxe4 js.Syntax.code #else __js__ #end ('new window.Image ()');
-		#else
-		var image = new JSImage();
-		#end
 
 		#if !display
 		if (!HTML5HTTPRequest.__isSameOrigin(path))


### PR DESCRIPTION
Need to explicitly use:

new window.Image() 

otherwise it will create a lime Image object.