### PR TITLE
[js] allow to use remote js dependecies like https://unpkg.com/react.js in Project.xml

### DIFF
--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -430,6 +430,10 @@ class HTML5Platform extends PlatformTarget
 					context.linkedLibraries.push("./" + dependencyPath + "/" + name);
 					System.copyIfNewer(dependency.path, Path.combine(destination, Path.combine(dependencyPath, name)));
 				}
+				else if (StringTools.startsWith(dependency.path, 'http') && StringTools.endsWith(dependency.path, '.js'))
+				{
+					context.linkedLibraries.push(dependency.path);
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR allows this syntax

```xml
<dependency path="https://unpkg.com/simple-peer@5.9.0/simplepeer.min.js" />
```

to include the library in `index.html`.

Without this PR, the same can be achieved using `name` attribute

 ```xml
<dependency name="https://unpkg.com/simple-peer@5.9.0/simplepeer.min.js" />
```

but I believe `path` attribute suits better.