### PR TITLE
Removed unused field `hello` in Float32Array.hx

### DIFF
--- a/src/lime/utils/Float32Array.hx
+++ b/src/lime/utils/Float32Array.hx
@@ -93,7 +93,6 @@ import lime.utils.ArrayBufferView;
 abstract Float32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {
 	public inline static var BYTES_PER_ELEMENT:Int = 4;
-	public static var hello:Int;
 
 	public var length(get, never):Int;
 


### PR DESCRIPTION
Fixes #1708
There's an unused field called `hello` in `lime/utils/Float32Array.hx`, which seems to have been added by mistake. This PR just removes it