### PR TITLE
Remove redundant file dialog string conversions

### DIFF
--- a/project/include/ui/FileDialog.h
+++ b/project/include/ui/FileDialog.h
@@ -13,10 +13,30 @@ namespace lime {
 
 		public:
 
-			static std::wstring* OpenDirectory (std::wstring* title = 0, std::wstring* filter = 0, std::wstring* defaultPath = 0);
-			static std::wstring* OpenFile (std::wstring* title = 0, std::wstring* filter = 0, std::wstring* defaultPath = 0);
-			static void OpenFiles (std::vector<std::wstring*>* files, std::wstring* title = 0, std::wstring* filter = 0, std::wstring* defaultPath = 0);
-			static std::wstring* SaveFile (std::wstring* title = 0, std::wstring* filter = 0, std::wstring* defaultPath = 0);
+#ifdef HX_WINDOWS
+			using char_t = wchar_t;
+#else
+			using char_t = char;
+#endif
+
+			static const char_t* OpenDirectory(const char_t* title = nullptr, const char_t* filter = nullptr, const char_t* defaultPath = nullptr);
+			static const char_t* OpenFile(const char_t* title = nullptr, const char_t* filter = nullptr, const char_t* defaultPath = nullptr);
+
+			// Use actual string view once we can use c++17
+			class string_view {
+			public:
+				string_view(const char_t* c_str, size_t length) : c_str(c_str), length(length) {}
+
+				const char_t* data() const { return c_str; }
+				const size_t size() const { return length; }
+
+			private:
+				const char_t* c_str;
+				size_t length;
+			};
+
+			static std::vector<string_view> OpenFiles(const char_t* title = nullptr, const char_t* filter = nullptr, const char_t* defaultPath = nullptr);
+			static const char_t* SaveFile(const char_t* title = nullptr, const char_t* filter = nullptr, const char_t* defaultPath = nullptr);
 
 	};
 

--- a/project/include/ui/FileDialog.h
+++ b/project/include/ui/FileDialog.h
@@ -30,7 +30,7 @@ namespace lime {
 				string_view(const char_t* c_str, size_t length) : c_str(c_str), length(length) {}
 
 				const char_t* data() const { return c_str; }
-				const size_t size() const { return length; }
+				size_t size() const { return length; }
 
 			private:
 				const char_t* c_str;

--- a/project/include/ui/FileDialog.h
+++ b/project/include/ui/FileDialog.h
@@ -9,6 +9,8 @@
 namespace lime {
 
 
+	// Functions in this class return pointers to externally owned memory, which will be reused automatically
+	// for future dialogs and should not be freed.
 	class FileDialog {
 
 		public:

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -203,66 +203,51 @@ namespace lime {
 	}
 
 
-	std::wstring* hxstring_to_wstring (HxString val) {
+	#ifdef HX_WINDOWS
+	#define hxs_to_fd_str(str) hxs_wchar(str, nullptr)
+	#define alloc_from_fd_str(str) alloc_wstring(str)
+	#define alloc_from_fd_str_len(str, len) alloc_wstring_len(str, len)
 
-		if (val.c_str ()) {
-
-			#ifdef HX_WINDOWS
-			return new std::wstring (hxs_wchar (val, nullptr));
-			#else
-			const std::string _val (hxs_utf8 (val, nullptr));
-			return new std::wstring (_val.begin (), _val.end ());
-			#endif
-
-		} else {
-
-			return 0;
-
-		}
-
-	}
-
-
-	std::wstring* hxstring_to_wstring (hl_vstring* val) {
-
+	static const FileDialog::char_t* hl_vstring_to_fd_str (hl_vstring* val) {
 		if (val) {
-
-			std::string _val = std::string (hl_to_utf8 (val->bytes));
-			#ifdef HX_WINDOWS
-			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-			return new std::wstring (converter.from_bytes (_val));
-			#else
-			return new std::wstring (_val.begin (), _val.end ());
-			#endif
-
-		} else {
-
-			return 0;
-
+			return val->bytes;
 		}
-
+		return nullptr;
 	}
 
+	static vbyte* hl_fd_str_to_utf8_bytes(const FileDialog::char_t* src, size_t length) {
+		// copy first, since hl_to_utf8 has no length parameter, and hl_utf16_to_utf8 is not exposed
+		FileDialog::char_t* utf16 = (FileDialog::char_t*)hl_copy_bytes((vbyte*)src, (length + 1) * sizeof(FileDialog::char_t));
+		utf16[length] = L'\0';
+		return (vbyte*)hl_to_utf8(utf16);
+	}
 
-	value wstring_to_value (std::wstring* val) {
+	static vbyte* hl_fd_str_to_utf8_bytes(const FileDialog::char_t* src) {
+		return (vbyte*)hl_to_utf8((uchar*)src);
+	}
 
+	#else
+	#define hxs_to_fd_str(str) hxs_utf8(str, nullptr)
+	#define alloc_from_fd_str(str) alloc_string(str)
+	#define alloc_from_fd_str_len(str, len) alloc_string_len(str, len)
+
+	static const FileDialog::char_t* hl_vstring_to_fd_str (hl_vstring* val) {
 		if (val) {
-
-			#ifdef HX_WINDOWS
-			return alloc_wstring (val->c_str ());
-			#else
-			std::string _val = std::string (val->begin (), val->end ());
-			return alloc_string (_val.c_str ());
-			#endif
-
-		} else {
-
-			return 0;
-
+			return hl_to_utf8 (val->bytes);
 		}
-
+		return nullptr;
 	}
 
+	static vbyte* hl_fd_str_to_utf8_bytes(const FileDialog::char_t* src, size_t length) {
+		vbyte* result = hl_copy_bytes((vbyte*)src, length + 1);
+		result[length] = '\0';
+		return result;
+	}
+
+	static vbyte* hl_fd_str_to_utf8_bytes(const FileDialog::char_t* src) {
+		return hl_fd_str_to_utf8_bytes(src, std::strlen(src));
+	}
+	#endif
 
 	value lime_application_create () {
 
@@ -764,25 +749,11 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::wstring* path = FileDialog::OpenDirectory (_title, _filter, _defaultPath);
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
+		const FileDialog::char_t* path = FileDialog::OpenDirectory (hxs_to_fd_str (title), hxs_to_fd_str (filter), hxs_to_fd_str (defaultPath));
 
 		if (path) {
 
-			value _path = wstring_to_value (path);
-			delete path;
-			return _path;
-
-		} else {
-
-			return alloc_null ();
+			return alloc_from_fd_str (path);
 
 		}
 
@@ -797,25 +768,11 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::wstring* path = FileDialog::OpenDirectory (_title, _filter, _defaultPath);
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
+		const FileDialog::char_t* path = FileDialog::OpenDirectory (hl_vstring_to_fd_str (title), hl_vstring_to_fd_str (filter), hl_vstring_to_fd_str (defaultPath));
 
 		if (path) {
 
-			vbyte* const result = hl_wstring_to_utf8_bytes (*path);
-			delete path;
-			return result;
-
-		} else {
-
-			return NULL;
+			return hl_fd_str_to_utf8_bytes(path);
 
 		}
 
@@ -830,25 +787,11 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::wstring* path = FileDialog::OpenFile (_title, _filter, _defaultPath);
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
+		const FileDialog::char_t* path = FileDialog::OpenFile (hxs_to_fd_str (title), hxs_to_fd_str (filter), hxs_to_fd_str (defaultPath));
 
 		if (path) {
 
-			value _path = wstring_to_value (path);
-			delete path;
-			return _path;
-
-		} else {
-
-			return alloc_null ();
+			return alloc_from_fd_str (path);
 
 		}
 
@@ -863,25 +806,11 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::wstring* path = FileDialog::OpenFile (_title, _filter, _defaultPath);
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
+		const FileDialog::char_t* path = FileDialog::OpenFile (hl_vstring_to_fd_str (title), hl_vstring_to_fd_str (filter), hl_vstring_to_fd_str (defaultPath));
 
 		if (path) {
 
-			vbyte* const result = hl_wstring_to_utf8_bytes (*path);
-			delete path;
-			return result;
-
-		} else {
-
-			return NULL;
+			return hl_fd_str_to_utf8_bytes (path);
 
 		}
 
@@ -896,24 +825,15 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::vector<std::wstring*> files;
-
-		FileDialog::OpenFiles (&files, _title, _filter, _defaultPath);
+		auto files = FileDialog::OpenFiles (hxs_to_fd_str (title), hxs_to_fd_str (filter), hxs_to_fd_str (defaultPath));
 		value result = alloc_array (files.size ());
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
 
 		for (int i = 0; i < files.size (); i++) {
 
-			value _file = wstring_to_value (files[i]);
-			val_array_set_i (result, i, _file);
-			delete files[i];
+			auto file_str = files[i];
+
+			value file = alloc_from_fd_str_len (file_str.data(), file_str.size());
+			val_array_set_i (result, i, file);
 
 		}
 
@@ -930,24 +850,14 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::vector<std::wstring*> files;
-
-		FileDialog::OpenFiles (&files, _title, _filter, _defaultPath);
+		auto files = FileDialog::OpenFiles (hl_vstring_to_fd_str (title), hl_vstring_to_fd_str (filter), hl_vstring_to_fd_str (defaultPath));
 		hl_varray* result = (hl_varray*)hl_alloc_array (&hlt_bytes, files.size ());
 		vbyte** resultData = hl_aptr (result, vbyte*);
 
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
-
 		for (int i = 0; i < files.size (); i++) {
 
-			*resultData++ = hl_wstring_to_utf8_bytes (*files[i]);
-			delete files[i];
+			auto file_str = files[i];
+			*resultData++ = hl_fd_str_to_utf8_bytes (file_str.data(), file_str.size());
 
 		}
 
@@ -964,25 +874,11 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::wstring* path = FileDialog::SaveFile (_title, _filter, _defaultPath);
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
+		const FileDialog::char_t* path = FileDialog::SaveFile (hxs_to_fd_str (title), hxs_to_fd_str (filter), hxs_to_fd_str (defaultPath));
 
 		if (path) {
 
-			value _path = wstring_to_value (path);
-			delete path;
-			return _path;
-
-		} else {
-
-			return alloc_null ();
+			return alloc_from_fd_str (path);
 
 		}
 
@@ -997,25 +893,11 @@ namespace lime {
 
 		#ifdef LIME_TINYFILEDIALOGS
 
-		std::wstring* _title = hxstring_to_wstring (title);
-		std::wstring* _filter = hxstring_to_wstring (filter);
-		std::wstring* _defaultPath = hxstring_to_wstring (defaultPath);
-
-		std::wstring* path = FileDialog::SaveFile (_title, _filter, _defaultPath);
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
+		const FileDialog::char_t* path = FileDialog::SaveFile (hl_vstring_to_fd_str (title), hl_vstring_to_fd_str (filter), hl_vstring_to_fd_str (defaultPath));
 
 		if (path) {
 
-			vbyte* const result = hl_wstring_to_utf8_bytes (*path);
-			delete path;
-			return result;
-
-		} else {
-
-			return NULL;
+			return hl_fd_str_to_utf8_bytes (path);
 
 		}
 

--- a/project/src/ui/FileDialog.cpp
+++ b/project/src/ui/FileDialog.cpp
@@ -6,297 +6,143 @@
 
 #include <tinyfiledialogs.h>
 
+#ifdef HX_WINDOWS
+#define tinyfd_selectFolderDialog tinyfd_selectFolderDialogW
+#define tinyfd_openFileDialog tinyfd_openFileDialogW
+#define tinyfd_saveFileDialog tinyfd_saveFileDialogW
+
+#define FD_STR(str) L##str
+#else
+#define FD_STR(str) str
+#endif
+
+using char_t = lime::FileDialog::char_t;
+using string_t = std::basic_string<char_t>;
 
 namespace lime {
 
-
-	std::string* wstring_to_string (std::wstring* source) {
-
-		if (!source) return NULL;
-
-		int size = std::wcslen (source->c_str ());
-		char* temp = (char*)malloc (size + 1);
-		std::wcstombs (temp, source->c_str (), size);
-		temp[size] = '\0';
-
-		std::string* data = new std::string (temp);
-		free (temp);
-		return data;
-
+	static bool is_null_or_empty (const char_t* str) {
+		return str == nullptr || str[0] == 0;
 	}
 
-
-	std::wstring* FileDialog::OpenDirectory (std::wstring* title, std::wstring* filter, std::wstring* defaultPath) {
+	const char_t* FileDialog::OpenDirectory (const char_t* title, const char_t* filter, const char_t* defaultPath) {
 
 		// TODO: Filter?
 
-		#ifdef HX_WINDOWS
+		const char_t* path = tinyfd_selectFolderDialog(title, defaultPath);
 
-		const wchar_t* path = tinyfd_selectFolderDialogW (title ? title->c_str () : 0, defaultPath ? defaultPath->c_str () : 0);
+		if (!is_null_or_empty(path)) {
 
-		if (path && std::wcslen(path) > 0) {
-
-			std::wstring* _path = new std::wstring (path);
-			return _path;
+			return path;
 
 		}
-
-		#else
-
-		std::string* _title = wstring_to_string (title);
-		//std::string* _filter = wstring_to_string (filter);
-		std::string* _defaultPath = wstring_to_string (defaultPath);
-
-		const char* path = tinyfd_selectFolderDialog (_title ? _title->c_str () : NULL, _defaultPath ? _defaultPath->c_str () : NULL);
-
-		if (_title) delete _title;
-		//if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
-
-		if (path && std::strlen(path) > 0) {
-
-			std::string _path = std::string (path);
-			std::wstring* __path = new std::wstring (_path.begin (), _path.end ());
-			return __path;
-
-		}
-
-		#endif
 
 		return 0;
 
 	}
 
 
-	std::wstring* FileDialog::OpenFile (std::wstring* title, std::wstring* filter, std::wstring* defaultPath) {
+	const char_t* FileDialog::OpenFile (const char_t* title, const char_t* filter, const char_t* defaultPath) {
 
-		#ifdef HX_WINDOWS
-
-		std::vector<std::wstring> filters_vec;
+		std::vector<string_t> filters_vec;
 		if (filter) {
-			std::wstring temp (L"*.");
-			std::wstring line;
-			std::wstringstream ss(*filter);
-			while(std::getline(ss, line, L',')) {
+			string_t temp(FD_STR("*."));
+			string_t line;
+			std::basic_stringstream<char_t> ss(filter);
+			while(std::getline(ss, line, FD_STR(','))) {
 				filters_vec.push_back(temp + line);
 			}
 		}
 
 		const int numFilters = filter ? filters_vec.size() : 1;
-		const wchar_t **filters = new const wchar_t*[numFilters];
+		const char_t **filters = new const char_t*[numFilters];
 		if (filter && numFilters > 0) {
 			for (int index = 0; index < numFilters; index++) {
-				filters[index] = const_cast<wchar_t*>(filters_vec[index].c_str());
+				filters[index] = const_cast<char_t*>(filters_vec[index].c_str());
 			}
 		} else {
 			filters[0] = NULL;
 		}
 
-		const wchar_t* path = tinyfd_openFileDialogW (title ? title->c_str () : 0, defaultPath ? defaultPath->c_str () : 0, filter ? numFilters : 0, filter ? filters : NULL, NULL, 0);
+		const char_t* path = tinyfd_openFileDialog (title, defaultPath, filter ? numFilters : 0, filter ? filters : NULL, NULL, 0);
 
 		delete[] filters;
 
-		if (path && std::wcslen(path) > 0) {
+		if (!is_null_or_empty(path)) {
 
-			std::wstring* _path = new std::wstring (path);
-			return _path;
-
-		}
-
-		#else
-
-		std::string* _title = wstring_to_string (title);
-		std::string* _filter = wstring_to_string (filter);
-		std::string* _defaultPath = wstring_to_string (defaultPath);
-
-		std::vector<std::string> filters_vec;
-		if (_filter) {
-			std::string line;
-			std::stringstream ss(*_filter);
-			while(std::getline(ss, line, ',')) {
-				line.insert (0, "*.");
-				filters_vec.push_back(line);
-			}
-		}
-
-		const int numFilters = _filter ? filters_vec.size() : 1;
-		const char **filters = new const char*[numFilters];
-		if (_filter && numFilters > 0) {
-			for (int index = 0; index < numFilters; index++) {
-				filters[index] = const_cast<char*>(filters_vec[index].c_str());
-			}
-		} else {
-			filters[0] = NULL;
-		}
-
-		const char* path = tinyfd_openFileDialog (_title ? _title->c_str () : NULL, _defaultPath ? _defaultPath->c_str () : NULL, _filter ? numFilters : 0, _filter ? filters : NULL, NULL, 0);
-
-		delete[] filters;
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
-
-		if (path && std::strlen(path) > 0) {
-
-			std::string _path = std::string (path);
-			std::wstring* __path = new std::wstring (_path.begin (), _path.end ());
-			return __path;
+			return path;
 
 		}
-
-		#endif
 
 		return 0;
 
 	}
 
 
-	void FileDialog::OpenFiles (std::vector<std::wstring*>* files, std::wstring* title, std::wstring* filter, std::wstring* defaultPath) {
+	std::vector<FileDialog::string_view> FileDialog::OpenFiles (const char_t* title, const char_t* filter, const char_t* defaultPath) {
+		std::vector<string_view> files;
 
-		std::wstring* __paths = 0;
-
-		#ifdef HX_WINDOWS
-
-		std::vector<std::wstring> filters_vec;
+		std::vector<string_t> filters_vec;
 		if (filter) {
-			std::wstring temp (L"*.");
-			std::wstring line;
-			std::wstringstream ss(*filter);
-			while(std::getline(ss, line, L',')) {
+			string_t temp(FD_STR("*."));
+			string_t line;
+			std::basic_stringstream<char_t> ss(filter);
+			while(std::getline(ss, line, FD_STR(','))) {
 				filters_vec.push_back(temp + line);
 			}
 		}
 
 		const int numFilters = filter ? filters_vec.size() : 1;
-		const wchar_t **filters = new const wchar_t*[numFilters];
+		const char_t **filters = new const char_t*[numFilters];
 		if (filter && numFilters > 0) {
 			for (int index = 0; index < numFilters; index++) {
-				filters[index] = const_cast<wchar_t*>(filters_vec[index].c_str());
+				filters[index] = const_cast<char_t*>(filters_vec[index].c_str());
 			}
 		} else {
 			filters[0] = NULL;
 		}
 
-		const wchar_t* paths = tinyfd_openFileDialogW (title ? title->c_str () : 0, defaultPath ? defaultPath->c_str () : 0, filter ? numFilters : 0, filter ? filters : NULL, NULL, 1);
+		const char_t* paths = tinyfd_openFileDialog (title, defaultPath, filter ? numFilters : 0, filter ? filters : NULL, NULL, 1);
 
 		delete[] filters;
 
-		if (paths) {
+		if (!is_null_or_empty(paths)) {
 
-			__paths = new std::wstring (paths);
+			char_t sep = FD_STR('|');
 
-		}
+			const char_t* start = paths,
+						* cur = paths;
 
-		#else
+			while (*cur) {
+				if (*cur == sep) {
+					files.emplace_back(start, cur - start);
+					start = cur + 1;
+				}
 
-		std::string* _title = wstring_to_string (title);
-		std::string* _filter = wstring_to_string (filter);
-		std::string* _defaultPath = wstring_to_string (defaultPath);
-
-		std::vector<std::string> filters_vec;
-		if (_filter) {
-			std::string line;
-			std::stringstream ss(*_filter);
-			while(std::getline(ss, line, ',')) {
-				line.insert (0, "*.");
-				filters_vec.push_back(line);
-			}
-		}
-
-		const int numFilters = _filter ? filters_vec.size() : 1;
-		const char **filters = new const char*[numFilters];
-		if (_filter && numFilters > 0) {
-			for (int index = 0; index < numFilters; index++) {
-				filters[index] = const_cast<char*>(filters_vec[index].c_str());
-			}
-		} else {
-			filters[0] = NULL;
-		}
-
-		const char* paths = tinyfd_openFileDialog (_title ? _title->c_str () : NULL, _defaultPath ? _defaultPath->c_str () : NULL, _filter ? numFilters : 0, _filter ? filters : NULL, NULL, 1);
-
-		delete[] filters;
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
-
-		if (paths) {
-
-			std::string _paths = std::string (paths);
-			__paths = new std::wstring (_paths.begin (), _paths.end ());
-
-		}
-
-		#endif
-
-		if (__paths) {
-
-			std::wstring sep = L"|";
-
-			std::size_t start = 0, end = 0;
-
-			while ((end = __paths->find (sep, start)) != std::wstring::npos) {
-
-				files->push_back (new std::wstring (__paths->substr (start, end - start).c_str ()));
-				start = end + 1;
-
+				cur++;
 			}
 
-			files->push_back (new std::wstring (__paths->substr (start).c_str ()));
+			files.emplace_back(start, cur - start);
 
 		}
+
+		return files;
 
 	}
 
 
-	std::wstring* FileDialog::SaveFile (std::wstring* title, std::wstring* filter, std::wstring* defaultPath) {
+	const char_t* FileDialog::SaveFile (const char_t* title, const char_t* filter, const char_t* defaultPath) {
 
-		#ifdef HX_WINDOWS
+		string_t temp(FD_STR("*."));
+		const char_t* filters[] = { filter ? (temp + *filter).c_str () : NULL };
 
-		std::wstring temp (L"*.");
-		const wchar_t* filters[] = { filter ? (temp + *filter).c_str () : NULL };
+		const char_t* path = tinyfd_saveFileDialog (title, defaultPath, filter ? 1 : 0, filter ? filters : NULL, NULL);
 
-		const wchar_t* path = tinyfd_saveFileDialogW (title ? title->c_str () : 0, defaultPath ? defaultPath->c_str () : 0, filter ? 1 : 0, filter ? filters : NULL, NULL);
+		if (!is_null_or_empty(path)) {
 
-		if (path && std::wcslen(path) > 0) {
-
-			std::wstring* _path = new std::wstring (path);
-			return _path;
+			return path;
 
 		}
-
-		#else
-
-		std::string* _title = wstring_to_string (title);
-		std::string* _filter = wstring_to_string (filter);
-		std::string* _defaultPath = wstring_to_string (defaultPath);
-
-		const char* filters[] = { NULL };
-
-		if (_filter) {
-
-			_filter->insert (0, "*.");
-			filters[0] = _filter->c_str ();
-
-		}
-
-		const char* path = tinyfd_saveFileDialog (_title ? _title->c_str () : NULL, _defaultPath ? _defaultPath->c_str () : NULL, _filter ? 1 : 0, _filter ? filters : NULL, NULL);
-
-		if (_title) delete _title;
-		if (_filter) delete _filter;
-		if (_defaultPath) delete _defaultPath;
-
-		if (path && std::strlen(path) > 0) {
-
-			std::string _path = std::string (path);
-			std::wstring* __path = new std::wstring (_path.begin (), _path.end ());
-			return __path;
-
-		}
-
-		#endif
 
 		return 0;
 


### PR DESCRIPTION
Currently, there are a lot of redundant string conversions when using the file dialog api. This was mentioned briefly in #1622.

Here is a rough overview of the current situation:

Linux/macOS:
- C++: `hxstring` -> `std::wstring` -> `std::string`, passed into tinyfiledialogs utf-8 api, then `std::string` -> `std::wstring` -> `hxstring`
- HL: `hl_vstring` -> `std::wstring` -> `std::string`, passed into tinyfiledialogs utf-8 api, then `std::string` -> `std::wstring` -> `utf-8` bytes -> native `utf-16` hashlink string (on Haxe side via `String.fromUtf8()`)

Windows:
- C++: `hxstring` -> `std::wstring`, passed into tinyfiledialogs utf-16 api, then `std::wstring` -> `hxstring`
- HL: `hl_vstring` -> `std::wstring`, passed into tinyfiledialogs utf-16 api, then `std::wstring` -> `utf-8` bytes -> native `utf-16` hashlink string (on Haxe side via `String.fromUtf8()`)

This cleans things up to avoid unnecessary conversions, so now it looks like this in most cases:

Linux/macOS:
- C++: `hxstring` -> `utf-8`[0], passed into tinyfiledialogs utf-8 api, then `utf-8` -> `hxstring`
- HL: `hl_vstring` -> `utf-8`, passed into tinyfiledialogs utf-8 api, then `utf-8` -> `utf-16` hashlink string (on Haxe side via `String.fromUtf8()`)

Windows:
- C++: `hxstring` -> `utf-16`[0], passed into tinyfiledialogs utf-16 api, then `utf-16` -> `hxstring`
- HL: `hl_vstring`, passed into tinyfiledialogs utf-16 api, then `utf-16` -> `utf8` -> `utf-16` hashlink string (on Haxe side via `String.fromUtf8()`)

[0] hxcpp can use ASCII (which is compatible with utf-8) or utf-16 depending on the string, so these conversions are avoided in some cases.

We can improve Hashlink further (for Windows), by returning utf-16 strings from the apis, however, I'm not sure if this would be considered a breaking change (new lime.hdlls would be incompatible with old lime haxe files).

In #1622, we briefly discussed using the utf-8 tinyfiledialog functions on Windows to unify the api, however, I looked into this and on Windows these functions just convert back to utf-16, so there would still be extra conversions. So I think this is the cleanest solution.

I've tested on Linux and Windows with the code from #1622, and everything works well.