### PR TITLE
Only escape backslashes in Android paths.

### DIFF
--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -490,9 +490,8 @@ class AndroidPlatform extends PlatformTarget
 			context.ANDROID_BUILD_TOOLS_VERSION = AndroidHelper.getBuildToolsVersion(project);
 		}
 
-		var escaped = ~/([ #!=\\:])/g;
-		context.ANDROID_SDK_ESCAPED = escaped.replace(context.ENV_ANDROID_SDK, "\\$1");
-		context.ANDROID_NDK_ROOT_ESCAPED = escaped.replace(context.ENV_ANDROID_NDK_ROOT, "\\$1");
+		context.ANDROID_SDK_ESCAPED = StringTools.replace(context.ENV_ANDROID_SDK, "\\", "\\\\");
+		context.ANDROID_NDK_ROOT_ESCAPED = StringTools.replace(context.ENV_ANDROID_NDK_ROOT, "\\", "\\\\");
 
 		if (Reflect.hasField(context, "KEY_STORE")) context.KEY_STORE = StringTools.replace(context.KEY_STORE, "\\", "\\\\");
 		if (Reflect.hasField(context, "KEY_STORE_ALIAS")) context.KEY_STORE_ALIAS = StringTools.replace(context.KEY_STORE_ALIAS, "\\", "\\\\");


### PR DESCRIPTION
Neither [.properties](https://en.wikipedia.org/wiki/.properties#Format) nor [.gradle](https://groovy-lang.org/syntax.html#_escaping_special_characters) files require anything else to be escaped, and in .gradle files, escaping anything else is incorrect.

I think most of these weren't well-tested in the first place. On Linux* I was able to use the ` #!=` characters without any trouble at all, while colons caused hxcpp to be unable to find the g++ executable. (For the latter, it makes no difference whether we do or don't escape it, because hxcpp doesn't get the file path from Lime.)

*And it's clear this wasn't well-tested on Windows either, since it escapes the colon in "C:\".

Supersedes #1720, or vice versa.