### PR TITLE
Fix warnings in Haxe 4.3.

### DIFF
--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -637,7 +637,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract ApplicationEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract ApplicationEventType(Int)
 {
 	var UPDATE = 0;
 	var EXIT = 1;
@@ -658,7 +658,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract ClipboardEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract ClipboardEventType(Int)
 {
 	var UPDATE = 0;
 }
@@ -680,7 +680,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract DropEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract DropEventType(Int)
 {
 	var DROP_FILE = 0;
 }
@@ -708,7 +708,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract GamepadEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract GamepadEventType(Int)
 {
 	var AXIS_MOVE = 0;
 	var BUTTON_DOWN = 1;
@@ -742,7 +742,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract JoystickEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract JoystickEventType(Int)
 {
 	var AXIS_MOVE = 0;
 	var HAT_MOVE = 1;
@@ -774,7 +774,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract KeyEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract KeyEventType(Int)
 {
 	var KEY_DOWN = 0;
 	var KEY_UP = 1;
@@ -809,7 +809,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract MouseEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract MouseEventType(Int)
 {
 	var MOUSE_DOWN = 0;
 	var MOUSE_UP = 1;
@@ -832,7 +832,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract RenderEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract RenderEventType(Int)
 {
 	var RENDER = 0;
 	var RENDER_CONTEXT_LOST = 1;
@@ -862,7 +862,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract SensorEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract SensorEventType(Int)
 {
 	var ACCELEROMETER = 0;
 }
@@ -891,7 +891,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract TextEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract TextEventType(Int)
 {
 	var TEXT_INPUT = 0;
 	var TEXT_EDIT = 1;
@@ -926,7 +926,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract TouchEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract TouchEventType(Int)
 {
 	var TOUCH_START = 0;
 	var TOUCH_END = 1;
@@ -958,7 +958,7 @@ class NativeApplication
 	}
 }
 
-@:enum private abstract WindowEventType(Int)
+#if haxe4 private enum #else @:enum private #end abstract WindowEventType(Int)
 {
 	var WINDOW_ACTIVATE = 0;
 	var WINDOW_CLOSE = 1;

--- a/src/lime/_internal/backend/native/NativeWindow.hx
+++ b/src/lime/_internal/backend/native/NativeWindow.hx
@@ -699,7 +699,7 @@ class NativeWindow
 	}
 }
 
-@:enum private abstract MouseCursorType(Int) from Int to Int
+#if haxe4 private enum #else @:enum private #end abstract MouseCursorType(Int) from Int to Int
 {
 	var HIDDEN = 0;
 	var ARROW = 1;
@@ -716,7 +716,7 @@ class NativeWindow
 	var WAIT_ARROW = 12;
 }
 
-@:enum private abstract WindowFlags(Int)
+#if haxe4 private enum #else @:enum private #end abstract WindowFlags(Int)
 {
 	var WINDOW_FLAG_FULLSCREEN = 0x00000001;
 	var WINDOW_FLAG_BORDERLESS = 0x00000002;

--- a/src/lime/_internal/graphics/ImageDataUtil.hx
+++ b/src/lime/_internal/graphics/ImageDataUtil.hx
@@ -1748,7 +1748,8 @@ private class ImageDataView
 	}
 }
 
-@:noCompletion @:dox(hide) @:enum private abstract ThresholdOperation(Int) from Int to Int
+@:noCompletion @:dox(hide) #if haxe4 private enum #else @:enum private #end
+abstract ThresholdOperation(Int) from Int to Int
 {
 	var NOT_EQUALS = 0;
 	var EQUALS = 1;

--- a/src/lime/graphics/PixelFormat.hx
+++ b/src/lime/graphics/PixelFormat.hx
@@ -3,7 +3,7 @@ package lime.graphics;
 /**
 	An enum containing different pixel encoding formats for image data
 **/
-@:enum abstract PixelFormat(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract PixelFormat(Int) from Int to Int from UInt to UInt
 {
 	/**
 		An image encoded in 32-bit RGBA color order

--- a/src/lime/graphics/RenderContextType.hx
+++ b/src/lime/graphics/RenderContextType.hx
@@ -3,7 +3,7 @@ package lime.graphics;
 /**
 	An enum for possible render context types
 **/
-@:enum abstract RenderContextType(String) from String to String
+#if haxe4 enum #else @:enum #end abstract RenderContextType(String) from String to String
 {
 	/**
 		Describes a Cairo render context

--- a/src/lime/graphics/cairo/CairoAntialias.hx
+++ b/src/lime/graphics/cairo/CairoAntialias.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoAntialias(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoAntialias(Int) from Int to Int from UInt to UInt
 {
 	public var DEFAULT = 0;
 	public var NONE = 1;

--- a/src/lime/graphics/cairo/CairoContent.hx
+++ b/src/lime/graphics/cairo/CairoContent.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoContent(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoContent(Int) from Int to Int from UInt to UInt
 {
 	public var COLOR = 0x1000;
 	public var ALPHA = 0x2000;

--- a/src/lime/graphics/cairo/CairoExtend.hx
+++ b/src/lime/graphics/cairo/CairoExtend.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoExtend(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoExtend(Int) from Int to Int from UInt to UInt
 {
 	public var NONE = 0;
 	public var REPEAT = 1;

--- a/src/lime/graphics/cairo/CairoFillRule.hx
+++ b/src/lime/graphics/cairo/CairoFillRule.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoFillRule(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoFillRule(Int) from Int to Int from UInt to UInt
 {
 	public var WINDING = 0;
 	public var EVEN_ODD = 1;

--- a/src/lime/graphics/cairo/CairoFilter.hx
+++ b/src/lime/graphics/cairo/CairoFilter.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoFilter(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoFilter(Int) from Int to Int from UInt to UInt
 {
 	public var FAST = 0;
 	public var GOOD = 1;

--- a/src/lime/graphics/cairo/CairoFormat.hx
+++ b/src/lime/graphics/cairo/CairoFormat.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoFormat(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoFormat(Int) from Int to Int from UInt to UInt
 {
 	public var INVALID = -1;
 	public var ARGB32 = 0;

--- a/src/lime/graphics/cairo/CairoHintMetrics.hx
+++ b/src/lime/graphics/cairo/CairoHintMetrics.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoHintMetrics(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoHintMetrics(Int) from Int to Int from UInt to UInt
 {
 	public var DEFAULT = 0;
 	public var OFF = 1;

--- a/src/lime/graphics/cairo/CairoHintStyle.hx
+++ b/src/lime/graphics/cairo/CairoHintStyle.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoHintStyle(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoHintStyle(Int) from Int to Int from UInt to UInt
 {
 	public var DEFAULT = 0;
 	public var NONE = 1;

--- a/src/lime/graphics/cairo/CairoLineCap.hx
+++ b/src/lime/graphics/cairo/CairoLineCap.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoLineCap(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoLineCap(Int) from Int to Int from UInt to UInt
 {
 	public var BUTT = 0;
 	public var ROUND = 1;

--- a/src/lime/graphics/cairo/CairoLineJoin.hx
+++ b/src/lime/graphics/cairo/CairoLineJoin.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoLineJoin(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoLineJoin(Int) from Int to Int from UInt to UInt
 {
 	public var MITER = 0;
 	public var ROUND = 1;

--- a/src/lime/graphics/cairo/CairoOperator.hx
+++ b/src/lime/graphics/cairo/CairoOperator.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoOperator(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoOperator(Int) from Int to Int from UInt to UInt
 {
 	public var CLEAR = 0;
 	public var SOURCE = 1;

--- a/src/lime/graphics/cairo/CairoStatus.hx
+++ b/src/lime/graphics/cairo/CairoStatus.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoStatus(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoStatus(Int) from Int to Int from UInt to UInt
 {
 	public var SUCCESS = 0;
 	public var NO_MEMORY = 1;

--- a/src/lime/graphics/cairo/CairoSubpixelOrder.hx
+++ b/src/lime/graphics/cairo/CairoSubpixelOrder.hx
@@ -1,7 +1,7 @@
 package lime.graphics.cairo;
 
 #if (!lime_doc_gen || lime_cairo)
-@:enum abstract CairoSubpixelOrder(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CairoSubpixelOrder(Int) from Int to Int from UInt to UInt
 {
 	public var DEFAULT = 0;
 	public var RGB = 1;

--- a/src/lime/graphics/opengl/GL.hx
+++ b/src/lime/graphics/opengl/GL.hx
@@ -2635,7 +2635,7 @@ class GL
 	}
 }
 
-@:dox(hide) @:noCompletion @:enum abstract GLObjectType(Int) to Int
+@:dox(hide) @:noCompletion #if haxe4 enum #else @:enum #end abstract GLObjectType(Int) to Int
 {
 	var UNKNOWN = 0;
 	var PROGRAM = 1;

--- a/src/lime/media/AudioContextType.hx
+++ b/src/lime/media/AudioContextType.hx
@@ -1,6 +1,6 @@
 package lime.media;
 
-@:enum abstract AudioContextType(String) from String to String
+#if haxe4 enum #else @:enum #end abstract AudioContextType(String) from String to String
 {
 	var FLASH = "flash";
 	var HTML5 = "html5";

--- a/src/lime/net/HTTPRequestMethod.hx
+++ b/src/lime/net/HTTPRequestMethod.hx
@@ -1,6 +1,6 @@
 package lime.net;
 
-@:enum abstract HTTPRequestMethod(String) from String to String
+#if haxe4 enum #else @:enum #end abstract HTTPRequestMethod(String) from String to String
 {
 	public var DELETE = "DELETE";
 	public var GET = "GET";

--- a/src/lime/net/curl/CURLCode.hx
+++ b/src/lime/net/curl/CURLCode.hx
@@ -1,7 +1,7 @@
 package lime.net.curl;
 
 #if (!lime_doc_gen || lime_curl)
-@:enum abstract CURLCode(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CURLCode(Int) from Int to Int from UInt to UInt
 {
 	var OK = 0;
 	var UNSUPPORTED_PROTOCOL = 1;

--- a/src/lime/net/curl/CURLInfo.hx
+++ b/src/lime/net/curl/CURLInfo.hx
@@ -1,7 +1,7 @@
 package lime.net.curl;
 
 #if (!lime_doc_gen || lime_curl)
-@:enum abstract CURLInfo(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CURLInfo(Int) from Int to Int from UInt to UInt
 {
 	var NONE = 0;
 	var EFFECTIVE_URL = 0x100000 + 1;

--- a/src/lime/net/curl/CURLMultiCode.hx
+++ b/src/lime/net/curl/CURLMultiCode.hx
@@ -1,7 +1,7 @@
 package lime.net.curl;
 
 #if (!lime_doc_gen || lime_curl)
-@:enum abstract CURLMultiCode(Int) from Int to Int from UInt /*to UInt*/
+#if haxe4 enum #else @:enum #end abstract CURLMultiCode(Int) from Int to Int from UInt /*to UInt*/
 {
 	/* please call curl_multi_perform() or curl_multi_socket*() soon */
 	var CALL_MULTI_PERFORM = -1;

--- a/src/lime/net/curl/CURLMultiOption.hx
+++ b/src/lime/net/curl/CURLMultiOption.hx
@@ -1,7 +1,7 @@
 package lime.net.curl;
 
 #if (!lime_doc_gen || lime_curl)
-@:enum abstract CURLMultiOption(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CURLMultiOption(Int) from Int to Int from UInt to UInt
 {
 	/* This is the socket callback function pointer */
 	var SOCKETFUNCTION = 200001;

--- a/src/lime/net/curl/CURLOption.hx
+++ b/src/lime/net/curl/CURLOption.hx
@@ -1,7 +1,7 @@
 package lime.net.curl;
 
 #if (!lime_doc_gen || lime_curl)
-@:enum abstract CURLOption(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CURLOption(Int) from Int to Int from UInt to UInt
 {
 	// var FILE = 10001;
 	// var WRITEDATA = 10001;

--- a/src/lime/net/curl/CURLVersion.hx
+++ b/src/lime/net/curl/CURLVersion.hx
@@ -1,7 +1,7 @@
 package lime.net.curl;
 
 #if (!lime_doc_gen || lime_curl)
-@:enum abstract CURLVersion(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract CURLVersion(Int) from Int to Int from UInt to UInt
 {
 	var FIRST = 0;
 	var SECOND = 1;

--- a/src/lime/net/oauth/OAuthSignatureMethod.hx
+++ b/src/lime/net/oauth/OAuthSignatureMethod.hx
@@ -1,6 +1,6 @@
 package lime.net.oauth;
 
-@:enum abstract OAuthSignatureMethod(String)
+#if haxe4 enum #else @:enum #end abstract OAuthSignatureMethod(String)
 {
 	// var PLAINTEXT = "PLAINTEXT";
 	var HMAC_SHA1 = "HMAC-SHA1";

--- a/src/lime/net/oauth/OAuthVersion.hx
+++ b/src/lime/net/oauth/OAuthVersion.hx
@@ -1,6 +1,6 @@
 package lime.net.oauth;
 
-@:enum abstract OAuthVersion(String)
+#if haxe4 enum #else @:enum #end abstract OAuthVersion(String)
 {
 	var V1 = "1.0";
 	var V2 = "2.0";

--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -812,7 +812,7 @@ class System
 	}
 }
 
-@:enum private abstract SystemDirectory(Int) from Int to Int from UInt to UInt
+#if haxe4 private enum #else @:enum private #end abstract SystemDirectory(Int) from Int to Int from UInt to UInt
 {
 	var APPLICATION = 0;
 	var APPLICATION_STORAGE = 1;

--- a/src/lime/system/WorkOutput.hx
+++ b/src/lime/system/WorkOutput.hx
@@ -204,7 +204,7 @@ class WorkOutput
 	}
 }
 
-@:enum abstract ThreadMode(Bool)
+#if haxe4 enum #else @:enum #end abstract ThreadMode(Bool)
 {
 	/**
 		All work will be done on the main thread, during `Application.onUpdate`.
@@ -341,7 +341,7 @@ class JobData
 	}
 }
 
-@:enum abstract ThreadEventType(String)
+#if haxe4 enum #else @:enum #end abstract ThreadEventType(String)
 {
 	/**
 		Sent by the background thread, indicating completion.

--- a/src/lime/text/harfbuzz/HBBufferClusterLevel.hx
+++ b/src/lime/text/harfbuzz/HBBufferClusterLevel.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBBufferClusterLevel(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBBufferClusterLevel(Int) from Int to Int
 {
 	public var MONOTONE_GRAPHEMES = 0;
 	public var MONOTONE_CHARACTERS = 1;

--- a/src/lime/text/harfbuzz/HBBufferContentType.hx
+++ b/src/lime/text/harfbuzz/HBBufferContentType.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBBufferContentType(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBBufferContentType(Int) from Int to Int
 {
 	public var INVALID = 0;
 	public var UNICODE = 1;

--- a/src/lime/text/harfbuzz/HBBufferFlags.hx
+++ b/src/lime/text/harfbuzz/HBBufferFlags.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBBufferFlags(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBBufferFlags(Int) from Int to Int
 {
 	public var DEFAULT = 0x00000000;
 	public var BOT = 0x00000001;

--- a/src/lime/text/harfbuzz/HBBufferSerializeFlags.hx
+++ b/src/lime/text/harfbuzz/HBBufferSerializeFlags.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBBufferSerializeFlags(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBBufferSerializeFlags(Int) from Int to Int
 {
 	public var DEFAULT = 0x00000000;
 	public var NO_CLUSTERS = 0x00000001;

--- a/src/lime/text/harfbuzz/HBBufferSerializeFormat.hx
+++ b/src/lime/text/harfbuzz/HBBufferSerializeFormat.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBBufferSerializeFormat(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBBufferSerializeFormat(Int) from Int to Int
 {
 	// public var HB_BUFFER_SERIALIZE_FORMAT_TEXT = HB_TAG('T', 'E', 'X', 'T');
 	// public var JSON = HB_TAG('J', 'S', 'O', 'N');

--- a/src/lime/text/harfbuzz/HBDirection.hx
+++ b/src/lime/text/harfbuzz/HBDirection.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBDirection(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBDirection(Int) from Int to Int
 {
 	public var INVALID = 0;
 	public var LTR = 4;

--- a/src/lime/text/harfbuzz/HBMemoryMode.hx
+++ b/src/lime/text/harfbuzz/HBMemoryMode.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBMemoryMode(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBMemoryMode(Int) from Int to Int
 {
 	public var DUPLICATE = 0;
 	public var READONLY = 1;

--- a/src/lime/text/harfbuzz/HBScript.hx
+++ b/src/lime/text/harfbuzz/HBScript.hx
@@ -1,7 +1,7 @@
 package lime.text.harfbuzz;
 
 #if (!lime_doc_gen || lime_harfbuzz)
-@:enum abstract HBScript(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract HBScript(Int) from Int to Int
 {
 	public var COMMON = "Z".code << 24 | "y".code << 16 | "y".code << 8 | "y".code;
 	public var INHERITED = "Z".code << 24 | "i".code << 16 | "n".code << 8 | "h".code;

--- a/src/lime/tools/Platform.hx
+++ b/src/lime/tools/Platform.hx
@@ -1,6 +1,6 @@
 package lime.tools;
 
-@:enum abstract Platform(String)
+#if haxe4 enum #else @:enum #end abstract Platform(String)
 {
 	var AIR = "air";
 	var ANDROID = "android";

--- a/src/lime/ui/GamepadAxis.hx
+++ b/src/lime/ui/GamepadAxis.hx
@@ -1,6 +1,6 @@
 package lime.ui;
 
-@:enum abstract GamepadAxis(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract GamepadAxis(Int) from Int to Int from UInt to UInt
 {
 	var LEFT_X = 0;
 	var LEFT_Y = 1;

--- a/src/lime/ui/GamepadButton.hx
+++ b/src/lime/ui/GamepadButton.hx
@@ -1,6 +1,6 @@
 package lime.ui;
 
-@:enum abstract GamepadButton(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract GamepadButton(Int) from Int to Int from UInt to UInt
 {
 	var A = 0;
 	var B = 1;

--- a/src/lime/ui/KeyCode.hx
+++ b/src/lime/ui/KeyCode.hx
@@ -3,7 +3,7 @@ package lime.ui;
 import lime._internal.backend.native.NativeCFFI;
 
 @:access(lime._internal.backend.native.NativeCFFI)
-@:enum abstract KeyCode(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract KeyCode(Int) from Int to Int from UInt to UInt
 {
 	var UNKNOWN = 0x00;
 	var BACKSPACE = 0x08;

--- a/src/lime/ui/MouseButton.hx
+++ b/src/lime/ui/MouseButton.hx
@@ -1,6 +1,6 @@
 package lime.ui;
 
-@:enum abstract MouseButton(Int) from Int to Int
+#if haxe4 enum #else @:enum #end abstract MouseButton(Int) from Int to Int
 {
 	var LEFT = 0;
 	var MIDDLE = 1;

--- a/src/lime/ui/ScanCode.hx
+++ b/src/lime/ui/ScanCode.hx
@@ -4,7 +4,7 @@ import lime._internal.backend.native.NativeCFFI;
 
 @:access(lime._internal.backend.native.NativeCFFI)
 @:access(lime.ui.KeyCode)
-@:enum abstract ScanCode(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract ScanCode(Int) from Int to Int from UInt to UInt
 {
 	var UNKNOWN = 0;
 	var BACKSPACE = 42;

--- a/src/lime/utils/ArrayBufferView.hx
+++ b/src/lime/utils/ArrayBufferView.hx
@@ -400,7 +400,7 @@ class ArrayBufferView
 	RangeError;
 }
 
-@:noCompletion @:dox(hide) @:enum
+@:noCompletion @:dox(hide) #if haxe4 enum #else @:enum #end
 abstract TypedArrayType(Int) from Int to Int
 {
 	var None = 0;
@@ -420,7 +420,7 @@ abstract TypedArrayType(Int) from Int to Int
 {
 	// 8
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getInt8(buffer:ArrayBuffer, byteOffset:Int):Int
@@ -434,7 +434,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setInt8(buffer:ArrayBuffer, byteOffset:Int, value:Int)
@@ -450,7 +450,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getUint8(buffer:ArrayBuffer, byteOffset:Int):Null<UInt>
@@ -463,7 +463,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setUint8Clamped(buffer:ArrayBuffer, byteOffset:Int, value:UInt)
@@ -472,7 +472,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setUint8(buffer:ArrayBuffer, byteOffset:Int, value:UInt)
@@ -547,7 +547,7 @@ abstract TypedArrayType(Int) from Int to Int
 	} // setInt16_BE
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getUint16(buffer:ArrayBuffer, byteOffset:Int):Null<UInt>
@@ -563,7 +563,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getUint16_BE(buffer:ArrayBuffer, byteOffset:Int):Null<UInt>
@@ -579,7 +579,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setUint16(buffer:ArrayBuffer, byteOffset:Int, value:UInt)
@@ -592,7 +592,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setUint16_BE(buffer:ArrayBuffer, byteOffset:Int, value:UInt)
@@ -607,7 +607,7 @@ abstract TypedArrayType(Int) from Int to Int
 
 	// 32
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getInt32(buffer:ArrayBuffer, byteOffset:Int):Int
@@ -620,7 +620,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getInt32_BE(buffer:ArrayBuffer, byteOffset:Int):Int
@@ -633,7 +633,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setInt32(buffer:ArrayBuffer, byteOffset:Int, value:Int)
@@ -650,7 +650,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setInt32_BE(buffer:ArrayBuffer, byteOffset:Int, value:Int)
@@ -667,7 +667,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getUint32(buffer:ArrayBuffer, byteOffset:Int):Null<UInt>
@@ -680,7 +680,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getUint32_BE(buffer:ArrayBuffer, byteOffset:Int):Null<UInt>
@@ -693,7 +693,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setUint32(buffer:ArrayBuffer, byteOffset:Int, value:UInt)
@@ -706,7 +706,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setUint32_BE(buffer:ArrayBuffer, byteOffset:Int, value:UInt)
@@ -720,7 +720,7 @@ abstract TypedArrayType(Int) from Int to Int
 
 	// Float
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getFloat32(buffer:ArrayBuffer, byteOffset:Int):Float
@@ -733,7 +733,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getFloat32_BE(buffer:ArrayBuffer, byteOffset:Int):Float
@@ -746,7 +746,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setFloat32(buffer:ArrayBuffer, byteOffset:Int, value:Float)
@@ -762,7 +762,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setFloat32_BE(buffer:ArrayBuffer, byteOffset:Int, value:Float)
@@ -778,7 +778,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getFloat64(buffer:ArrayBuffer, byteOffset:Int):Float
@@ -791,7 +791,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function getFloat64_BE(buffer:ArrayBuffer, byteOffset:Int):Float
@@ -804,7 +804,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setFloat64(buffer:ArrayBuffer, byteOffset:Int, value:Float)
@@ -820,7 +820,7 @@ abstract TypedArrayType(Int) from Int to Int
 	}
 
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	public static function setFloat64_BE(buffer:ArrayBuffer, byteOffset:Int, value:Float)
@@ -837,7 +837,7 @@ abstract TypedArrayType(Int) from Int to Int
 
 	// Internal
 	#if !no_typedarray_inline
-	@:extern
+	#if haxe4 extern #else @:extern #end
 	inline
 	#end
 	// clamp a Int to a 0-255 Uint8 (for Uint8Clamped array)

--- a/src/lime/utils/AssetType.hx
+++ b/src/lime/utils/AssetType.hx
@@ -1,6 +1,6 @@
 package lime.utils;
 
-@:enum abstract AssetType(String) to String
+#if haxe4 enum #else @:enum #end abstract AssetType(String) to String
 {
 	var BINARY = "BINARY";
 	var FONT = "FONT";

--- a/src/lime/utils/Float32Array.hx
+++ b/src/lime/utils/Float32Array.hx
@@ -62,10 +62,10 @@ abstract Float32Array(JSFloat32Array) from JSFloat32Array to JSFloat32Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:Float):Float
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:Float):Float
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):Float
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):Float
 		return this[idx];
 
 	// non spec haxe conversions
@@ -150,18 +150,18 @@ abstract Float32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 	inline function toString()
 		return this != null ? 'Float32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
-	@:extern inline function get_length()
+	#if haxe4 extern #else @:extern #end inline function get_length()
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int):Float
 	{
 		return ArrayBufferIO.getFloat32(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT));
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:Float):Float
 	{
 		ArrayBufferIO.setFloat32(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT), val);

--- a/src/lime/utils/Float64Array.hx
+++ b/src/lime/utils/Float64Array.hx
@@ -61,10 +61,10 @@ abstract Float64Array(JSFloat64Array) from JSFloat64Array to JSFloat64Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:Float):Float
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:Float):Float
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):Float
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):Float
 		return this[idx];
 
 	// non spec haxe conversions
@@ -148,14 +148,14 @@ abstract Float64Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int):Float
 	{
 		return ArrayBufferIO.getFloat64(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT));
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:Float):Float
 	{
 		ArrayBufferIO.setFloat64(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT), val);

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -61,10 +61,10 @@ abstract Int16Array(JSInt16Array) from JSInt16Array to JSInt16Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:Int):Int
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:Int):Int
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):Int
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):Int
 		return this[idx];
 
 	// non spec haxe conversions
@@ -148,14 +148,14 @@ abstract Int16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int)
 	{
 		return ArrayBufferIO.getInt16(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT));
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:Int)
 	{
 		ArrayBufferIO.setInt16(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT), val);

--- a/src/lime/utils/Int32Array.hx
+++ b/src/lime/utils/Int32Array.hx
@@ -61,10 +61,10 @@ abstract Int32Array(JSInt32Array) from JSInt32Array to JSInt32Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:Int):Int
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:Int):Int
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):Int
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):Int
 		return this[idx];
 
 	// non spec haxe conversions
@@ -148,14 +148,14 @@ abstract Int32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int)
 	{
 		return ArrayBufferIO.getInt32(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT));
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:Int)
 	{
 		ArrayBufferIO.setInt32(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT), val);

--- a/src/lime/utils/Int8Array.hx
+++ b/src/lime/utils/Int8Array.hx
@@ -61,10 +61,10 @@ abstract Int8Array(JSInt8Array) from JSInt8Array to JSInt8Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:Int):Int
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:Int):Int
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):Int
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):Int
 		return this[idx];
 
 	// non spec haxe conversions
@@ -148,14 +148,14 @@ abstract Int8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int)
 	{
 		return ArrayBufferIO.getInt8(this.buffer, this.byteOffset + idx);
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:Int)
 	{
 		ArrayBufferIO.setInt8(this.buffer, this.byteOffset + idx, val);

--- a/src/lime/utils/LogLevel.hx
+++ b/src/lime/utils/LogLevel.hx
@@ -1,6 +1,6 @@
 package lime.utils;
 
-@:enum abstract LogLevel(Int) from Int to Int from UInt to UInt
+#if haxe4 enum #else @:enum #end abstract LogLevel(Int) from Int to Int from UInt to UInt
 {
 	var NONE = 0;
 	var ERROR = 1;

--- a/src/lime/utils/UInt16Array.hx
+++ b/src/lime/utils/UInt16Array.hx
@@ -61,10 +61,10 @@ abstract UInt16Array(JSUInt16Array) from JSUInt16Array to JSUInt16Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:UInt):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:UInt):UInt
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):UInt
 		return this[idx];
 
 	// non spec haxe conversions
@@ -148,14 +148,14 @@ abstract UInt16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int)
 	{
 		return ArrayBufferIO.getUint16(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT));
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:UInt)
 	{
 		ArrayBufferIO.setUint16(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT), val);

--- a/src/lime/utils/UInt32Array.hx
+++ b/src/lime/utils/UInt32Array.hx
@@ -61,10 +61,10 @@ abstract UInt32Array(JSUInt32Array) from JSUInt32Array to JSUInt32Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:UInt):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:UInt):UInt
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):UInt
 		return this[idx];
 
 	// non spec haxe conversions
@@ -148,14 +148,14 @@ abstract UInt32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int)
 	{
 		return ArrayBufferIO.getUint32(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT));
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:UInt)
 	{
 		ArrayBufferIO.setUint32(this.buffer, this.byteOffset + (idx * BYTES_PER_ELEMENT), val);

--- a/src/lime/utils/UInt8Array.hx
+++ b/src/lime/utils/UInt8Array.hx
@@ -59,10 +59,10 @@ abstract UInt8Array(JSUInt8Array) from JSUInt8Array to JSUInt8Array
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:UInt):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:UInt):UInt
 		return this[idx] = val;
 
-	@:arrayAccess @:extern inline function __get(idx:Int):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):UInt
 		return this[idx];
 
 	// non spec haxe conversions
@@ -149,14 +149,14 @@ abstract UInt8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int)
 	{
 		return ArrayBufferIO.getUint8(this.buffer, this.byteOffset + idx);
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:UInt)
 	{
 		ArrayBufferIO.setUint8(this.buffer, this.byteOffset + idx, val);

--- a/src/lime/utils/UInt8ClampedArray.hx
+++ b/src/lime/utils/UInt8ClampedArray.hx
@@ -61,10 +61,10 @@ abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUI
 		}
 	}
 
-	@:arrayAccess @:extern inline function __set(idx:Int, val:UInt):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __set(idx:Int, val:UInt):UInt
 		return this[idx] = _clamp(val);
 
-	@:arrayAccess @:extern inline function __get(idx:Int):UInt
+	@:arrayAccess #if haxe4 extern #else @:extern #end inline function __get(idx:Int):UInt
 		return this[idx];
 
 	// non spec haxe conversions
@@ -158,14 +158,14 @@ abstract UInt8ClampedArray(ArrayBufferView) from ArrayBufferView to ArrayBufferV
 		return this.length;
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __get(idx:Int)
 	{
 		return ArrayBufferIO.getUint8(this.buffer, this.byteOffset + idx);
 	}
 
 	@:noCompletion
-	@:arrayAccess @:extern
+	@:arrayAccess #if haxe4 extern #else @:extern #end
 	public inline function __set(idx:Int, val:UInt)
 	{
 		ArrayBufferIO.setUint8Clamped(this.buffer, this.byteOffset + idx, val);

--- a/tools/utils/publish/FirefoxMarketplace.hx
+++ b/tools/utils/publish/FirefoxMarketplace.hx
@@ -749,7 +749,7 @@ class MarketplaceAPI
 	}
 }
 
-@:enum abstract DeviceType(String)
+#if haxe4 enum #else @:enum #end abstract DeviceType(String)
 {
 	var FIREFOXOS = "firefoxos";
 	var DESKTOP = "desktop";
@@ -757,7 +757,7 @@ class MarketplaceAPI
 	var TABLET = "tablet";
 }
 
-@:enum abstract PremiumType(String)
+#if haxe4 enum #else @:enum #end abstract PremiumType(String)
 {
 	var FREE = "free";
 	var FREE_INAPP = "free-inapp";


### PR DESCRIPTION
Looks like Haxe is dropping support for `@:enum abstract`, and we'll have to use `enum abstract` instead. (Same with `@:extern` → `extern`.)

For now, all it does is generate warnings, but it can generate them after build-stopping errors, making it hard to find what went wrong.