### PR TITLE
Always use `getPath` instead of `paths.get()` directly.

### DIFF
--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -477,7 +477,7 @@ class AssetLibrary
 			}
 			else
 			{
-				return AudioBuffer.loadFromFile(getPath(id));
+				return AudioBuffer.loadFromFile(paths.get(id));
 			}
 		}
 	}

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -200,7 +200,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return AudioBuffer.fromFile(paths.get(id));
+			return AudioBuffer.fromFile(getPath(id));
 		}
 	}
 
@@ -239,7 +239,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Bytes.fromFile(paths.get(id));
+			return Bytes.fromFile(getPath(id));
 		}
 	}
 
@@ -263,7 +263,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Font.fromFile(paths.get(id));
+			return Font.fromFile(getPath(id));
 		}
 	}
 
@@ -283,7 +283,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Image.fromFile(paths.get(id));
+			return Image.fromFile(getPath(id));
 		}
 	}
 
@@ -477,7 +477,7 @@ class AssetLibrary
 			}
 			else
 			{
-				return AudioBuffer.loadFromFile(paths.get(id));
+				return AudioBuffer.loadFromFile(getPath(id));
 			}
 		}
 	}
@@ -498,7 +498,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Bytes.loadFromFile(paths.get(id));
+			return Bytes.loadFromFile(getPath(id));
 		}
 	}
 
@@ -521,9 +521,9 @@ class AssetLibrary
 		else
 		{
 			#if (js && html5)
-			return Font.loadFromName(paths.get(id));
+			return Font.loadFromName(getPath(id));
 			#else
-			return Font.loadFromFile(paths.get(id));
+			return Font.loadFromFile(getPath(id));
 			#end
 		}
 	}
@@ -579,7 +579,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Image.loadFromFile(paths.get(id));
+			return Image.loadFromFile(getPath(id));
 		}
 	}
 
@@ -607,7 +607,7 @@ class AssetLibrary
 		else
 		{
 			var request = new HTTPRequest<String>();
-			return request.load(paths.get(id));
+			return request.load(getPath(id));
 		}
 	}
 

--- a/src/lime/utils/PackedAssetLibrary.hx
+++ b/src/lime/utils/PackedAssetLibrary.hx
@@ -242,7 +242,7 @@ import flash.media.Sound;
 			else
 			{
 				var basePath = rootPath == null || rootPath == "" ?  "" : Path.addTrailingSlash(rootPath);
-				var libPath = paths.exists(id) ? paths.get(id) : id;
+				var libPath = paths.exists(id) ? getPath(id) : id;
 
 				var path = Path.join([basePath, libPath]);
 				path = __cacheBreak(path);


### PR DESCRIPTION
Make the behavior of AssetLibrary more concise by replacing all calls to `paths.get()` with the existing `getPath` function.