### PR TITLE
Migrate to SDL3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/openfl/libvorbis
 [submodule "project/lib/sdl"]
 	path = project/lib/sdl
-	url = https://github.com/openfl/libsdl
+	url = https://github.com/libsdl-org/SDL
 [submodule "project/lib/openal"]
 	path = project/lib/openal
 	url = https://github.com/openfl/libopenal

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,10 +3,10 @@
 	url = https://github.com/openfl/libvorbis
 [submodule "project/lib/sdl"]
 	path = project/lib/sdl
-	url = https://github.com/libsdl-org/SDL
+	url = https://github.com/EliteMasterEric/openfl-libsdl
 [submodule "project/lib/openal"]
 	path = project/lib/openal
-	url = https://github.com/openfl/libopenal
+	url = https://github.com/EliteMasterEric/libopenal
 [submodule "project/lib/curl"]
 	path = project/lib/curl
 	url = https://github.com/openfl/libcurl

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -211,7 +211,7 @@
 			<section if="emscripten">
 
 				<compilerflag value="-s" />
-				<compilerflag value="USE_SDL=2" />
+				<compilerflag value="USE_SDL=3" />
 
 			</section>
 

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -2307,20 +2307,6 @@ namespace lime {
 	}
 
 
-	int lime_joystick_get_num_trackballs (int id) {
-
-		return Joystick::GetNumTrackballs (id);
-
-	}
-
-
-	HL_PRIM int HL_NAME(hl_joystick_get_num_trackballs) (int id) {
-
-		return Joystick::GetNumTrackballs (id);
-
-	}
-
-
 	value lime_jpeg_decode_bytes (value data, bool decodeData, value buffer) {
 
 		ImageBuffer imageBuffer (buffer);
@@ -3915,7 +3901,6 @@ namespace lime {
 	DEFINE_PRIME1 (lime_joystick_get_num_axes);
 	DEFINE_PRIME1 (lime_joystick_get_num_buttons);
 	DEFINE_PRIME1 (lime_joystick_get_num_hats);
-	DEFINE_PRIME1 (lime_joystick_get_num_trackballs);
 	DEFINE_PRIME3 (lime_jpeg_decode_bytes);
 	DEFINE_PRIME3 (lime_jpeg_decode_file);
 	DEFINE_PRIME1 (lime_key_code_from_scan_code);
@@ -4099,7 +4084,6 @@ namespace lime {
 	DEFINE_HL_PRIM (_I32, hl_joystick_get_num_axes, _I32);
 	DEFINE_HL_PRIM (_I32, hl_joystick_get_num_buttons, _I32);
 	DEFINE_HL_PRIM (_I32, hl_joystick_get_num_hats, _I32);
-	DEFINE_HL_PRIM (_I32, hl_joystick_get_num_trackballs, _I32);
 	DEFINE_HL_PRIM (_TIMAGEBUFFER, hl_jpeg_decode_bytes, _TBYTES _BOOL _TIMAGEBUFFER);
 	DEFINE_HL_PRIM (_TIMAGEBUFFER, hl_jpeg_decode_file, _STRING _BOOL _TIMAGEBUFFER);
 	DEFINE_HL_PRIM (_F32, hl_key_code_from_scan_code, _F32);

--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -25,7 +25,7 @@ namespace lime {
 
 	SDLApplication::SDLApplication () {
 
-		Uint32 initFlags = SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_TIMER | SDL_INIT_JOYSTICK;
+		Uint32 initFlags = SDL_INIT_VIDEO | SDL_INIT_GAMEPAD | SDL_INIT_TIMER | SDL_INIT_JOYSTICK;
 		#if defined(LIME_MOJOAL) || defined(LIME_OPENALSOFT)
 		initFlags |= SDL_INIT_AUDIO;
 		#endif
@@ -65,7 +65,7 @@ namespace lime {
 		TouchEvent touchEvent;
 		WindowEvent windowEvent;
 
-		SDL_EventState (SDL_DROPFILE, SDL_ENABLE);
+		SDL_SetEventEnabled (SDL_EVENT_DROP_FILE, SDL_TRUE);
 		SDLJoystick::Init ();
 
 		#ifdef HX_MACOS
@@ -125,7 +125,7 @@ namespace lime {
 
 		switch (event->type) {
 
-			case SDL_USEREVENT:
+			case SDL_EVENT_USER:
 
 				if (!inBackground) {
 
@@ -149,7 +149,7 @@ namespace lime {
 
 				break;
 
-			case SDL_APP_WILLENTERBACKGROUND:
+			case SDL_EVENT_WILL_ENTER_BACKGROUND:
 
 				inBackground = true;
 
@@ -157,11 +157,11 @@ namespace lime {
 				WindowEvent::Dispatch (&windowEvent);
 				break;
 
-			case SDL_APP_WILLENTERFOREGROUND:
+			case SDL_EVENT_WILL_ENTER_FOREGROUND:
 
 				break;
 
-			case SDL_APP_DIDENTERFOREGROUND:
+			case SDL_EVENT_DID_ENTER_FOREGROUND:
 
 				windowEvent.type = WINDOW_ACTIVATE;
 				WindowEvent::Dispatch (&windowEvent);
@@ -169,33 +169,33 @@ namespace lime {
 				inBackground = false;
 				break;
 
-			case SDL_CLIPBOARDUPDATE:
+			case SDL_EVENT_CLIPBOARD_UPDATE:
 
 				ProcessClipboardEvent (event);
 				break;
 
-			case SDL_CONTROLLERAXISMOTION:
-			case SDL_CONTROLLERBUTTONDOWN:
-			case SDL_CONTROLLERBUTTONUP:
-			case SDL_CONTROLLERDEVICEADDED:
-			case SDL_CONTROLLERDEVICEREMOVED:
+			case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+			case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+			case SDL_EVENT_GAMEPAD_BUTTON_UP:
+			case SDL_EVENT_GAMEPAD_ADDED:
+			case SDL_EVENT_GAMEPAD_REMOVED:
 
 				ProcessGamepadEvent (event);
 				break;
 
-			case SDL_DROPFILE:
+			case SDL_EVENT_DROP_FILE:
 
 				ProcessDropEvent (event);
 				break;
 
-			case SDL_FINGERMOTION:
-			case SDL_FINGERDOWN:
-			case SDL_FINGERUP:
+			case SDL_EVENT_FINGER_MOTION:
+			case SDL_EVENT_FINGER_DOWN:
+			case SDL_EVENT_FINGER_UP:
 
 				ProcessTouchEvent (event);
 				break;
 
-			case SDL_JOYAXISMOTION:
+			case SDL_EVENT_JOYSTICK_AXIS_MOTION:
 
 				if (SDLJoystick::IsAccelerometer (event->jaxis.which)) {
 
@@ -209,32 +209,31 @@ namespace lime {
 
 				break;
 
-			case SDL_JOYBALLMOTION:
-			case SDL_JOYBUTTONDOWN:
-			case SDL_JOYBUTTONUP:
-			case SDL_JOYHATMOTION:
-			case SDL_JOYDEVICEADDED:
-			case SDL_JOYDEVICEREMOVED:
+			case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
+			case SDL_EVENT_JOYSTICK_BUTTON_UP:
+			case SDL_EVENT_JOYSTICK_HAT_MOTION:
+			case SDL_EVENT_JOYSTICK_ADDED:
+			case SDL_EVENT_JOYSTICK_REMOVED:
 
 				ProcessJoystickEvent (event);
 				break;
 
-			case SDL_KEYDOWN:
-			case SDL_KEYUP:
+			case SDL_EVENT_KEY_DOWN:
+			case SDL_EVENT_KEY_UP:
 
 				ProcessKeyEvent (event);
 				break;
 
-			case SDL_MOUSEMOTION:
-			case SDL_MOUSEBUTTONDOWN:
-			case SDL_MOUSEBUTTONUP:
-			case SDL_MOUSEWHEEL:
+			case SDL_EVENT_MOUSE_MOTION:
+			case SDL_EVENT_MOUSE_BUTTON_DOWN:
+			case SDL_EVENT_MOUSE_BUTTON_UP:
+			case SDL_EVENT_MOUSE_WHEEL:
 
 				ProcessMouseEvent (event);
 				break;
 
 			#ifndef EMSCRIPTEN
-			case SDL_RENDER_DEVICE_RESET:
+			case SDL_EVENT_RENDER_DEVICE_RESET:
 
 				renderEvent.type = RENDER_CONTEXT_LOST;
 				RenderEvent::Dispatch (&renderEvent);
@@ -246,77 +245,70 @@ namespace lime {
 				break;
 			#endif
 
-			case SDL_TEXTINPUT:
-			case SDL_TEXTEDITING:
+			case SDL_EVENT_TEXT_INPUT:
+			case SDL_EVENT_TEXT_EDITING:
 
 				ProcessTextEvent (event);
 				break;
 
-			case SDL_WINDOWEVENT:
+			case SDL_EVENT_WINDOW_MOUSE_ENTER:
+			case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+			case SDL_EVENT_WINDOW_SHOWN:
+			case SDL_EVENT_WINDOW_HIDDEN:
+			case SDL_EVENT_WINDOW_FOCUS_GAINED:
+			case SDL_EVENT_WINDOW_FOCUS_LOST:
+			case SDL_EVENT_WINDOW_MAXIMIZED:
+			case SDL_EVENT_WINDOW_MINIMIZED:
+			case SDL_EVENT_WINDOW_MOVED:
+			case SDL_EVENT_WINDOW_RESTORED:
 
-				switch (event->window.event) {
+				ProcessWindowEvent (event);
+				break;
 
-					case SDL_WINDOWEVENT_ENTER:
-					case SDL_WINDOWEVENT_LEAVE:
-					case SDL_WINDOWEVENT_SHOWN:
-					case SDL_WINDOWEVENT_HIDDEN:
-					case SDL_WINDOWEVENT_FOCUS_GAINED:
-					case SDL_WINDOWEVENT_FOCUS_LOST:
-					case SDL_WINDOWEVENT_MAXIMIZED:
-					case SDL_WINDOWEVENT_MINIMIZED:
-					case SDL_WINDOWEVENT_MOVED:
-					case SDL_WINDOWEVENT_RESTORED:
+			case SDL_EVENT_WINDOW_EXPOSED:
 
-						ProcessWindowEvent (event);
-						break;
+				ProcessWindowEvent (event);
 
-					case SDL_WINDOWEVENT_EXPOSED:
+				if (!inBackground) {
 
-						ProcessWindowEvent (event);
-
-						if (!inBackground) {
-
-							RenderEvent::Dispatch (&renderEvent);
-
-						}
-
-						break;
-
-					case SDL_WINDOWEVENT_SIZE_CHANGED:
-
-						ProcessWindowEvent (event);
-
-						if (!inBackground) {
-
-							RenderEvent::Dispatch (&renderEvent);
-
-						}
-
-						break;
-
-					case SDL_WINDOWEVENT_CLOSE:
-
-						ProcessWindowEvent (event);
-
-						// Avoid handling SDL_QUIT if in response to window.close
-						SDL_Event event;
-
-						if (SDL_PollEvent (&event)) {
-
-							if (event.type != SDL_QUIT) {
-
-								HandleEvent (&event);
-
-							}
-
-						}
-						break;
+					RenderEvent::Dispatch (&renderEvent);
 
 				}
 
 				break;
 
-			case SDL_QUIT:
+			case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+
+				ProcessWindowEvent (event);
+
+				if (!inBackground) {
+
+					RenderEvent::Dispatch (&renderEvent);
+
+				}
+
+				break;
+
+			case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+
+				ProcessWindowEvent (event);
+
+				// Avoid handling SDL_EVENT_QUIT if in response to window.close
+				SDL_Event event;
+
+				if (SDL_PollEvent (&event)) {
+
+					if (event.type != SDL_EVENT_QUIT) {
+
+						HandleEvent (&event);
+
+					}
+
+				}
+				break;
+
+
+			case SDL_EVENT_QUIT:
 
 				active = false;
 				break;
@@ -369,27 +361,27 @@ namespace lime {
 
 			switch (event->type) {
 
-				case SDL_CONTROLLERAXISMOTION:
+				case SDL_EVENT_GAMEPAD_AXIS_MOTION:
 
-					if (gamepadsAxisMap[event->caxis.which].empty ()) {
+					if (gamepadsAxisMap[event->gaxis.which].empty ()) {
 
-						gamepadsAxisMap[event->caxis.which][event->caxis.axis] = event->caxis.value;
+						gamepadsAxisMap[event->gaxis.which][event->gaxis.axis] = event->gaxis.value;
 
-					} else if (gamepadsAxisMap[event->caxis.which][event->caxis.axis] == event->caxis.value) {
+					} else if (gamepadsAxisMap[event->gaxis.which][event->gaxis.axis] == event->gaxis.value) {
 
 						break;
 
 					}
 
 					gamepadEvent.type = GAMEPAD_AXIS_MOVE;
-					gamepadEvent.axis = event->caxis.axis;
-					gamepadEvent.id = event->caxis.which;
+					gamepadEvent.axis = event->gaxis.axis;
+					gamepadEvent.id = event->gaxis.which;
 
-					if (event->caxis.value > -analogAxisDeadZone && event->caxis.value < analogAxisDeadZone) {
+					if (event->gaxis.value > -analogAxisDeadZone && event->gaxis.value < analogAxisDeadZone) {
 
-						if (gamepadsAxisMap[event->caxis.which][event->caxis.axis] != 0) {
+						if (gamepadsAxisMap[event->gaxis.which][event->gaxis.axis] != 0) {
 
-							gamepadsAxisMap[event->caxis.which][event->caxis.axis] = 0;
+							gamepadsAxisMap[event->gaxis.which][event->gaxis.axis] = 0;
 							gamepadEvent.axisValue = 0;
 							GamepadEvent::Dispatch (&gamepadEvent);
 
@@ -399,36 +391,36 @@ namespace lime {
 
 					}
 
-					gamepadsAxisMap[event->caxis.which][event->caxis.axis] = event->caxis.value;
-					gamepadEvent.axisValue = event->caxis.value / (event->caxis.value > 0 ? 32767.0 : 32768.0);
+					gamepadsAxisMap[event->gaxis.which][event->gaxis.axis] = event->gaxis.value;
+					gamepadEvent.axisValue = event->gaxis.value / (event->gaxis.value > 0 ? 32767.0 : 32768.0);
 
 					GamepadEvent::Dispatch (&gamepadEvent);
 					break;
 
-				case SDL_CONTROLLERBUTTONDOWN:
+				case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
 
 					gamepadEvent.type = GAMEPAD_BUTTON_DOWN;
-					gamepadEvent.button = event->cbutton.button;
-					gamepadEvent.id = event->cbutton.which;
+					gamepadEvent.button = event->gbutton.button;
+					gamepadEvent.id = event->gbutton.which;
 
 					GamepadEvent::Dispatch (&gamepadEvent);
 					break;
 
-				case SDL_CONTROLLERBUTTONUP:
+				case SDL_EVENT_GAMEPAD_BUTTON_UP:
 
 					gamepadEvent.type = GAMEPAD_BUTTON_UP;
-					gamepadEvent.button = event->cbutton.button;
-					gamepadEvent.id = event->cbutton.which;
+					gamepadEvent.button = event->gbutton.button;
+					gamepadEvent.id = event->gbutton.which;
 
 					GamepadEvent::Dispatch (&gamepadEvent);
 					break;
 
-				case SDL_CONTROLLERDEVICEADDED:
+				case SDL_EVENT_GAMEPAD_ADDED:
 
-					if (SDLGamepad::Connect (event->cdevice.which)) {
+					if (SDLGamepad::Connect (event->gdevice.which)) {
 
 						gamepadEvent.type = GAMEPAD_CONNECT;
-						gamepadEvent.id = SDLGamepad::GetInstanceID (event->cdevice.which);
+						gamepadEvent.id = SDLGamepad::GetInstanceID (event->gdevice.which);
 
 						GamepadEvent::Dispatch (&gamepadEvent);
 
@@ -436,13 +428,13 @@ namespace lime {
 
 					break;
 
-				case SDL_CONTROLLERDEVICEREMOVED: {
+				case SDL_EVENT_GAMEPAD_REMOVED: {
 
 					gamepadEvent.type = GAMEPAD_DISCONNECT;
-					gamepadEvent.id = event->cdevice.which;
+					gamepadEvent.id = event->gdevice.which;
 
 					GamepadEvent::Dispatch (&gamepadEvent);
-					SDLGamepad::Disconnect (event->cdevice.which);
+					SDLGamepad::Disconnect (event->gdevice.which);
 					break;
 
 				}
@@ -460,7 +452,7 @@ namespace lime {
 
 			switch (event->type) {
 
-				case SDL_JOYAXISMOTION:
+				case SDL_EVENT_JOYSTICK_AXIS_MOTION:
 
 					if (!SDLJoystick::IsAccelerometer (event->jaxis.which)) {
 
@@ -474,22 +466,7 @@ namespace lime {
 					}
 					break;
 
-				case SDL_JOYBALLMOTION:
-
-					if (!SDLJoystick::IsAccelerometer (event->jball.which)) {
-
-						joystickEvent.type = JOYSTICK_TRACKBALL_MOVE;
-						joystickEvent.index = event->jball.ball;
-						joystickEvent.x = event->jball.xrel / (event->jball.xrel > 0 ? 32767.0 : 32768.0);
-						joystickEvent.y = event->jball.yrel / (event->jball.yrel > 0 ? 32767.0 : 32768.0);
-						joystickEvent.id = event->jball.which;
-
-						JoystickEvent::Dispatch (&joystickEvent);
-
-					}
-					break;
-
-				case SDL_JOYBUTTONDOWN:
+				case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
 
 					if (!SDLJoystick::IsAccelerometer (event->jbutton.which)) {
 
@@ -502,7 +479,7 @@ namespace lime {
 					}
 					break;
 
-				case SDL_JOYBUTTONUP:
+				case SDL_EVENT_JOYSTICK_BUTTON_UP:
 
 					if (!SDLJoystick::IsAccelerometer (event->jbutton.which)) {
 
@@ -515,7 +492,7 @@ namespace lime {
 					}
 					break;
 
-				case SDL_JOYHATMOTION:
+				case SDL_EVENT_JOYSTICK_HAT_MOTION:
 
 					if (!SDLJoystick::IsAccelerometer (event->jhat.which)) {
 
@@ -529,7 +506,7 @@ namespace lime {
 					}
 					break;
 
-				case SDL_JOYDEVICEADDED:
+				case SDL_EVENT_JOYSTICK_ADDED:
 
 					if (SDLJoystick::Connect (event->jdevice.which)) {
 
@@ -541,7 +518,7 @@ namespace lime {
 					}
 					break;
 
-				case SDL_JOYDEVICEREMOVED:
+				case SDL_EVENT_JOYSTICK_REMOVED:
 
 					if (!SDLJoystick::IsAccelerometer (event->jdevice.which)) {
 
@@ -567,8 +544,8 @@ namespace lime {
 
 			switch (event->type) {
 
-				case SDL_KEYDOWN: keyEvent.type = KEY_DOWN; break;
-				case SDL_KEYUP: keyEvent.type = KEY_UP; break;
+				case SDL_EVENT_KEY_DOWN: keyEvent.type = KEY_DOWN; break;
+				case SDL_EVENT_KEY_UP: keyEvent.type = KEY_UP; break;
 
 			}
 
@@ -578,17 +555,17 @@ namespace lime {
 
 			if (keyEvent.type == KEY_DOWN) {
 
-				if (keyEvent.keyCode == SDLK_CAPSLOCK) keyEvent.modifier |= KMOD_CAPS;
-				if (keyEvent.keyCode == SDLK_LALT) keyEvent.modifier |= KMOD_LALT;
-				if (keyEvent.keyCode == SDLK_LCTRL) keyEvent.modifier |= KMOD_LCTRL;
-				if (keyEvent.keyCode == SDLK_LGUI) keyEvent.modifier |= KMOD_LGUI;
-				if (keyEvent.keyCode == SDLK_LSHIFT) keyEvent.modifier |= KMOD_LSHIFT;
-				if (keyEvent.keyCode == SDLK_MODE) keyEvent.modifier |= KMOD_MODE;
-				if (keyEvent.keyCode == SDLK_NUMLOCKCLEAR) keyEvent.modifier |= KMOD_NUM;
-				if (keyEvent.keyCode == SDLK_RALT) keyEvent.modifier |= KMOD_RALT;
-				if (keyEvent.keyCode == SDLK_RCTRL) keyEvent.modifier |= KMOD_RCTRL;
-				if (keyEvent.keyCode == SDLK_RGUI) keyEvent.modifier |= KMOD_RGUI;
-				if (keyEvent.keyCode == SDLK_RSHIFT) keyEvent.modifier |= KMOD_RSHIFT;
+				if (keyEvent.keyCode == SDLK_CAPSLOCK) keyEvent.modifier |= SDL_KMOD_CAPS;
+				if (keyEvent.keyCode == SDLK_LALT) keyEvent.modifier |= SDL_KMOD_LALT;
+				if (keyEvent.keyCode == SDLK_LCTRL) keyEvent.modifier |= SDL_KMOD_LCTRL;
+				if (keyEvent.keyCode == SDLK_LGUI) keyEvent.modifier |= SDL_KMOD_LGUI;
+				if (keyEvent.keyCode == SDLK_LSHIFT) keyEvent.modifier |= SDL_KMOD_LSHIFT;
+				if (keyEvent.keyCode == SDLK_MODE) keyEvent.modifier |= SDL_KMOD_MODE;
+				if (keyEvent.keyCode == SDLK_NUMLOCKCLEAR) keyEvent.modifier |= SDL_KMOD_NUM;
+				if (keyEvent.keyCode == SDLK_RALT) keyEvent.modifier |= SDL_KMOD_RALT;
+				if (keyEvent.keyCode == SDLK_RCTRL) keyEvent.modifier |= SDL_KMOD_RCTRL;
+				if (keyEvent.keyCode == SDLK_RGUI) keyEvent.modifier |= SDL_KMOD_RGUI;
+				if (keyEvent.keyCode == SDLK_RSHIFT) keyEvent.modifier |= SDL_KMOD_RSHIFT;
 
 			}
 
@@ -605,7 +582,7 @@ namespace lime {
 
 			switch (event->type) {
 
-				case SDL_MOUSEMOTION:
+				case SDL_EVENT_MOUSE_MOTION:
 
 					mouseEvent.type = MOUSE_MOVE;
 					mouseEvent.x = event->motion.x;
@@ -614,7 +591,7 @@ namespace lime {
 					mouseEvent.movementY = event->motion.yrel;
 					break;
 
-				case SDL_MOUSEBUTTONDOWN:
+				case SDL_EVENT_MOUSE_BUTTON_DOWN:
 
 					SDL_CaptureMouse (SDL_TRUE);
 
@@ -624,7 +601,7 @@ namespace lime {
 					mouseEvent.y = event->button.y;
 					break;
 
-				case SDL_MOUSEBUTTONUP:
+				case SDL_EVENT_MOUSE_BUTTON_UP:
 
 					SDL_CaptureMouse (SDL_FALSE);
 
@@ -634,7 +611,7 @@ namespace lime {
 					mouseEvent.y = event->button.y;
 					break;
 
-				case SDL_MOUSEWHEEL:
+				case SDL_EVENT_MOUSE_WHEEL:
 
 					mouseEvent.type = MOUSE_WHEEL;
 
@@ -689,12 +666,12 @@ namespace lime {
 
 			switch (event->type) {
 
-				case SDL_TEXTINPUT:
+				case SDL_EVENT_TEXT_INPUT:
 
 					textEvent.type = TEXT_INPUT;
 					break;
 
-				case SDL_TEXTEDITING:
+				case SDL_EVENT_TEXT_EDITING:
 
 					textEvent.type = TEXT_EDIT;
 					textEvent.start = event->edit.start;
@@ -726,17 +703,17 @@ namespace lime {
 
 			switch (event->type) {
 
-				case SDL_FINGERMOTION:
+				case SDL_EVENT_FINGER_MOTION:
 
 					touchEvent.type = TOUCH_MOVE;
 					break;
 
-				case SDL_FINGERDOWN:
+				case SDL_EVENT_FINGER_DOWN:
 
 					touchEvent.type = TOUCH_START;
 					break;
 
-				case SDL_FINGERUP:
+				case SDL_EVENT_FINGER_UP:
 
 					touchEvent.type = TOUCH_END;
 					break;
@@ -762,34 +739,34 @@ namespace lime {
 
 		if (WindowEvent::callback) {
 
-			switch (event->window.event) {
+			switch (event->type) {
 
-				case SDL_WINDOWEVENT_SHOWN: windowEvent.type = WINDOW_ACTIVATE; break;
-				case SDL_WINDOWEVENT_CLOSE: windowEvent.type = WINDOW_CLOSE; break;
-				case SDL_WINDOWEVENT_HIDDEN: windowEvent.type = WINDOW_DEACTIVATE; break;
-				case SDL_WINDOWEVENT_ENTER: windowEvent.type = WINDOW_ENTER; break;
-				case SDL_WINDOWEVENT_FOCUS_GAINED: windowEvent.type = WINDOW_FOCUS_IN; break;
-				case SDL_WINDOWEVENT_FOCUS_LOST: windowEvent.type = WINDOW_FOCUS_OUT; break;
-				case SDL_WINDOWEVENT_LEAVE: windowEvent.type = WINDOW_LEAVE; break;
-				case SDL_WINDOWEVENT_MAXIMIZED: windowEvent.type = WINDOW_MAXIMIZE; break;
-				case SDL_WINDOWEVENT_MINIMIZED: windowEvent.type = WINDOW_MINIMIZE; break;
-				case SDL_WINDOWEVENT_EXPOSED: windowEvent.type = WINDOW_EXPOSE; break;
+				case SDL_EVENT_WINDOW_SHOWN: windowEvent.type = WINDOW_ACTIVATE; break;
+				case SDL_EVENT_WINDOW_CLOSE_REQUESTED: windowEvent.type = WINDOW_CLOSE; break;
+				case SDL_EVENT_WINDOW_HIDDEN: windowEvent.type = WINDOW_DEACTIVATE; break;
+				case SDL_EVENT_WINDOW_MOUSE_ENTER: windowEvent.type = WINDOW_ENTER; break;
+				case SDL_EVENT_WINDOW_FOCUS_GAINED: windowEvent.type = WINDOW_FOCUS_IN; break;
+				case SDL_EVENT_WINDOW_FOCUS_LOST: windowEvent.type = WINDOW_FOCUS_OUT; break;
+				case SDL_EVENT_WINDOW_MOUSE_LEAVE: windowEvent.type = WINDOW_LEAVE; break;
+				case SDL_EVENT_WINDOW_MAXIMIZED: windowEvent.type = WINDOW_MAXIMIZE; break;
+				case SDL_EVENT_WINDOW_MINIMIZED: windowEvent.type = WINDOW_MINIMIZE; break;
+				case SDL_EVENT_WINDOW_EXPOSED: windowEvent.type = WINDOW_EXPOSE; break;
 
-				case SDL_WINDOWEVENT_MOVED:
+				case SDL_EVENT_WINDOW_MOVED:
 
 					windowEvent.type = WINDOW_MOVE;
 					windowEvent.x = event->window.data1;
 					windowEvent.y = event->window.data2;
 					break;
 
-				case SDL_WINDOWEVENT_SIZE_CHANGED:
+				case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
 
 					windowEvent.type = WINDOW_RESIZE;
 					windowEvent.width = event->window.data1;
 					windowEvent.height = event->window.data2;
 					break;
 
-				case SDL_WINDOWEVENT_RESTORED: windowEvent.type = WINDOW_RESTORE; break;
+				case SDL_EVENT_WINDOW_RESTORED: windowEvent.type = WINDOW_RESTORE; break;
 
 			}
 
@@ -845,11 +822,11 @@ namespace lime {
 
 		SDL_Event event;
 		SDL_UserEvent userevent;
-		userevent.type = SDL_USEREVENT;
+		userevent.type = SDL_EVENT_USER;
 		userevent.code = 0;
 		userevent.data1 = NULL;
 		userevent.data2 = NULL;
-		event.type = SDL_USEREVENT;
+		event.type = SDL_EVENT_USER;
 		event.user = userevent;
 
 		timerActive = false;
@@ -895,7 +872,7 @@ namespace lime {
 
 			if (currentUpdate >= nextUpdate) {
 
-				event.type = SDL_USEREVENT;
+				event.type = SDL_EVENT_USER;
 				HandleEvent (&event);
 				event.type = -1;
 
@@ -903,7 +880,7 @@ namespace lime {
 
 		#elif defined (EMSCRIPTEN)
 
-			event.type = SDL_USEREVENT;
+			event.type = SDL_EVENT_USER;
 			HandleEvent (&event);
 			event.type = -1;
 
@@ -961,7 +938,7 @@ namespace lime {
 
 			SDL_PumpEvents ();
 
-			switch (SDL_PeepEvents (event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT)) {
+			switch (SDL_PeepEvents (event, 1, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_LAST)) {
 
 				case -1:
 

--- a/project/src/backend/sdl/SDLApplication.h
+++ b/project/src/backend/sdl/SDLApplication.h
@@ -2,7 +2,7 @@
 #define LIME_SDL_APPLICATION_H
 
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <app/Application.h>
 #include <app/ApplicationEvent.h>
 #include <graphics/RenderEvent.h>

--- a/project/src/backend/sdl/SDLCursor.h
+++ b/project/src/backend/sdl/SDLCursor.h
@@ -2,7 +2,7 @@
 #define LIME_SDL_CURSOR_H
 
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 
 namespace lime {

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -4,20 +4,20 @@
 namespace lime {
 
 
-	std::map<int, SDL_GameController*> gameControllers = std::map<int, SDL_GameController*> ();
+	std::map<int, SDL_Gamepad*> gameControllers = std::map<int, SDL_Gamepad*> ();
 	std::map<int, int> gameControllerIDs = std::map<int, int> ();
 
 
 	bool SDLGamepad::Connect (int deviceID) {
 
-		if (SDL_IsGameController (deviceID)) {
+		if (SDL_IsGamepad (deviceID)) {
 
-			SDL_GameController *gameController = SDL_GameControllerOpen (deviceID);
+			SDL_Gamepad *gameController = SDL_OpenGamepad (deviceID);
 
 			if (gameController) {
 
-				SDL_Joystick *joystick = SDL_GameControllerGetJoystick (gameController);
-				int id = SDL_JoystickInstanceID (joystick);
+				SDL_Joystick *joystick = SDL_GetGamepadJoystick (gameController);
+				int id = SDL_GetJoystickInstanceID (joystick);
 
 				gameControllers[id] = gameController;
 				gameControllerIDs[deviceID] = id;
@@ -37,8 +37,8 @@ namespace lime {
 
 		if (gameControllers.find (id) != gameControllers.end ()) {
 
-			SDL_GameController *gameController = gameControllers[id];
-			SDL_GameControllerClose (gameController);
+			SDL_Gamepad *gameController = gameControllers[id];
+			SDL_CloseGamepad (gameController);
 			gameControllers.erase (id);
 
 			return true;
@@ -59,19 +59,19 @@ namespace lime {
 
 	void Gamepad::AddMapping (const char* content) {
 
-		SDL_GameControllerAddMapping (content);
+		SDL_AddGamepadMapping (content);
 
 	}
 
 
 	const char* Gamepad::GetDeviceGUID (int id) {
 
-		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (gameControllers[id]);
+		SDL_Joystick* joystick = SDL_GetGamepadJoystick (gameControllers[id]);
 
 		if (joystick) {
 
 			char* guid = new char[64];
-			SDL_JoystickGetGUIDString (SDL_JoystickGetGUID (joystick), guid, 64);
+			SDL_GetJoystickGUIDString (SDL_GetJoystickGUID (joystick), guid, 64);
 			return guid;
 
 		}
@@ -83,7 +83,7 @@ namespace lime {
 
 	const char* Gamepad::GetDeviceName (int id) {
 
-		return SDL_GameControllerName (gameControllers[id]);
+		return SDL_GetGamepadName (gameControllers[id]);
 
 	}
 

--- a/project/src/backend/sdl/SDLGamepad.h
+++ b/project/src/backend/sdl/SDLGamepad.h
@@ -2,7 +2,7 @@
 #define LIME_SDL_GAMEPAD_H
 
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <ui/Gamepad.h>
 #include <map>
 

--- a/project/src/backend/sdl/SDLJoystick.cpp
+++ b/project/src/backend/sdl/SDLJoystick.cpp
@@ -1,127 +1,107 @@
 #include "SDLJoystick.h"
 
+namespace lime
+{
 
-namespace lime {
-
-
-	static SDL_Joystick* accelerometer = 0;
+	static SDL_Joystick *accelerometer = 0;
 	static SDL_JoystickID accelerometerID = -1;
-	std::map<int, int> joystickIDs = std::map<int, int> ();
-	std::map<int, SDL_Joystick*> joysticks = std::map<int, SDL_Joystick*> ();
+	std::map<int, int> joystickIDs = std::map<int, int>();
+	std::map<int, SDL_Joystick *> joysticks = std::map<int, SDL_Joystick *>();
 
+	bool SDLJoystick::Connect(int deviceID)
+	{
 
-	bool SDLJoystick::Connect (int deviceID) {
+		if (deviceID != accelerometerID)
+		{
 
-		if (deviceID != accelerometerID) {
+			SDL_Joystick *joystick = SDL_OpenJoystick(deviceID);
+			int id = SDL_GetJoystickInstanceID(joystick);
 
-			SDL_Joystick* joystick = SDL_JoystickOpen (deviceID);
-			int id = SDL_JoystickInstanceID (joystick);
-
-			if (joystick) {
+			if (joystick)
+			{
 
 				joysticks[id] = joystick;
 				joystickIDs[deviceID] = id;
 				return true;
-
 			}
-
 		}
 
 		return false;
-
 	}
 
+	bool SDLJoystick::Disconnect(int id)
+	{
 
-	bool SDLJoystick::Disconnect (int id) {
+		if (joysticks.find(id) != joysticks.end())
+		{
 
-		if (joysticks.find (id) != joysticks.end ()) {
-
-			SDL_Joystick* joystick = joysticks[id];
-			SDL_JoystickClose (joystick);
-			joysticks.erase (id);
+			SDL_Joystick *joystick = joysticks[id];
+			SDL_CloseJoystick(joystick);
+			joysticks.erase(id);
 			return true;
-
 		}
 
 		return false;
-
 	}
 
-
-	int SDLJoystick::GetInstanceID (int deviceID) {
+	int SDLJoystick::GetInstanceID(int deviceID)
+	{
 
 		return joystickIDs[deviceID];
-
 	}
 
+	void SDLJoystick::Init()
+	{
 
-	void SDLJoystick::Init () {
+#if defined(IPHONE) || defined(ANDROID) || defined(TVOS)
+		for (int i = 0; i < SDL_NumJoysticks(); i++)
+		{
 
-		#if defined(IPHONE) || defined(ANDROID) || defined(TVOS)
-		for (int i = 0; i < SDL_NumJoysticks (); i++) {
+			if (strstr(SDL_JoystickNameForIndex(i), "Accelerometer"))
+			{
 
-			if (strstr (SDL_JoystickNameForIndex (i), "Accelerometer")) {
-
-				accelerometer = SDL_JoystickOpen (i);
-				accelerometerID = SDL_JoystickInstanceID (accelerometer);
-
+				accelerometer = SDL_OpenJoystick(i);
+				accelerometerID = SDL_GetJoystickInstanceID(accelerometer);
 			}
-
 		}
-		#endif
-
+#endif
 	}
 
-
-	bool SDLJoystick::IsAccelerometer (int id) {
+	bool SDLJoystick::IsAccelerometer(int id)
+	{
 
 		return (id == accelerometerID);
-
 	}
 
+	const char *Joystick::GetDeviceGUID(int id)
+	{
 
-	const char* Joystick::GetDeviceGUID (int id) {
-
-		char* guid = new char[64];
-		SDL_JoystickGetGUIDString (SDL_JoystickGetGUID (joysticks[id]), guid, 64);
+		char *guid = new char[64];
+		SDL_GetJoystickGUIDString(SDL_GetJoystickGUID(joysticks[id]), guid, 64);
 		return guid;
-
 	}
 
+	const char *Joystick::GetDeviceName(int id)
+	{
 
-	const char* Joystick::GetDeviceName (int id) {
-
-		return SDL_JoystickName (joysticks[id]);
-
+		return SDL_GetJoystickName(joysticks[id]);
 	}
 
+	int Joystick::GetNumAxes(int id)
+	{
 
-	int Joystick::GetNumAxes (int id) {
-
-		return SDL_JoystickNumAxes (joysticks[id]);
-
+		return SDL_GetNumJoystickAxes(joysticks[id]);
 	}
 
+	int Joystick::GetNumButtons(int id)
+	{
 
-	int Joystick::GetNumButtons (int id) {
-
-		return SDL_JoystickNumButtons (joysticks[id]);
-
+		return SDL_GetNumJoystickButtons(joysticks[id]);
 	}
 
+	int Joystick::GetNumHats(int id)
+	{
 
-	int Joystick::GetNumHats (int id) {
-
-		return SDL_JoystickNumHats (joysticks[id]);
-
+		return SDL_GetNumJoystickHats(joysticks[id]);
 	}
-
-
-	int Joystick::GetNumTrackballs (int id) {
-
-		return SDL_JoystickNumBalls (joysticks[id]);
-
-	}
-
-
 }

--- a/project/src/backend/sdl/SDLJoystick.h
+++ b/project/src/backend/sdl/SDLJoystick.h
@@ -2,7 +2,7 @@
 #define LIME_SDL_JOYSTICK_H
 
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <ui/Joystick.h>
 #include <map>
 

--- a/project/src/backend/sdl/SDLKeyCode.cpp
+++ b/project/src/backend/sdl/SDLKeyCode.cpp
@@ -1,4 +1,4 @@
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <ui/KeyCode.h>
 
 

--- a/project/src/backend/sdl/SDLMutex.cpp
+++ b/project/src/backend/sdl/SDLMutex.cpp
@@ -1,5 +1,5 @@
 #include <system/Mutex.h>
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 
 namespace lime {
@@ -16,7 +16,7 @@ namespace lime {
 
 		if (mutex) {
 
-			SDL_DestroyMutex ((SDL_mutex*)mutex);
+			SDL_DestroyMutex ((SDL_Mutex*)mutex);
 
 		}
 
@@ -27,7 +27,7 @@ namespace lime {
 
 		if (mutex) {
 
-			return SDL_LockMutex ((SDL_mutex*)mutex) == 0;
+			return SDL_LockMutex ((SDL_Mutex*)mutex) == 0;
 
 		}
 
@@ -40,7 +40,7 @@ namespace lime {
 
 		if (mutex) {
 
-			return SDL_TryLockMutex ((SDL_mutex*)mutex) == 0;
+			return SDL_TryLockMutex ((SDL_Mutex*)mutex) == 0;
 
 		}
 
@@ -53,7 +53,7 @@ namespace lime {
 
 		if (mutex) {
 
-			return SDL_UnlockMutex ((SDL_mutex*)mutex) == 0;
+			return SDL_UnlockMutex ((SDL_Mutex*)mutex) == 0;
 
 		}
 

--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -326,7 +326,7 @@ namespace lime {
 			alloc_field (display, id_bounds, Rectangle (bounds.x, bounds.y, bounds.w, bounds.h).Value ());
 
 			float dpi = 72.0;
-			const SDL_DisplayMode* dpiDisplayMode = SDL_GetDesktopDisplayMode(SDL_GetPrimaryDisplay());
+			const SDL_DisplayMode* dpiDisplayMode = SDL_GetDesktopDisplayMode(id);
 			#ifdef IPHONE
 			dpi = dpiDisplayMode->display_scale * 160.0;
 			#elifdef ANDROID
@@ -339,7 +339,7 @@ namespace lime {
 
 			DisplayMode mode;
 
-			const SDL_DisplayMode* displayMode = SDL_GetDesktopDisplayMode (SDL_GetPrimaryDisplay());
+			const SDL_DisplayMode* displayMode = SDL_GetDesktopDisplayMode (id);
 
 			mode.height = displayMode->pixel_h;
 
@@ -368,7 +368,7 @@ namespace lime {
 			alloc_field (display, id_currentMode, (value)mode.Value ());
 
 			int numDisplayModes = 0;
-			const SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(SDL_GetPrimaryDisplay(), &numDisplayModes);
+			const SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(id, &numDisplayModes);
 
 			value supportedModes = alloc_array (numDisplayModes);
 
@@ -448,7 +448,7 @@ namespace lime {
 			hl_dyn_setp (display, id_bounds, &hlt_dynobj, _bounds);
 
 			float dpi = 72.0;
-			const SDL_DisplayMode* dpiDisplayMode = SDL_GetDesktopDisplayMode(SDL_GetPrimaryDisplay());
+			const SDL_DisplayMode* dpiDisplayMode = SDL_GetDesktopDisplayMode(id);
 			#ifdef IPHONE
 			dpi = dpiDisplayMode->display_scale * 160.0;
 			#elifdef ANDROID
@@ -495,7 +495,7 @@ namespace lime {
 			hl_dyn_setp (display, id_currentMode, &hlt_dynobj, _displayMode);
 
 			int numDisplayModes = 0;
-        	const SDL_DisplayMode** displayModes = SDL_GetFullscreenDisplayModes(SDL_GetPrimaryDisplay(), &numDisplayModes);
+        	const SDL_DisplayMode** displayModes = SDL_GetFullscreenDisplayModes(id, &numDisplayModes);
 
 			hl_varray* supportedModes = (hl_varray*)hl_alloc_array (&hlt_dynobj, numDisplayModes);
 			vdynamic** supportedModesData = hl_aptr (supportedModes, vdynamic*);

--- a/project/src/backend/sdl/SDLWindow.h
+++ b/project/src/backend/sdl/SDLWindow.h
@@ -2,7 +2,7 @@
 #define LIME_SDL_WINDOW_H
 
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <graphics/ImageBuffer.h>
 #include <ui/Cursor.h>
 #include <ui/Window.h>

--- a/project/src/graphics/opengl/OpenGL.h
+++ b/project/src/graphics/opengl/OpenGL.h
@@ -41,8 +41,8 @@
 #define NEED_EXTENSIONS
 #define DYNAMIC_OGL
 #define GL_GLEXT_PROTOTYPES
-#include <SDL_opengl.h>
-#include <SDL_opengl_glext.h>
+#include <SDL3/SDL_opengl.h>
+#include <SDL3/SDL_opengl_glext.h>
 #define FORCE_NON_PO2
 
 #elif defined (HX_MACOS)
@@ -51,8 +51,8 @@
 #define NEED_EXTENSIONS
 #define DYNAMIC_OGL
 #define GL_GLEXT_PROTOTYPES
-#include <SDL_opengl.h>
-#include <SDL_opengl_glext.h>
+#include <SDL3/SDL_opengl.h>
+#include <SDL3/SDL_opengl_glext.h>
 #define FORCE_NON_PO2
 #define glBindFramebuffer glBindFramebufferEXT
 #define glBindRenderbuffer glBindRenderbufferEXT
@@ -79,7 +79,7 @@
 #include <gl/GL.h>
 #endif
 
-typedef ptrdiff_t GLsizeiptrARB;
+// typedef ptrdiff_t GLsizeiptrARB;
 #define NEED_EXTENSIONS
 #define DYNAMIC_OGL
 
@@ -88,11 +88,11 @@ typedef ptrdiff_t GLsizeiptrARB;
 #endif
 
 #ifdef NATIVE_TOOLKIT_SDL_ANGLE
-#include <SDL_opengles2.h>
+#include <SDL3/SDL_opengles2.h>
 #else
 #define GL_GLEXT_PROTOTYPES
-#include <SDL_opengl.h>
-#include <SDL_opengl_glext.h>
+#include <SDL3/SDL_opengl.h>
+#include <SDL3/SDL_opengl_glext.h>
 #endif
 
 #endif

--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -23,7 +23,7 @@
 #endif
 
 #ifdef LIME_SDL
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #endif
 
 

--- a/project/src/graphics/opengl/OpenGLExtensions.h
+++ b/project/src/graphics/opengl/OpenGLExtensions.h
@@ -13,9 +13,9 @@
 #include "OpenGLBindings.h"
 
 #ifdef LIME_SDL
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #ifdef NATIVE_TOOLKIT_SDL_ANGLE
-#include <SDL_egl.h>
+#include <SDL3/SDL_egl.h>
 #endif
 #endif
 

--- a/project/src/system/JNI.cpp
+++ b/project/src/system/JNI.cpp
@@ -4,7 +4,7 @@
 #include <jni.h>
 #include <pthread.h>
 #include <android/log.h>
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <map>
 #include <string>
 

--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -227,10 +227,6 @@ class NativeApplication
 				var joystick = Joystick.devices.get(joystickEventInfo.id);
 				if (joystick != null) joystick.onHatMove.dispatch(joystickEventInfo.index, joystickEventInfo.eventValue);
 
-			case TRACKBALL_MOVE:
-				var joystick = Joystick.devices.get(joystickEventInfo.id);
-				if (joystick != null) joystick.onTrackballMove.dispatch(joystickEventInfo.index, joystickEventInfo.x, joystickEventInfo.y);
-
 			case BUTTON_DOWN:
 				var joystick = Joystick.devices.get(joystickEventInfo.id);
 				if (joystick != null) joystick.onButtonDown.dispatch(joystickEventInfo.index);
@@ -742,7 +738,7 @@ class NativeApplication
 {
 	var AXIS_MOVE = 0;
 	var HAT_MOVE = 1;
-	var TRACKBALL_MOVE = 2;
+	// var TRACKBALL_MOVE = 2;
 	var BUTTON_DOWN = 3;
 	var BUTTON_UP = 4;
 	var CONNECT = 5;

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -213,8 +213,6 @@ class NativeCFFI
 
 	@:cffi private static function lime_joystick_get_num_hats(id:Int):Int;
 
-	@:cffi private static function lime_joystick_get_num_trackballs(id:Int):Int;
-
 	@:cffi private static function lime_joystick_event_manager_register(callback:Dynamic, eventObject:Dynamic):Void;
 
 	@:cffi private static function lime_jpeg_decode_bytes(data:Dynamic, decodeData:Bool, buffer:Dynamic):Dynamic;
@@ -485,8 +483,6 @@ class NativeCFFI
 	private static var lime_joystick_get_num_axes = new cpp.Callable<Int->Int>(cpp.Prime._loadPrime("lime", "lime_joystick_get_num_axes", "ii", false));
 	private static var lime_joystick_get_num_buttons = new cpp.Callable<Int->Int>(cpp.Prime._loadPrime("lime", "lime_joystick_get_num_buttons", "ii", false));
 	private static var lime_joystick_get_num_hats = new cpp.Callable<Int->Int>(cpp.Prime._loadPrime("lime", "lime_joystick_get_num_hats", "ii", false));
-	private static var lime_joystick_get_num_trackballs = new cpp.Callable<Int->Int>(cpp.Prime._loadPrime("lime", "lime_joystick_get_num_trackballs", "ii",
-		false));
 	private static var lime_joystick_event_manager_register = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_joystick_event_manager_register", "oov", false));
 	private static var lime_jpeg_decode_bytes = new cpp.Callable<cpp.Object->Bool->cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime",
@@ -687,7 +683,6 @@ class NativeCFFI
 	private static var lime_joystick_get_num_axes = CFFI.load("lime", "lime_joystick_get_num_axes", 1);
 	private static var lime_joystick_get_num_buttons = CFFI.load("lime", "lime_joystick_get_num_buttons", 1);
 	private static var lime_joystick_get_num_hats = CFFI.load("lime", "lime_joystick_get_num_hats", 1);
-	private static var lime_joystick_get_num_trackballs = CFFI.load("lime", "lime_joystick_get_num_trackballs", 1);
 	private static var lime_joystick_event_manager_register = CFFI.load("lime", "lime_joystick_event_manager_register", 2);
 	private static var lime_jpeg_decode_bytes = CFFI.load("lime", "lime_jpeg_decode_bytes", 3);
 	private static var lime_jpeg_decode_file = CFFI.load("lime", "lime_jpeg_decode_file", 3);
@@ -1085,11 +1080,6 @@ class NativeCFFI
 	}
 
 	@:hlNative("lime", "hl_joystick_get_num_hats") private static function lime_joystick_get_num_hats(id:Int):Int
-	{
-		return 0;
-	}
-
-	@:hlNative("lime", "hl_joystick_get_num_trackballs") private static function lime_joystick_get_num_trackballs(id:Int):Int
 	{
 		return 0;
 	}

--- a/src/lime/app/Application.hx
+++ b/src/lime/app/Application.hx
@@ -227,15 +227,6 @@ class Application extends Module
 	public function onJoystickHatMove(joystick:Joystick, hat:Int, position:JoystickHatPosition):Void {}
 
 	/**
-		Called when a joystick axis move event is fired
-		@param	joystick	The current joystick
-		@param	trackball	The trackball that was moved
-		@param	x	The x movement of the trackball (between 0 and 1)
-		@param	y	The y movement of the trackball (between 0 and 1)
-	**/
-	public function onJoystickTrackballMove(joystick:Joystick, trackball:Int, x:Float, y:Float):Void {}
-
-	/**
 		Called when a key down event is fired on the primary window
 		@param	keyCode	The code of the key that was pressed
 		@param	modifier	The modifier of the key that was pressed
@@ -577,7 +568,6 @@ class Application extends Module
 		joystick.onButtonUp.add(onJoystickButtonUp.bind(joystick));
 		joystick.onDisconnect.add(onJoystickDisconnect.bind(joystick));
 		joystick.onHatMove.add(onJoystickHatMove.bind(joystick));
-		joystick.onTrackballMove.add(onJoystickTrackballMove.bind(joystick));
 	}
 
 	@:noCompletion private function __onModuleExit(code:Int):Void

--- a/src/lime/ui/Joystick.hx
+++ b/src/lime/ui/Joystick.hx
@@ -20,13 +20,11 @@ class Joystick
 	public var numAxes(get, never):Int;
 	public var numButtons(get, never):Int;
 	public var numHats(get, never):Int;
-	public var numTrackballs(get, never):Int;
 	public var onAxisMove = new Event<Int->Float->Void>();
 	public var onButtonDown = new Event<Int->Void>();
 	public var onButtonUp = new Event<Int->Void>();
 	public var onDisconnect = new Event<Void->Void>();
 	public var onHatMove = new Event<Int->JoystickHatPosition->Void>();
-	public var onTrackballMove = new Event<Int->Float->Float->Void>();
 
 	public function new(id:Int)
 	{
@@ -121,15 +119,6 @@ class Joystick
 	{
 		#if (lime_cffi && !macro)
 		return NativeCFFI.lime_joystick_get_num_hats(this.id);
-		#else
-		return 0;
-		#end
-	}
-
-	@:noCompletion private inline function get_numTrackballs():Int
-	{
-		#if (lime_cffi && !macro)
-		return NativeCFFI.lime_joystick_get_num_trackballs(this.id);
 		#else
 		return 0;
 		#end


### PR DESCRIPTION
I wanted to implement some of the features introduced in SDL3

- [x] Initial migration
  - [x] Remove API calls related to Joystick trackballs (see libsdl-org/SDL#6766)
- [ ] Bug testing
  - [ ] Build issue tied to removal of deprecated CFFI functions
  - [ ] Rendering issue causing only partial window to be visible
- [ ] Implement a couple of new features using SDL3 features
  - [ ] **PreciseKeyEvent**: Implemented as a new event to avoid breaking changes. Provides an accurate timestamp (accurate to 100 μs or 0.1 ms on Windows) for each input.
  - [ ] **SDL_GetTicksNS()**: Expose as a function in a way that makes sense. Used for comparision with `PreciseKeyEvent` timestamps.
  - [ ] **SDL_GetSystemTheme()**: Returns an enum with either `DARK`, `LIGHT`, or `UNKNOWN`, representing the current system theme.