### PR TITLE
html5 bugfix: enable onResize.dispatch when project.xml window resizable=true

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -190,6 +190,7 @@ class HTML5Window
 		if ((Reflect.hasField(attributes, "resizable") && attributes.resizable)
 			|| (!Reflect.hasField(attributes, "width") && setWidth == 0 && setHeight == 0))
 		{
+			resizeElement = true;
 			parent.__resizable = true;
 		}
 


### PR DESCRIPTION
This is a bug fix for the following issue.

# onResize event issue

Adding window element to `project.xml` prevents the `Application.window.onResize` event from triggering

e.g.

```xml
<window width="800" height="600" resizable="true" />
```

makes this line never hit

https://github.com/openfl/lime/blob/5634ad72d2d71f9e910f15a8652eaf15891d7ad7/src/lime/_internal/backend/html5/HTML5Window.hx#L1273

There is a small project here that can be used to reproduce the issue https://github.com/jobf/lime-html5window-resize-glitch
