### PR TITLE
Changed Backend Mutex `lock` and `unlock` Methods to be Constant

### DIFF
--- a/project/include/system/Mutex.h
+++ b/project/include/system/Mutex.h
@@ -13,9 +13,9 @@ namespace lime {
 			Mutex ();
 			~Mutex ();
 
-			bool Lock ();
-			bool TryLock ();
-			bool Unlock ();
+			bool Lock () const;
+			bool TryLock () const;
+			bool Unlock () const;
 
 		private:
 

--- a/project/src/backend/sdl/SDLMutex.cpp
+++ b/project/src/backend/sdl/SDLMutex.cpp
@@ -23,7 +23,7 @@ namespace lime {
 	}
 
 
-	bool Mutex::Lock () {
+	bool Mutex::Lock () const {
 
 		if (mutex) {
 
@@ -36,7 +36,7 @@ namespace lime {
 	}
 
 
-	bool Mutex::TryLock () {
+	bool Mutex::TryLock () const {
 
 		if (mutex) {
 
@@ -49,7 +49,7 @@ namespace lime {
 	}
 
 
-	bool Mutex::Unlock () {
+	bool Mutex::Unlock () const {
 
 		if (mutex) {
 

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -477,7 +477,7 @@ class AssetLibrary
 			}
 			else
 			{
-				return AudioBuffer.loadFromFile(getPath(id));
+				return AudioBuffer.loadFromFile(paths.get(id));
 			}
 		}
 	}

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -200,7 +200,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return AudioBuffer.fromFile(paths.get(id));
+			return AudioBuffer.fromFile(getPath(id));
 		}
 	}
 
@@ -239,7 +239,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Bytes.fromFile(paths.get(id));
+			return Bytes.fromFile(getPath(id));
 		}
 	}
 
@@ -263,7 +263,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Font.fromFile(paths.get(id));
+			return Font.fromFile(getPath(id));
 		}
 	}
 
@@ -283,7 +283,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Image.fromFile(paths.get(id));
+			return Image.fromFile(getPath(id));
 		}
 	}
 
@@ -477,7 +477,7 @@ class AssetLibrary
 			}
 			else
 			{
-				return AudioBuffer.loadFromFile(paths.get(id));
+				return AudioBuffer.loadFromFile(getPath(id));
 			}
 		}
 	}
@@ -498,7 +498,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Bytes.loadFromFile(paths.get(id));
+			return Bytes.loadFromFile(getPath(id));
 		}
 	}
 
@@ -521,9 +521,9 @@ class AssetLibrary
 		else
 		{
 			#if (js && html5)
-			return Font.loadFromName(paths.get(id));
+			return Font.loadFromName(getPath(id));
 			#else
-			return Font.loadFromFile(paths.get(id));
+			return Font.loadFromFile(getPath(id));
 			#end
 		}
 	}
@@ -579,7 +579,7 @@ class AssetLibrary
 		}
 		else
 		{
-			return Image.loadFromFile(paths.get(id));
+			return Image.loadFromFile(getPath(id));
 		}
 	}
 
@@ -607,7 +607,7 @@ class AssetLibrary
 		else
 		{
 			var request = new HTTPRequest<String>();
-			return request.load(paths.get(id));
+			return request.load(getPath(id));
 		}
 	}
 

--- a/src/lime/utils/PackedAssetLibrary.hx
+++ b/src/lime/utils/PackedAssetLibrary.hx
@@ -242,7 +242,7 @@ import flash.media.Sound;
 			else
 			{
 				var basePath = rootPath == null || rootPath == "" ?  "" : Path.addTrailingSlash(rootPath);
-				var libPath = paths.exists(id) ? paths.get(id) : id;
+				var libPath = paths.exists(id) ? getPath(id) : id;
 
 				var path = Path.join([basePath, libPath]);
 				path = __cacheBreak(path);

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -145,7 +145,7 @@ class AndroidPlatform extends PlatformTarget
 		var architectures = [];
 
 		if (hasARMV5) architectures.push(Architecture.ARMV5);
-		if (hasARMV7 || (!hasARMV5 && !hasX86)) architectures.push(Architecture.ARMV7);
+		if (hasARMV7) architectures.push(Architecture.ARMV7);
 		if (hasARM64) architectures.push(Architecture.ARM64);
 		if (hasX86) architectures.push(Architecture.X86);
 		if (hasX64) architectures.push(Architecture.X64);

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -150,7 +150,12 @@ class AndroidPlatform extends PlatformTarget
 		if (hasX86) architectures.push(Architecture.X86);
 		if (hasX64) architectures.push(Architecture.X64);
 
-		if (architectures.length == 0) architectures.push(Architecture.ARM64);
+		if (architectures.length == 0)
+		{
+			hasARM64 = true;
+
+			architectures.push(Architecture.ARM64);
+		}
 
 		for (architecture in architectures)
 		{

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -152,7 +152,7 @@ class AndroidPlatform extends PlatformTarget
 
 		if (architectures.length == 0)
 		{
-			Log.warn("No architecture selected, resorting to arm64.");
+			Log.warn("No architecture selected, defaulting to ARM64.");
 
 			hasARM64 = true;
 

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -150,6 +150,8 @@ class AndroidPlatform extends PlatformTarget
 		if (hasX86) architectures.push(Architecture.X86);
 		if (hasX64) architectures.push(Architecture.X64);
 
+		if (architectures.length == 0) architectures.push(Architecture.ARM64);
+
 		for (architecture in architectures)
 		{
 			var haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-21"];

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -152,6 +152,8 @@ class AndroidPlatform extends PlatformTarget
 
 		if (architectures.length == 0)
 		{
+			Log.warn("No architecture selected, resorting to arm64.");
+
 			hasARM64 = true;
 
 			architectures.push(Architecture.ARM64);

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -475,8 +475,7 @@ class IOSPlatform extends PlatformTarget
 	public override function rebuild():Void
 	{
 		var armv6 = (project.architectures.indexOf(Architecture.ARMV6) > -1 && !project.targetFlags.exists("simulator"));
-		var armv7 = (command == "rebuild"
-			|| (project.architectures.indexOf(Architecture.ARMV7) > -1 && !project.targetFlags.exists("simulator")));
+		var armv7 = (project.architectures.indexOf(Architecture.ARMV7) > -1 && !project.targetFlags.exists("simulator"));
 		var armv7s = (project.architectures.indexOf(Architecture.ARMV7S) > -1 && !project.targetFlags.exists("simulator"));
 		var arm64 = (command == "rebuild"
 			|| (project.architectures.indexOf(Architecture.ARM64) > -1 && !project.targetFlags.exists("simulator")));


### PR DESCRIPTION
This PR is a minor change. However, this change does offer a broader use towards const instances that need to perform synchronization, such as a `ScopeLock` class.