### PR TITLE
Take const char pointers in lime::Font methods

### DIFF
--- a/project/include/text/Font.h
+++ b/project/include/text/Font.h
@@ -49,8 +49,8 @@ namespace lime {
 			int GetAscender ();
 			int GetDescender ();
 			wchar_t *GetFamilyName ();
-			int GetGlyphIndex (char* character);
-			void* GetGlyphIndices (bool useCFFIValue, char* characters);
+			int GetGlyphIndex (const char* character);
+			void* GetGlyphIndices (bool useCFFIValue, const char* characters);
 			void* GetGlyphMetrics (bool useCFFIValue, int index);
 			int GetHeight ();
 			int GetNumGlyphs ();

--- a/project/src/text/Font.cpp
+++ b/project/src/text/Font.cpp
@@ -25,7 +25,7 @@
 #define IS_IN_RANGE(c, f, l) (((c) >= (f)) && ((c) <= (l)))
 
 
-unsigned long readNextChar (char*& p)
+unsigned long readNextChar (const char*& p)
 {
 	 // TODO: since UTF-8 is a variable-length
 	 // encoding, you should pass in the input
@@ -33,7 +33,8 @@ unsigned long readNextChar (char*& p)
 	 // can determine if a malformed UTF-8
 	 // sequence would exceed the end of the buffer...
 
-	 unsigned char c1, c2, *ptr = (unsigned char*) p;
+	 const unsigned char* ptr = (const unsigned char*) p;
+	 unsigned char c1, c2;
 	 unsigned long uc = 0;
 	 int seqlen;
 
@@ -792,7 +793,7 @@ namespace lime {
 	}
 
 
-	int Font::GetGlyphIndex (char* character) {
+	int Font::GetGlyphIndex (const char* character) {
 
 		long charCode = readNextChar (character);
 
@@ -801,7 +802,7 @@ namespace lime {
 	}
 
 
-	void* Font::GetGlyphIndices (bool useCFFIValue, char* characters) {
+	void* Font::GetGlyphIndices (bool useCFFIValue, const char* characters) {
 
 		if (useCFFIValue) {
 


### PR DESCRIPTION
Makes it clear that the string won't be modified, and avoids needing to cast away const when passing const char pointers into these methods.