### PR TITLE
Prevents stuck if we don't have access to gamepad

### DIFF
--- a/src/lime/ui/Joystick.hx
+++ b/src/lime/ui/Joystick.hx
@@ -63,7 +63,8 @@ class Joystick
 		}
 		catch (err:Dynamic)
 		{
-			trace("Gamepad access issue");
+			// if something went wrong, treat it the same as when navigator.getGamepads doesn't exist
+			// we probably don't have permission to use this feature
 		}
 		
 		return res;

--- a/src/lime/ui/Joystick.hx
+++ b/src/lime/ui/Joystick.hx
@@ -55,8 +55,18 @@ class Joystick
 	#if (js && html5)
 	@:noCompletion private static function __getDeviceData():Array<Dynamic>
 	{
-		return
-			(untyped navigator.getGamepads) ? untyped navigator.getGamepads() : (untyped navigator.webkitGetGamepads) ? untyped navigator.webkitGetGamepads() : null;
+		var res:Dynamic = null;
+		
+		try 
+		{
+			res = (untyped navigator.getGamepads) ? untyped navigator.getGamepads() : (untyped navigator.webkitGetGamepads) ? untyped navigator.webkitGetGamepads() : null;
+		}
+		catch (err:Dynamic)
+		{
+			trace("Gamepad access issue");
+		}
+		
+		return res;
 	}
 	#end
 


### PR DESCRIPTION
Original issue: Failed to execute 'getGamepads' on 'Navigator': Access to the feature "gamepad" is disallowed by permissions policy. #1727 