### PR TITLE
clear cached files on library unload

### DIFF
--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -611,7 +611,8 @@ class AssetLibrary
 		}
 	}
 
-	public function unload():Void {
+	public function unload():Void
+	{
 		#if haxe4
 		cachedBytes.clear();
 		cachedFonts.clear();

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -612,11 +612,19 @@ class AssetLibrary
 	}
 
 	public function unload():Void {
+		#if haxe4
 		cachedBytes.clear();
 		cachedFonts.clear();
 		cachedImages.clear();
 		cachedAudioBuffers.clear();
 		cachedText.clear();
+		#else
+		cachedBytes = new Map<String, Bytes>();
+		cachedFonts = new Map<String, Font>();
+		cachedImages = new Map<String, Image>();
+		cachedText = new Map<String, String>();
+		classTypes = new Map<String, Class<Dynamic>>();
+		#end
 	}
 
 	@:noCompletion private function __assetLoaded(id:String):Void

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -611,7 +611,13 @@ class AssetLibrary
 		}
 	}
 
-	public function unload():Void {}
+	public function unload():Void {
+		cachedBytes.clear();
+		cachedFonts.clear();
+		cachedImages.clear();
+		cachedAudioBuffers.clear();
+		cachedText.clear();
+	}
 
 	@:noCompletion private function __assetLoaded(id:String):Void
 	{


### PR DESCRIPTION
I don't know why the unload method was empty but now it clears all cached files when calling `Assets.unloadLibrary("");`.
