### PR TITLE
Implement controller rumble support to ui/Gamepad

### DIFF
--- a/project/include/ui/Gamepad.h
+++ b/project/include/ui/Gamepad.h
@@ -12,6 +12,8 @@ namespace lime {
 			static void AddMapping (const char* content);
 			static const char* GetDeviceGUID (int id);
 			static const char* GetDeviceName (int id);
+			
+			static void Rumble(int id, int duration, double largeStrength, double smallStrength);
 
 	};
 

--- a/project/include/ui/Gamepad.h
+++ b/project/include/ui/Gamepad.h
@@ -12,7 +12,6 @@ namespace lime {
 			static void AddMapping (const char* content);
 			static const char* GetDeviceGUID (int id);
 			static const char* GetDeviceName (int id);
-
 			static void Rumble (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration);
 
 	};

--- a/project/include/ui/Gamepad.h
+++ b/project/include/ui/Gamepad.h
@@ -13,7 +13,7 @@ namespace lime {
 			static const char* GetDeviceGUID (int id);
 			static const char* GetDeviceName (int id);
 			
-			static void Rumble(int id, int duration, double largeStrength, double smallStrength);
+			static void Rumble(int id, double lowFrequencyRumble, double highFrequencyRumble, int duration);
 
 	};
 

--- a/project/include/ui/Gamepad.h
+++ b/project/include/ui/Gamepad.h
@@ -12,8 +12,8 @@ namespace lime {
 			static void AddMapping (const char* content);
 			static const char* GetDeviceGUID (int id);
 			static const char* GetDeviceName (int id);
-			
-			static void Rumble(int id, double lowFrequencyRumble, double highFrequencyRumble, int duration);
+
+			static void Rumble (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration);
 
 	};
 

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -1678,6 +1678,20 @@ namespace lime {
 	}
 
 
+	void lime_gamepad_rumble (int id, int duration, float largeStrength, float smallStrength) {
+
+		Gamepad::Rumble (id, duration, largeStrength, smallStrength);
+
+	}
+
+
+	HL_PRIM void HL_NAME(hl_lime_gamepad_rumble) (int id, int duration, float largeStrength, float smallStrength) {
+
+		Gamepad::Rumble (id, duration, largeStrength, smallStrength);
+
+	}
+
+
 	value lime_gzip_compress (value buffer, value bytes) {
 
 		#ifdef LIME_ZLIB

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -1678,14 +1678,14 @@ namespace lime {
 	}
 
 
-	void lime_gamepad_rumble (int id, int duration, float largeStrength, float smallStrength) {
+	void lime_gamepad_rumble (int id, int duration, double largeStrength, double smallStrength) {
 
 		Gamepad::Rumble (id, duration, largeStrength, smallStrength);
 
 	}
 
 
-	HL_PRIM void HL_NAME(hl_lime_gamepad_rumble) (int id, int duration, float largeStrength, float smallStrength) {
+	HL_PRIM void HL_NAME(hl_gamepad_rumble) (int id, int duration, double largeStrength, double smallStrength) {
 
 		Gamepad::Rumble (id, duration, largeStrength, smallStrength);
 
@@ -3984,6 +3984,7 @@ namespace lime {
 	DEFINE_PRIME2v (lime_gamepad_event_manager_register);
 	DEFINE_PRIME1 (lime_gamepad_get_device_guid);
 	DEFINE_PRIME1 (lime_gamepad_get_device_name);
+	DEFINE_PRIME4v (lime_gamepad_rumble);
 	DEFINE_PRIME2 (lime_gzip_compress);
 	DEFINE_PRIME2 (lime_gzip_decompress);
 	DEFINE_PRIME2v (lime_haptic_vibrate);
@@ -4173,6 +4174,7 @@ namespace lime {
 	DEFINE_HL_PRIM (_VOID, hl_gamepad_event_manager_register, _FUN(_VOID, _NO_ARG) _TGAMEPAD_EVENT);
 	DEFINE_HL_PRIM (_BYTES, hl_gamepad_get_device_guid, _I32);
 	DEFINE_HL_PRIM (_BYTES, hl_gamepad_get_device_name, _I32);
+	DEFINE_HL_PRIM (_VOID, hl_gamepad_rumble, _I32 _I32 _F64 _F64);
 	DEFINE_HL_PRIM (_TBYTES, hl_gzip_compress, _TBYTES _TBYTES);
 	DEFINE_HL_PRIM (_TBYTES, hl_gzip_decompress, _TBYTES _TBYTES);
 	DEFINE_HL_PRIM (_VOID, hl_haptic_vibrate, _I32 _I32);

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -1678,16 +1678,16 @@ namespace lime {
 	}
 
 
-	void lime_gamepad_rumble (int id, int duration, double largeStrength, double smallStrength) {
+	void lime_gamepad_rumble (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration) {
 
-		Gamepad::Rumble (id, duration, largeStrength, smallStrength);
+		Gamepad::Rumble (id, lowFrequencyRumble, highFrequencyRumble, duration);
 
 	}
 
 
-	HL_PRIM void HL_NAME(hl_gamepad_rumble) (int id, int duration, double largeStrength, double smallStrength) {
+	HL_PRIM void HL_NAME(hl_gamepad_rumble) (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration) {
 
-		Gamepad::Rumble (id, duration, largeStrength, smallStrength);
+		Gamepad::Rumble (id, lowFrequencyRumble, highFrequencyRumble, duration);
 
 	}
 

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -2,78 +2,96 @@
 
 
 namespace lime {
-
-
-	std::map<int, SDL_GameController*> gameControllers = std::map<int, SDL_GameController*> ();
-	std::map<int, int> gameControllerIDs = std::map<int, int> ();
-
-
-	bool SDLGamepad::Connect (int deviceID) {
-
-		if (SDL_IsGameController (deviceID)) {
-
-			SDL_GameController *gameController = SDL_GameControllerOpen (deviceID);
-
-			if (gameController) {
-
-				SDL_Joystick *joystick = SDL_GameControllerGetJoystick (gameController);
-				int id = SDL_JoystickInstanceID (joystick);
-
-				gameControllers[id] = gameController;
-				gameControllerIDs[deviceID] = id;
-
-				return true;
-
-			}
-
+	std::map<int, SDLGamepad> gameControllers;
+	std::map<int, int> gameControllerIDs;
+	
+	SDLGamepad::SDLGamepad(SDL_GameController *_gameController) : gameController(_gameController) {
+		// Get joystick from controller
+		joystick = SDL_GameControllerGetJoystick(gameController);
+		if (!joystick) {
+			// Close joystick, since something has to be seriously wrong at this point
+			SDL_GameControllerClose(gameController);
+			gameController = nullptr;
+			return;
 		}
+	}
+	
+	SDLGamepad::~SDLGamepad() {
+		if (gameController != nullptr)
+			SDL_GameControllerClose(gameController);
+	}
+	
+	void SDLGamepad::Rumble(int duration, double largeStrength, double smallStrength) {
+		// Make sure game controller is open
+		if (gameController == nullptr)
+			return;
+		
+		// Rumble controller
+		if (smallStrength < 0.0f)
+			smallStrength = 0.0f;
+		else if (smallStrength > 1.0f)
+			smallStrength = 1.0f;
+		
+		if (largeStrength < 0.0f)
+			largeStrength = 0.0f;
+		else if (largeStrength > 1.0f)
+			largeStrength = 1.0f;
+		
+		if (duration < 0)
+			duration = 0;
+		else if (duration > 0xFFFF)
+			duration = 0xFFFF;
+		
+		SDL_GameControllerRumble(gameController, smallStrength * 0xFFFF, largeStrength * 0xFFFF, duration);
+	}
 
+	// SDL static gamepad API
+	bool SDLGamepad::Connect (int deviceID) {
+		if (SDL_IsGameController (deviceID)) {
+			SDL_GameController *gameController = SDL_GameControllerOpen(deviceID);
+			
+			if (gameController != nullptr) {
+				SDL_Joystick *joystick = SDL_GameControllerGetJoystick(gameController);
+				int id = SDL_JoystickInstanceID(joystick);
+
+				gameControllers.emplace(std::pair<int, SDLGamepad>(id, SDLGamepad(gameController)));
+				gameControllerIDs[deviceID] = id;
+				return true;
+			}
+		}
 		return false;
 
 	}
 
 
 	bool SDLGamepad::Disconnect (int id) {
-
-		if (gameControllers.find (id) != gameControllers.end ()) {
-
-			SDL_GameController *gameController = gameControllers[id];
-			SDL_GameControllerClose (gameController);
-			gameControllers.erase (id);
-
+		if (gameControllers.find(id) != gameControllers.end()) {
+			gameControllers.erase(id);
 			return true;
-
 		}
-
 		return false;
 
 	}
 
 
 	int SDLGamepad::GetInstanceID (int deviceID) {
-
 		return gameControllerIDs[deviceID];
-
 	}
 
 
+	// Gamepad API
 	void Gamepad::AddMapping (const char* content) {
-
 		SDL_GameControllerAddMapping (content);
-
 	}
 
 
 	const char* Gamepad::GetDeviceGUID (int id) {
-
-		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (gameControllers[id]);
+		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (gameControllers[id].gameController);
 
 		if (joystick) {
-
 			char* guid = new char[64];
 			SDL_JoystickGetGUIDString (SDL_JoystickGetGUID (joystick), guid, 64);
 			return guid;
-
 		}
 
 		return 0;
@@ -82,10 +100,10 @@ namespace lime {
 
 
 	const char* Gamepad::GetDeviceName (int id) {
-
-		return SDL_GameControllerName (gameControllers[id]);
-
+		return SDL_GameControllerName (gameControllers[id].gameController);
 	}
 
-
+	void Gamepad::Rumble (int id, int duration, double largeStrength, double smallStrength) {
+		gameControllers[id].Rumble(duration, largeStrength, smallStrength);
+	}
 }

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -2,6 +2,8 @@
 
 
 namespace lime {
+
+
 	std::map<int, SDLGamepad> gameControllers;
 	std::map<int, int> gameControllerIDs;
 	
@@ -30,42 +32,58 @@ namespace lime {
 	}
 
 	// SDL static gamepad API
+
 	bool SDLGamepad::Connect (int deviceID) {
+
 		if (SDL_IsGameController (deviceID)) {
+
 			SDL_GameController *gameController = SDL_GameControllerOpen(deviceID);
 			
 			if (gameController != nullptr) {
+
 				SDL_Joystick *joystick = SDL_GameControllerGetJoystick(gameController);
 				int id = SDL_JoystickInstanceID(joystick);
 
 				gameControllers[id] = std::move(SDLGamepad(gameController));
 				gameControllerIDs[deviceID] = id;
+
 				return true;
+
 			}
+
 		}
+
 		return false;
 
 	}
 
 
 	bool SDLGamepad::Disconnect (int id) {
+
 		if (gameControllers.find(id) != gameControllers.end()) {
+
 			gameControllers.erase(id);
 			return true;
+
 		}
+
 		return false;
 
 	}
 
 
 	int SDLGamepad::GetInstanceID (int deviceID) {
+
 		return gameControllerIDs[deviceID];
+
 	}
 
 
 	// Gamepad API
 	void Gamepad::AddMapping (const char* content) {
+
 		SDL_GameControllerAddMapping (content);
+
 	}
 
 
@@ -77,9 +95,11 @@ namespace lime {
 		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (it->second.gameController);
 
 		if (joystick) {
+
 			char* guid = new char[64];
 			SDL_JoystickGetGUIDString (SDL_JoystickGetGUID (joystick), guid, 64);
 			return guid;
+
 		}
 		
 		return nullptr;

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -38,7 +38,7 @@ namespace lime {
 		if (SDL_IsGameController (deviceID)) {
 
 			SDL_GameController *gameController = SDL_GameControllerOpen(deviceID);
-			
+
 			if (gameController != nullptr) {
 
 				SDL_Joystick *joystick = SDL_GameControllerGetJoystick(gameController);
@@ -101,7 +101,7 @@ namespace lime {
 			return guid;
 
 		}
-		
+
 		return nullptr;
 
 	}

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -93,20 +93,9 @@ namespace lime {
 		if (it == gameControllers.end ())
 			return;
 
-		if (highFrequencyRumble < 0.0f)
-			highFrequencyRumble = 0.0f;
-		else if (highFrequencyRumble > 1.0f)
-			highFrequencyRumble = 1.0f;
-
-		if (lowFrequencyRumble < 0.0f)
-			lowFrequencyRumble = 0.0f;
-		else if (lowFrequencyRumble > 1.0f)
-			lowFrequencyRumble = 1.0f;
-
-		if (duration < 0)
-			duration = 0;
-		else if (duration > 0xFFFF)
-			duration = 0xFFFF;
+		highFrequencyRumble = std::clamp(highFrequencyRumble, 0.0f, 1.0f);
+		lowFrequencyRumble = std::clamp(lowFrequencyRumble, 0.0f, 1.0f);
+		duration = std::clamp(duration, 0, 0xFFFF);
 
 		SDL_GameControllerRumble (it->second, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
 

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -1,5 +1,4 @@
 #include "SDLGamepad.h"
-#include <algorithm>
 
 
 namespace lime {

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -1,4 +1,5 @@
 #include "SDLGamepad.h"
+#include <algorithm>
 
 
 namespace lime {

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -67,15 +67,12 @@ namespace lime {
 
 		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (it->second);
 
-		if (joystick) {
+		if (joystick == nullptr)
+			return nullptr;
 
-			char* guid = new char[64];
-			SDL_JoystickGetGUIDString (SDL_JoystickGetGUID (joystick), guid, 64);
-			return guid;
-
-		}
-
-		return nullptr;
+		char* guid = new char[64];
+		SDL_JoystickGetGUIDString (SDL_JoystickGetGUID (joystick), guid, 64);
+		return guid;
 
 	}
 

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -7,28 +7,28 @@ namespace lime {
 	std::map<int, SDLGamepad> gameControllers;
 	std::map<int, int> gameControllerIDs;
 	
-	void SDLGamepad::Rumble(int duration, double largeStrength, double smallStrength) {
+	void SDLGamepad::Rumble(double lowFrequencyRumble, double highFrequencyRumble, int duration) {
 		// Make sure game controller is open
 		if (gameController == nullptr)
 			return;
 		
 		// Rumble controller
-		if (smallStrength < 0.0f)
-			smallStrength = 0.0f;
-		else if (smallStrength > 1.0f)
-			smallStrength = 1.0f;
+		if (highFrequencyRumble < 0.0f)
+			highFrequencyRumble = 0.0f;
+		else if (highFrequencyRumble > 1.0f)
+			highFrequencyRumble = 1.0f;
 		
-		if (largeStrength < 0.0f)
-			largeStrength = 0.0f;
-		else if (largeStrength > 1.0f)
-			largeStrength = 1.0f;
+		if (lowFrequencyRumble < 0.0f)
+			lowFrequencyRumble = 0.0f;
+		else if (lowFrequencyRumble > 1.0f)
+			lowFrequencyRumble = 1.0f;
 		
 		if (duration < 0)
 			duration = 0;
 		else if (duration > 0xFFFF)
 			duration = 0xFFFF;
 		
-		SDL_GameControllerRumble(gameController, largeStrength * 0xFFFF, smallStrength * 0xFFFF, duration);
+		SDL_GameControllerRumble(gameController, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
 	}
 
 	// SDL static gamepad API
@@ -115,11 +115,11 @@ namespace lime {
 		return SDL_GameControllerName(it->second.gameController);
 	}
 
-	void Gamepad::Rumble (int id, int duration, double largeStrength, double smallStrength) {
+	void Gamepad::Rumble (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration) {
 		auto it = gameControllers.find(id);
 		if (it == gameControllers.end())
 			return;
 		
-		it->second.Rumble(duration, largeStrength, smallStrength);
+		it->second.Rumble(lowFrequencyRumble, highFrequencyRumble, duration);
 	}
 }

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -14,7 +14,6 @@ namespace lime {
 			return false;
 
 		SDL_GameController *gameController = SDL_GameControllerOpen (deviceID);
-
 		if (gameController == nullptr)
 			return false;
 
@@ -35,8 +34,7 @@ namespace lime {
 		if (it == gameControllers.end ())
 			return false;
 
-		SDL_GameController *gameController = it->second;
-		SDL_GameControllerClose (gameController);
+		SDL_GameControllerClose (it->second);
 		gameControllers.erase (id);
 
 		return true;
@@ -51,7 +49,6 @@ namespace lime {
 	}
 
 
-	// Gamepad API
 	void Gamepad::AddMapping (const char* content) {
 
 		SDL_GameControllerAddMapping (content);
@@ -66,7 +63,6 @@ namespace lime {
 			return nullptr;
 
 		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (it->second);
-
 		if (joystick == nullptr)
 			return nullptr;
 
@@ -86,6 +82,7 @@ namespace lime {
 		return SDL_GameControllerName (it->second);
 
 	}
+
 
 	void Gamepad::Rumble (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration) {
 
@@ -111,4 +108,6 @@ namespace lime {
 		SDL_GameControllerRumble (it->second, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
 
 	}
+
+
 }

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -100,11 +100,6 @@ namespace lime {
 		else if (lowFrequencyRumble > 1.0f)
 			lowFrequencyRumble = 1.0f;
 
-		if (duration < 0)
-			duration = 0;
-		else if (duration > 0xFFFF)
-			duration = 0xFFFF;
-
 		SDL_GameControllerRumble (it->second, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
 
 	}

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -94,9 +94,20 @@ namespace lime {
 		if (it == gameControllers.end ())
 			return;
 
-		highFrequencyRumble = std::clamp(highFrequencyRumble, 0.0f, 1.0f);
-		lowFrequencyRumble = std::clamp(lowFrequencyRumble, 0.0f, 1.0f);
-		duration = std::clamp(duration, 0, 0xFFFF);
+		if (highFrequencyRumble < 0.0f)
+			highFrequencyRumble = 0.0f;
+		else if (highFrequencyRumble > 1.0f)
+			highFrequencyRumble = 1.0f;
+
+		if (lowFrequencyRumble < 0.0f)
+			lowFrequencyRumble = 0.0f;
+		else if (lowFrequencyRumble > 1.0f)
+			lowFrequencyRumble = 1.0f;
+
+		if (duration < 0)
+			duration = 0;
+		else if (duration > 0xFFFF)
+			duration = 0xFFFF;
 
 		SDL_GameControllerRumble (it->second, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
 

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -4,70 +4,42 @@
 namespace lime {
 
 
-	std::map<int, SDLGamepad> gameControllers;
+	std::map<int, SDL_GameController*> gameControllers;
 	std::map<int, int> gameControllerIDs;
 
-	void SDLGamepad::Rumble (double lowFrequencyRumble, double highFrequencyRumble, int duration) {
-		// Make sure game controller is open
-		if (gameController == nullptr)
-			return;
 
-		// Rumble controller
-		if (highFrequencyRumble < 0.0f)
-			highFrequencyRumble = 0.0f;
-		else if (highFrequencyRumble > 1.0f)
-			highFrequencyRumble = 1.0f;
-
-		if (lowFrequencyRumble < 0.0f)
-			lowFrequencyRumble = 0.0f;
-		else if (lowFrequencyRumble > 1.0f)
-			lowFrequencyRumble = 1.0f;
-
-		if (duration < 0)
-			duration = 0;
-		else if (duration > 0xFFFF)
-			duration = 0xFFFF;
-
-		SDL_GameControllerRumble (gameController, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
-	}
-
-
-	// SDL static gamepad API
 	bool SDLGamepad::Connect (int deviceID) {
 
-		if (SDL_IsGameController (deviceID)) {
+		if (!SDL_IsGameController (deviceID))
+			return false;
 
-			SDL_GameController *gameController = SDL_GameControllerOpen (deviceID);
+		SDL_GameController *gameController = SDL_GameControllerOpen (deviceID);
 
-			if (gameController != nullptr) {
+		if (gameController == nullptr)
+			return false;
 
-				SDL_Joystick *joystick = SDL_GameControllerGetJoystick (gameController);
-				int id = SDL_JoystickInstanceID (joystick);
+		SDL_Joystick *joystick = SDL_GameControllerGetJoystick (gameController);
+		int id = SDL_JoystickInstanceID (joystick);
 
-				gameControllers[id] = std::move (SDLGamepad (gameController));
-				gameControllerIDs[deviceID] = id;
+		gameControllers[id] = gameController;
+		gameControllerIDs[deviceID] = id;
 
-				return true;
-
-			}
-
-		}
-
-		return false;
+		return true;
 
 	}
 
 
 	bool SDLGamepad::Disconnect (int id) {
 
-		if (gameControllers.find (id) != gameControllers.end ()) {
+		auto it = gameControllers.find (id);
+		if (it == gameControllers.end ())
+			return false;
 
-			gameControllers.erase (id);
-			return true;
+		SDL_GameController *gameController = it->second;
+		SDL_GameControllerClose (gameController);
+		gameControllers.erase (id);
 
-		}
-
-		return false;
+		return true;
 
 	}
 
@@ -88,11 +60,12 @@ namespace lime {
 
 
 	const char* Gamepad::GetDeviceGUID (int id) {
+
 		auto it = gameControllers.find (id);
 		if (it == gameControllers.end ())
 			return nullptr;
 
-		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (it->second.gameController);
+		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (it->second);
 
 		if (joystick) {
 
@@ -108,18 +81,37 @@ namespace lime {
 
 
 	const char* Gamepad::GetDeviceName (int id) {
+
 		auto it = gameControllers.find (id);
 		if (it == gameControllers.end ())
 			return nullptr;
 
-		return SDL_GameControllerName (it->second.gameController);
+		return SDL_GameControllerName (it->second);
+
 	}
 
 	void Gamepad::Rumble (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration) {
+
 		auto it = gameControllers.find (id);
 		if (it == gameControllers.end ())
 			return;
 
-		it->second.Rumble (lowFrequencyRumble, highFrequencyRumble, duration);
+		if (highFrequencyRumble < 0.0f)
+			highFrequencyRumble = 0.0f;
+		else if (highFrequencyRumble > 1.0f)
+			highFrequencyRumble = 1.0f;
+
+		if (lowFrequencyRumble < 0.0f)
+			lowFrequencyRumble = 0.0f;
+		else if (lowFrequencyRumble > 1.0f)
+			lowFrequencyRumble = 1.0f;
+
+		if (duration < 0)
+			duration = 0;
+		else if (duration > 0xFFFF)
+			duration = 0xFFFF;
+
+		SDL_GameControllerRumble (it->second, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
+
 	}
 }

--- a/project/src/backend/sdl/SDLGamepad.cpp
+++ b/project/src/backend/sdl/SDLGamepad.cpp
@@ -6,45 +6,45 @@ namespace lime {
 
 	std::map<int, SDLGamepad> gameControllers;
 	std::map<int, int> gameControllerIDs;
-	
-	void SDLGamepad::Rumble(double lowFrequencyRumble, double highFrequencyRumble, int duration) {
+
+	void SDLGamepad::Rumble (double lowFrequencyRumble, double highFrequencyRumble, int duration) {
 		// Make sure game controller is open
 		if (gameController == nullptr)
 			return;
-		
+
 		// Rumble controller
 		if (highFrequencyRumble < 0.0f)
 			highFrequencyRumble = 0.0f;
 		else if (highFrequencyRumble > 1.0f)
 			highFrequencyRumble = 1.0f;
-		
+
 		if (lowFrequencyRumble < 0.0f)
 			lowFrequencyRumble = 0.0f;
 		else if (lowFrequencyRumble > 1.0f)
 			lowFrequencyRumble = 1.0f;
-		
+
 		if (duration < 0)
 			duration = 0;
 		else if (duration > 0xFFFF)
 			duration = 0xFFFF;
-		
-		SDL_GameControllerRumble(gameController, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
+
+		SDL_GameControllerRumble (gameController, lowFrequencyRumble * 0xFFFF, highFrequencyRumble * 0xFFFF, duration);
 	}
 
-	// SDL static gamepad API
 
+	// SDL static gamepad API
 	bool SDLGamepad::Connect (int deviceID) {
 
 		if (SDL_IsGameController (deviceID)) {
 
-			SDL_GameController *gameController = SDL_GameControllerOpen(deviceID);
+			SDL_GameController *gameController = SDL_GameControllerOpen (deviceID);
 
 			if (gameController != nullptr) {
 
-				SDL_Joystick *joystick = SDL_GameControllerGetJoystick(gameController);
-				int id = SDL_JoystickInstanceID(joystick);
+				SDL_Joystick *joystick = SDL_GameControllerGetJoystick (gameController);
+				int id = SDL_JoystickInstanceID (joystick);
 
-				gameControllers[id] = std::move(SDLGamepad(gameController));
+				gameControllers[id] = std::move (SDLGamepad (gameController));
 				gameControllerIDs[deviceID] = id;
 
 				return true;
@@ -60,9 +60,9 @@ namespace lime {
 
 	bool SDLGamepad::Disconnect (int id) {
 
-		if (gameControllers.find(id) != gameControllers.end()) {
+		if (gameControllers.find (id) != gameControllers.end ()) {
 
-			gameControllers.erase(id);
+			gameControllers.erase (id);
 			return true;
 
 		}
@@ -88,10 +88,10 @@ namespace lime {
 
 
 	const char* Gamepad::GetDeviceGUID (int id) {
-		auto it = gameControllers.find(id);
-		if (it == gameControllers.end())
+		auto it = gameControllers.find (id);
+		if (it == gameControllers.end ())
 			return nullptr;
-		
+
 		SDL_Joystick* joystick = SDL_GameControllerGetJoystick (it->second.gameController);
 
 		if (joystick) {
@@ -108,18 +108,18 @@ namespace lime {
 
 
 	const char* Gamepad::GetDeviceName (int id) {
-		auto it = gameControllers.find(id);
-		if (it == gameControllers.end())
+		auto it = gameControllers.find (id);
+		if (it == gameControllers.end ())
 			return nullptr;
-		
-		return SDL_GameControllerName(it->second.gameController);
+
+		return SDL_GameControllerName (it->second.gameController);
 	}
 
 	void Gamepad::Rumble (int id, double lowFrequencyRumble, double highFrequencyRumble, int duration) {
-		auto it = gameControllers.find(id);
-		if (it == gameControllers.end())
+		auto it = gameControllers.find (id);
+		if (it == gameControllers.end ())
 			return;
-		
-		it->second.Rumble(lowFrequencyRumble, highFrequencyRumble, duration);
+
+		it->second.Rumble (lowFrequencyRumble, highFrequencyRumble, duration);
 	}
 }

--- a/project/src/backend/sdl/SDLGamepad.h
+++ b/project/src/backend/sdl/SDLGamepad.h
@@ -11,8 +11,15 @@ namespace lime {
 
 
 	class SDLGamepad {
-
 		public:
+			SDL_GameController *gameController = nullptr;
+			SDL_Joystick *joystick = nullptr;
+			
+			SDLGamepad() {}
+			SDLGamepad(SDL_GameController *_gameController);
+			~SDLGamepad();
+
+			void Rumble(int duration, double largeStrength, double smallStrength);
 
 			static bool Connect (int deviceID);
 			static int GetInstanceID (int deviceID);

--- a/project/src/backend/sdl/SDLGamepad.h
+++ b/project/src/backend/sdl/SDLGamepad.h
@@ -13,11 +13,15 @@ namespace lime {
 	class SDLGamepad {
 		public:
 			SDL_GameController *gameController = nullptr;
-			SDL_Joystick *joystick = nullptr;
 			
 			SDLGamepad() {}
-			SDLGamepad(SDL_GameController *_gameController);
-			~SDLGamepad();
+			SDLGamepad(SDL_GameController *_gameController) : gameController(_gameController) {}
+			
+			~SDLGamepad() {
+				// Close controller if opened
+				if (gameController != nullptr)
+					SDL_GameControllerClose(gameController);
+			}
 
 			void Rumble(int duration, double largeStrength, double smallStrength);
 
@@ -25,6 +29,13 @@ namespace lime {
 			static int GetInstanceID (int deviceID);
 			static bool Disconnect (int id);
 
+			SDLGamepad &operator=(SDLGamepad &&other)
+			{
+				SDL_GameController *temp = gameController;
+				gameController = other.gameController;
+				other.gameController = temp;
+				return *this;
+			}
 	};
 
 

--- a/project/src/backend/sdl/SDLGamepad.h
+++ b/project/src/backend/sdl/SDLGamepad.h
@@ -11,6 +11,7 @@ namespace lime {
 
 
 	class SDLGamepad {
+
 		public:
 			SDL_GameController *gameController = nullptr;
 			

--- a/project/src/backend/sdl/SDLGamepad.h
+++ b/project/src/backend/sdl/SDLGamepad.h
@@ -14,29 +14,30 @@ namespace lime {
 
 		public:
 			SDL_GameController *gameController = nullptr;
-			
-			SDLGamepad() {}
-			SDLGamepad(SDL_GameController *_gameController) : gameController(_gameController) {}
-			
-			~SDLGamepad() {
+
+			SDLGamepad () {}
+			SDLGamepad (SDL_GameController *_gameController) : gameController (_gameController) {}
+
+			~SDLGamepad () {
 				// Close controller if opened
 				if (gameController != nullptr)
-					SDL_GameControllerClose(gameController);
+					SDL_GameControllerClose (gameController);
 			}
 
-			void Rumble(double lowFrequencyRumble, double highFrequencyRumble, int duration);
+			void Rumble (double lowFrequencyRumble, double highFrequencyRumble, int duration);
 
 			static bool Connect (int deviceID);
 			static int GetInstanceID (int deviceID);
 			static bool Disconnect (int id);
 
-			SDLGamepad &operator=(SDLGamepad &&other)
+			SDLGamepad &operator= (SDLGamepad &&other)
 			{
 				SDL_GameController *temp = gameController;
 				gameController = other.gameController;
 				other.gameController = temp;
 				return *this;
 			}
+
 	};
 
 

--- a/project/src/backend/sdl/SDLGamepad.h
+++ b/project/src/backend/sdl/SDLGamepad.h
@@ -24,7 +24,7 @@ namespace lime {
 					SDL_GameControllerClose(gameController);
 			}
 
-			void Rumble(int duration, double largeStrength, double smallStrength);
+			void Rumble(double lowFrequencyRumble, double highFrequencyRumble, int duration);
 
 			static bool Connect (int deviceID);
 			static int GetInstanceID (int deviceID);

--- a/project/src/backend/sdl/SDLGamepad.h
+++ b/project/src/backend/sdl/SDLGamepad.h
@@ -13,30 +13,10 @@ namespace lime {
 	class SDLGamepad {
 
 		public:
-			SDL_GameController *gameController = nullptr;
-
-			SDLGamepad () {}
-			SDLGamepad (SDL_GameController *_gameController) : gameController (_gameController) {}
-
-			~SDLGamepad () {
-				// Close controller if opened
-				if (gameController != nullptr)
-					SDL_GameControllerClose (gameController);
-			}
-
-			void Rumble (double lowFrequencyRumble, double highFrequencyRumble, int duration);
 
 			static bool Connect (int deviceID);
 			static int GetInstanceID (int deviceID);
 			static bool Disconnect (int id);
-
-			SDLGamepad &operator= (SDLGamepad &&other)
-			{
-				SDL_GameController *temp = gameController;
-				gameController = other.gameController;
-				other.gameController = temp;
-				return *this;
-			}
 
 	};
 

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -1,14 +1,14 @@
 package lime._internal.backend.native;
 
 import haxe.io.Bytes;
-import lime.graphics.Image;
-import lime.graphics.ImageBuffer;
 import lime.graphics.opengl.GLBuffer;
 import lime.graphics.opengl.GLFramebuffer;
 import lime.graphics.opengl.GLProgram;
 import lime.graphics.opengl.GLRenderbuffer;
 import lime.graphics.opengl.GLShader;
 import lime.graphics.opengl.GLTexture;
+import lime.graphics.Image;
+import lime.graphics.ImageBuffer;
 import lime.math.Rectangle;
 import lime.media.openal.ALAuxiliaryEffectSlot;
 import lime.utils.DataPointer;
@@ -18,9 +18,9 @@ import lime.graphics.cairo.CairoGlyph;
 import lime.graphics.opengl.GL;
 import lime.math.Matrix3;
 import lime.math.Vector2;
-import lime.media.AudioBuffer;
 import lime.media.openal.ALContext;
 import lime.media.openal.ALDevice;
+import lime.media.AudioBuffer;
 import lime.system.DisplayMode;
 import lime.utils.ArrayBufferView;
 #end
@@ -415,7 +415,8 @@ class NativeCFFI
 		"lime_file_watcher_add_directory", "oobo", false));
 	private static var lime_file_watcher_remove_directory = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_file_watcher_remove_directory", "oov", false));
-	private static var lime_file_watcher_update = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_file_watcher_update", "ov", false));
+	private static var lime_file_watcher_update = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_file_watcher_update", "ov",
+		false));
 	private static var lime_font_get_ascender = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_font_get_ascender", "oi", false));
 	private static var lime_font_get_descender = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_font_get_descender", "oi", false));
 	private static var lime_font_get_family_name = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_font_get_family_name", "oo",
@@ -556,7 +557,8 @@ class NativeCFFI
 	private static var lime_window_alert = new cpp.Callable<cpp.Object->String->String->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_alert", "ossv",
 		false));
 	private static var lime_window_close = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_close", "ov", false));
-	private static var lime_window_context_flip = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_context_flip", "ov", false));
+	private static var lime_window_context_flip = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_context_flip", "ov",
+		false));
 	private static var lime_window_context_lock = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_window_context_lock", "oo",
 		false));
 	private static var lime_window_context_make_current = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -574,7 +576,8 @@ class NativeCFFI
 		"oo", false));
 	private static var lime_window_get_height = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_window_get_height", "oi", false));
 	private static var lime_window_get_id = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_window_get_id", "oi", false));
-	private static var lime_window_get_mouse_lock = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_window_get_mouse_lock", "ob", false));
+	private static var lime_window_get_mouse_lock = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_window_get_mouse_lock", "ob",
+		false));
 	private static var lime_window_get_opacity = new cpp.Callable<cpp.Object->Float>(cpp.Prime._loadPrime("lime", "lime_window_get_opacity", "od", false));
 	private static var lime_window_get_scale = new cpp.Callable<cpp.Object->Float>(cpp.Prime._loadPrime("lime", "lime_window_get_scale", "od", false));
 	private static var lime_window_get_text_input_enabled = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime",
@@ -585,11 +588,12 @@ class NativeCFFI
 	private static var lime_window_move = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_move", "oiiv", false));
 	private static var lime_window_read_pixels = new cpp.Callable<cpp.Object->cpp.Object->cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime",
 		"lime_window_read_pixels", "oooo", false));
-	private static var lime_window_resize = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_resize", "oiiv", false));
-	private static var lime_window_set_minimum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
-		"lime_window_set_minimum_size", "oiiv", false));
-	private static var lime_window_set_maximum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
-		"lime_window_set_maximum_size", "oiiv", false));
+	private static var lime_window_resize = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_resize", "oiiv",
+		false));
+	private static var lime_window_set_minimum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_set_minimum_size", "oiiv",
+		false));
+	private static var lime_window_set_maximum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_set_maximum_size", "oiiv",
+		false));
 	private static var lime_window_set_borderless = new cpp.Callable<cpp.Object->Bool->Bool>(cpp.Prime._loadPrime("lime", "lime_window_set_borderless", "obb",
 		false));
 	private static var lime_window_set_cursor = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_set_cursor", "oiv",
@@ -882,7 +886,8 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_file_dialog_open_file") private static function lime_file_dialog_open_file(title:String, filter:String, defaultPath:String):hl.Bytes
+	@:hlNative("lime", "hl_file_dialog_open_file") private static function lime_file_dialog_open_file(title:String, filter:String,
+			defaultPath:String):hl.Bytes
 	{
 		return null;
 	}
@@ -893,7 +898,8 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_file_dialog_save_file") private static function lime_file_dialog_save_file(title:String, filter:String, defaultPath:String):hl.Bytes
+	@:hlNative("lime", "hl_file_dialog_save_file") private static function lime_file_dialog_save_file(title:String, filter:String,
+			defaultPath:String):hl.Bytes
 	{
 		return null;
 	}
@@ -909,7 +915,8 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_file_watcher_remove_directory") private static function lime_file_watcher_remove_directory(handle:CFFIPointer, watchID:Int):Void {}
+	@:hlNative("lime", "hl_file_watcher_remove_directory") private static function lime_file_watcher_remove_directory(handle:CFFIPointer,
+		watchID:Int):Void {}
 
 	@:hlNative("lime", "hl_file_watcher_update") private static function lime_file_watcher_update(handle:CFFIPointer):Void {}
 
@@ -1372,9 +1379,11 @@ class NativeCFFI
 		return false;
 	}
 
-	@:hlNative("lime", "hl_window_set_text_input_enabled") private static function lime_window_set_text_input_enabled(handle:CFFIPointer, enabled:Bool):Void {}
+	@:hlNative("lime", "hl_window_set_text_input_enabled") private static function lime_window_set_text_input_enabled(handle:CFFIPointer,
+		enabled:Bool):Void {}
 
-	@:hlNative("lime", "hl_window_set_text_input_rect") private static function lime_window_set_text_input_rect(handle:CFFIPointer, rect:Rectangle):Void {}
+	@:hlNative("lime", "hl_window_set_text_input_rect") private static function lime_window_set_text_input_rect(handle:CFFIPointer,
+		rect:Rectangle):Void {}
 
 	@:hlNative("lime", "hl_window_set_title") private static function lime_window_set_title(handle:CFFIPointer, title:String):String
 	{
@@ -1388,10 +1397,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_window_warp_mouse") private static function lime_window_warp_mouse(handle:CFFIPointer, x:Int, y:Int):Void {}
 
-	@:hlNative("lime", "hl_window_get_opacity") private static function lime_window_get_opacity(handle:CFFIPointer):Float
-	{
-		return 0.0;
-	}
+	@:hlNative("lime", "hl_window_get_opacity") private static function lime_window_get_opacity(handle:CFFIPointer):Float { return 0.0; }
 
 	@:hlNative("lime", "hl_window_set_opacity") private static function lime_window_set_opacity(handle:CFFIPointer, value:Float):Void {}
 
@@ -1731,8 +1737,10 @@ class NativeCFFI
 	private static var lime_al_get_booleanv = new cpp.Callable<Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_booleanv", "iio", false));
 	private static var lime_al_gen_buffer = new cpp.Callable<Void->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_gen_buffer", "o", false));
 	private static var lime_al_gen_buffers = new cpp.Callable<Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_gen_buffers", "io", false));
-	private static var lime_al_get_buffer3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3f", "oio", false));
-	private static var lime_al_get_buffer3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3i", "oio", false));
+	private static var lime_al_get_buffer3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3f", "oio",
+		false));
+	private static var lime_al_get_buffer3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3i", "oio",
+		false));
 	private static var lime_al_get_bufferf = new cpp.Callable<cpp.Object->Int->cpp.Float32>(cpp.Prime._loadPrime("lime", "lime_al_get_bufferf", "oif", false));
 	private static var lime_al_get_bufferfv = new cpp.Callable<cpp.Object->Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_bufferfv", "oiio",
 		false));
@@ -1754,8 +1762,10 @@ class NativeCFFI
 	private static var lime_al_get_listeneri = new cpp.Callable<Int->Int>(cpp.Prime._loadPrime("lime", "lime_al_get_listeneri", "ii", false));
 	private static var lime_al_get_listeneriv = new cpp.Callable<Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_listeneriv", "iio", false));
 	private static var lime_al_get_proc_address = new cpp.Callable<String->Float>(cpp.Prime._loadPrime("lime", "lime_al_get_proc_address", "sd", false));
-	private static var lime_al_get_source3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3f", "oio", false));
-	private static var lime_al_get_source3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3i", "oio", false));
+	private static var lime_al_get_source3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3f", "oio",
+		false));
+	private static var lime_al_get_source3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3i", "oio",
+		false));
 	private static var lime_al_get_sourcef = new cpp.Callable<cpp.Object->Int->cpp.Float32>(cpp.Prime._loadPrime("lime", "lime_al_get_sourcef", "oif", false));
 	private static var lime_al_get_sourcefv = new cpp.Callable<cpp.Object->Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_sourcefv", "oiio",
 		false));
@@ -1765,7 +1775,8 @@ class NativeCFFI
 	private static var lime_al_get_string = new cpp.Callable<Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_string", "io", false));
 	private static var lime_al_is_buffer = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_buffer", "ob", false));
 	private static var lime_al_is_enabled = new cpp.Callable<Int->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_enabled", "ib", false));
-	private static var lime_al_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_extension_present", "sb", false));
+	private static var lime_al_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_extension_present", "sb",
+		false));
 	private static var lime_al_is_source = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_source", "ob", false));
 	private static var lime_al_listener3f = new cpp.Callable<Int->cpp.Float32->cpp.Float32->cpp.Float32->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_al_listener3f", "ifffv", false));
@@ -1775,7 +1786,8 @@ class NativeCFFI
 	private static var lime_al_listeneri = new cpp.Callable<Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_listeneri", "iiv", false));
 	private static var lime_al_listeneriv = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_listeneriv", "iov", false));
 	private static var lime_al_source_pause = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_pause", "ov", false));
-	private static var lime_al_source_pausev = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_pausev", "iov", false));
+	private static var lime_al_source_pausev = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_pausev", "iov",
+		false));
 	private static var lime_al_source_play = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_play", "ov", false));
 	private static var lime_al_source_playv = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_playv", "iov", false));
 	private static var lime_al_source_queue_buffers = new cpp.Callable<cpp.Object->Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -1803,7 +1815,8 @@ class NativeCFFI
 	private static var lime_alc_close_device = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_alc_close_device", "ob", false));
 	private static var lime_alc_create_context = new cpp.Callable<cpp.Object->cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_create_context",
 		"ooo", false));
-	private static var lime_alc_destroy_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_destroy_context", "ov", false));
+	private static var lime_alc_destroy_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_destroy_context", "ov",
+		false));
 	private static var lime_alc_get_contexts_device = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_get_contexts_device",
 		"oo", false));
 	private static var lime_alc_get_current_context = new cpp.Callable<Void->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_get_current_context", "o",
@@ -1816,9 +1829,11 @@ class NativeCFFI
 		false));
 	private static var lime_alc_open_device = new cpp.Callable<String->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_open_device", "so", false));
 	private static var lime_alc_pause_device = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_pause_device", "ov", false));
-	private static var lime_alc_process_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_process_context", "ov", false));
+	private static var lime_alc_process_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_process_context", "ov",
+		false));
 	private static var lime_alc_resume_device = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_resume_device", "ov", false));
-	private static var lime_alc_suspend_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_suspend_context", "ov", false));
+	private static var lime_alc_suspend_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_suspend_context", "ov",
+		false));
 	private static var lime_al_gen_filter = new cpp.Callable<Void->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_gen_filter", "o", false));
 	private static var lime_al_filteri = new cpp.Callable<cpp.Object->Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_filteri", "oiov",
 		false));
@@ -2227,7 +2242,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_al_source3f") private static function lime_al_source3f(source:CFFIPointer, param:Int, value1:hl.F32, value2:hl.F32,
 		value3:hl.F32):Void {}
 
-	@:hlNative("lime", "hl_al_source3i") private static function lime_al_source3i(source:CFFIPointer, param:Int, value1:Dynamic, value2:Int, value3:Int):Void {}
+	@:hlNative("lime", "hl_al_source3i") private static function lime_al_source3i(source:CFFIPointer, param:Int, value1:Dynamic, value2:Int,
+		value3:Int):Void {}
 
 	@:hlNative("lime", "hl_al_sourcef") private static function lime_al_sourcef(source:CFFIPointer, param:Int, value:hl.F32):Void {}
 
@@ -2596,7 +2612,8 @@ class NativeCFFI
 	private static var lime_cairo_arc_negative = new cpp.Callable<cpp.Object->Float->Float->Float->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_arc_negative", "odddddv", false));
 	private static var lime_cairo_clip = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_clip", "ov", false));
-	private static var lime_cairo_clip_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_clip_preserve", "ov", false));
+	private static var lime_cairo_clip_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_clip_preserve", "ov",
+		false));
 	private static var lime_cairo_clip_extents = new cpp.Callable<cpp.Object->Float->Float->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_clip_extents", "oddddv", false));
 	private static var lime_cairo_close_path = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_close_path", "ov", false));
@@ -2607,7 +2624,8 @@ class NativeCFFI
 	private static var lime_cairo_fill = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_fill", "ov", false));
 	private static var lime_cairo_fill_extents = new cpp.Callable<cpp.Object->Float->Float->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_fill_extents", "oddddv", false));
-	private static var lime_cairo_fill_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_fill_preserve", "ov", false));
+	private static var lime_cairo_fill_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_fill_preserve", "ov",
+		false));
 	private static var lime_cairo_get_antialias = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_cairo_get_antialias", "oi", false));
 	private static var lime_cairo_get_current_point = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_cairo_get_current_point",
 		"oo", false));
@@ -2634,8 +2652,10 @@ class NativeCFFI
 		false));
 	private static var lime_cairo_identity_matrix = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_identity_matrix", "ov",
 		false));
-	private static var lime_cairo_in_clip = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_clip", "oddb", false));
-	private static var lime_cairo_in_fill = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_fill", "oddb", false));
+	private static var lime_cairo_in_clip = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_clip", "oddb",
+		false));
+	private static var lime_cairo_in_fill = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_fill", "oddb",
+		false));
 	private static var lime_cairo_in_stroke = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_stroke", "oddb",
 		false));
 	private static var lime_cairo_line_to = new cpp.Callable<cpp.Object->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_line_to", "oddv",
@@ -2667,7 +2687,8 @@ class NativeCFFI
 	private static var lime_cairo_restore = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_restore", "ov", false));
 	private static var lime_cairo_rotate = new cpp.Callable<cpp.Object->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_rotate", "odv", false));
 	private static var lime_cairo_save = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_save", "ov", false));
-	private static var lime_cairo_scale = new cpp.Callable<cpp.Object->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_scale", "oddv", false));
+	private static var lime_cairo_scale = new cpp.Callable<cpp.Object->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_scale", "oddv",
+		false));
 	private static var lime_cairo_set_antialias = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_set_antialias", "oiv",
 		false));
 	private static var lime_cairo_set_dash = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_set_dash", "oov",
@@ -2785,7 +2806,8 @@ class NativeCFFI
 		"lime_cairo_pattern_set_filter", "oiv", false));
 	private static var lime_cairo_pattern_set_matrix = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_pattern_set_matrix", "oov", false));
-	private static var lime_cairo_surface_flush = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_surface_flush", "ov", false));
+	private static var lime_cairo_surface_flush = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_surface_flush", "ov",
+		false));
 	#end
 	#end
 	#if (neko || cppia)
@@ -2930,8 +2952,8 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_cairo_curve_to") private static function lime_cairo_curve_to(handle:CFFIPointer, x1:Float, y1:Float, x2:Float, y2:Float, x3:Float,
-		y3:Float):Void {}
+	@:hlNative("lime", "hl_cairo_curve_to") private static function lime_cairo_curve_to(handle:CFFIPointer, x1:Float, y1:Float, x2:Float, y2:Float,
+		x3:Float, y3:Float):Void {}
 
 	@:hlNative("lime", "hl_cairo_fill") private static function lime_cairo_fill(handle:CFFIPointer):Void {}
 
@@ -3071,7 +3093,8 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_cairo_push_group") private static function lime_cairo_push_group(handle:CFFIPointer):Void {}
 
-	@:hlNative("lime", "hl_cairo_push_group_with_content") private static function lime_cairo_push_group_with_content(handle:CFFIPointer, content:Int):Void {}
+	@:hlNative("lime", "hl_cairo_push_group_with_content") private static function lime_cairo_push_group_with_content(handle:CFFIPointer,
+		content:Int):Void {}
 
 	@:hlNative("lime", "hl_cairo_rectangle") private static function lime_cairo_rectangle(handle:CFFIPointer, x:Float, y:Float, width:Float,
 		height:Float):Void {}
@@ -3124,8 +3147,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_cairo_set_source_rgba") private static function lime_cairo_set_source_rgba(handle:CFFIPointer, r:Float, g:Float, b:Float,
 		a:Float):Void {}
 
-	@:hlNative("lime", "hl_cairo_set_source_surface") private static function lime_cairo_set_source_surface(handle:CFFIPointer, surface:CFFIPointer, x:Float,
-		y:Float):Void {}
+	@:hlNative("lime", "hl_cairo_set_source_surface") private static function lime_cairo_set_source_surface(handle:CFFIPointer, surface:CFFIPointer,
+		x:Float, y:Float):Void {}
 
 	@:hlNative("lime", "hl_cairo_set_tolerance") private static function lime_cairo_set_tolerance(handle:CFFIPointer, tolerance:Float):Void {}
 
@@ -3193,12 +3216,14 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_cairo_font_options_set_antialias") private static function lime_cairo_font_options_set_antialias(handle:CFFIPointer, v:Int):Void {}
+	@:hlNative("lime", "hl_cairo_font_options_set_antialias") private static function lime_cairo_font_options_set_antialias(handle:CFFIPointer,
+		v:Int):Void {}
 
 	@:hlNative("lime", "hl_cairo_font_options_set_hint_metrics") private static function lime_cairo_font_options_set_hint_metrics(handle:CFFIPointer,
 		v:Int):Void {}
 
-	@:hlNative("lime", "hl_cairo_font_options_set_hint_style") private static function lime_cairo_font_options_set_hint_style(handle:CFFIPointer, v:Int):Void {}
+	@:hlNative("lime", "hl_cairo_font_options_set_hint_style") private static function lime_cairo_font_options_set_hint_style(handle:CFFIPointer,
+		v:Int):Void {}
 
 	@:hlNative("lime", "hl_cairo_font_options_set_subpixel_order") private static function lime_cairo_font_options_set_subpixel_order(handle:CFFIPointer,
 		v:Int):Void {}
@@ -3208,7 +3233,8 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_cairo_image_surface_create") private static function lime_cairo_image_surface_create(format:Int, width:Int, height:Int):CFFIPointer
+	@:hlNative("lime", "hl_cairo_image_surface_create") private static function lime_cairo_image_surface_create(format:Int, width:Int,
+			height:Int):CFFIPointer
 	{
 		return null;
 	}
@@ -3244,8 +3270,8 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_cairo_pattern_add_color_stop_rgb") private static function lime_cairo_pattern_add_color_stop_rgb(handle:CFFIPointer, offset:Float,
-		red:Float, green:Float, blue:Float):Void {}
+	@:hlNative("lime", "hl_cairo_pattern_add_color_stop_rgb") private static function lime_cairo_pattern_add_color_stop_rgb(handle:CFFIPointer,
+		offset:Float, red:Float, green:Float, blue:Float):Void {}
 
 	@:hlNative("lime", "hl_cairo_pattern_add_color_stop_rgba") private static function lime_cairo_pattern_add_color_stop_rgba(handle:CFFIPointer,
 		offset:Float, red:Float, green:Float, blue:Float, alpha:Float):Void {}
@@ -4365,7 +4391,8 @@ class NativeCFFI
 	private static var lime_gl_get_vertex_attribi = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribi", "iii", false));
 	private static var lime_gl_get_vertex_attribiv = new cpp.Callable<Int->Int->lime.utils.DataPointer->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_gl_get_vertex_attribiv", "iidv", false));
-	private static var lime_gl_get_vertex_attribii = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribii", "iii", false));
+	private static var lime_gl_get_vertex_attribii = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribii", "iii",
+		false));
 	private static var lime_gl_get_vertex_attribiiv = new cpp.Callable<Int->Int->lime.utils.DataPointer->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_gl_get_vertex_attribiiv", "iidv", false));
 	private static var lime_gl_get_vertex_attribiui = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribiui", "iii",
@@ -4874,7 +4901,8 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_gl_buffer_data") private static function lime_gl_buffer_data(target:Int, size:Int, srcData:DataPointer, usage:Int):Void {}
 
-	@:hlNative("lime", "hl_gl_buffer_sub_data") private static function lime_gl_buffer_sub_data(target:Int, offset:Int, size:Int, srcData:DataPointer):Void {}
+	@:hlNative("lime", "hl_gl_buffer_sub_data") private static function lime_gl_buffer_sub_data(target:Int, offset:Int, size:Int,
+		srcData:DataPointer):Void {}
 
 	@:hlNative("lime", "hl_gl_check_framebuffer_status") private static function lime_gl_check_framebuffer_status(target:Int):Int
 	{
@@ -4891,7 +4919,8 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_gl_clear_bufferuiv") private static function lime_gl_clear_bufferuiv(buffer:Int, drawBuffer:Int, data:DataPointer):Void {}
 
-	@:hlNative("lime", "hl_gl_client_wait_sync") private static function lime_gl_client_wait_sync(sync:CFFIPointer, flags:Int, timeoutA:Int, timeoutB:Int):Int
+	@:hlNative("lime", "hl_gl_client_wait_sync") private static function lime_gl_client_wait_sync(sync:CFFIPointer, flags:Int, timeoutA:Int,
+			timeoutB:Int):Int
 	{
 		return 0;
 	}
@@ -5114,7 +5143,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_gl_get_buffer_parameteri64v") private static function lime_gl_get_buffer_parameteri64v(target:Int, index:Int,
 		params:DataPointer):Void {}
 
-	@:hlNative("lime", "hl_gl_get_buffer_parameteriv") private static function lime_gl_get_buffer_parameteriv(target:Int, pname:Int, params:DataPointer):Void {}
+	@:hlNative("lime", "hl_gl_get_buffer_parameteriv") private static function lime_gl_get_buffer_parameteriv(target:Int, pname:Int,
+		params:DataPointer):Void {}
 
 	@:hlNative("lime", "hl_gl_get_buffer_pointerv") private static function lime_gl_get_buffer_pointerv(target:Int, pname:Int):DataPointer
 	{
@@ -5476,8 +5506,8 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_gl_scissor") private static function lime_gl_scissor(x:Int, y:Int, width:Int, height:Int):Void {}
 
-	@:hlNative("lime", "hl_gl_shader_binary") private static function lime_gl_shader_binary(shaders:hl.NativeArray<Int>, binaryformat:Int, binary:DataPointer,
-		length:Int):Void {}
+	@:hlNative("lime", "hl_gl_shader_binary") private static function lime_gl_shader_binary(shaders:hl.NativeArray<Int>, binaryformat:Int,
+		binary:DataPointer, length:Int):Void {}
 
 	@:hlNative("lime", "hl_gl_shader_source") private static function lime_gl_shader_source(shader:Int, source:String):Void {}
 
@@ -5509,8 +5539,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_gl_tex_storage_3d") private static function lime_gl_tex_storage_3d(target:Int, level:Int, internalformat:Int, width:Int,
 		height:Int, depth:Int):Void {}
 
-	@:hlNative("lime", "hl_gl_tex_sub_image_2d") private static function lime_gl_tex_sub_image_2d(target:Int, level:Int, xoffset:Int, yoffset:Int, width:Int,
-		height:Int, format:Int, type:Int, data:DataPointer):Void {}
+	@:hlNative("lime", "hl_gl_tex_sub_image_2d") private static function lime_gl_tex_sub_image_2d(target:Int, level:Int, xoffset:Int, yoffset:Int,
+		width:Int, height:Int, format:Int, type:Int, data:DataPointer):Void {}
 
 	@:hlNative("lime", "hl_gl_tex_sub_image_3d") private static function lime_gl_tex_sub_image_3d(target:Int, level:Int, xoffset:Int, yoffset:Int,
 		zoffset:Int, width:Int, height:Int, depth:Int, format:Int, type:Int, data:DataPointer):Void {}
@@ -5877,7 +5907,8 @@ class NativeCFFI
 	private static var lime_hb_blob_is_immutable = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_hb_blob_is_immutable", "ob", false));
 	private static var lime_hb_blob_make_immutable = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_blob_make_immutable", "ov",
 		false));
-	private static var lime_hb_buffer_add = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add", "oiiv", false));
+	private static var lime_hb_buffer_add = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add", "oiiv",
+		false));
 	private static var lime_hb_buffer_add_codepoints = new cpp.Callable<cpp.Object->lime.utils.DataPointer->Int->Int->Int->
 		cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add_codepoints", "odiiiv", false));
 	private static var lime_hb_buffer_add_utf8 = new cpp.Callable<cpp.Object->String->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -5962,7 +5993,8 @@ class NativeCFFI
 		"oiv", false));
 	private static var lime_hb_face_set_index = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_face_set_index", "oiv",
 		false));
-	private static var lime_hb_face_set_upem = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_face_set_upem", "oiv", false));
+	private static var lime_hb_face_set_upem = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_face_set_upem", "oiv",
+		false));
 	private static var lime_hb_feature_from_string = new cpp.Callable<String->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_feature_from_string", "so",
 		false));
 	private static var lime_hb_feature_to_string = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_feature_to_string", "oo",
@@ -5980,7 +6012,8 @@ class NativeCFFI
 		"lime_hb_font_get_glyph_kerning_for_direction", "oiiio", false));
 	private static var lime_hb_font_get_glyph_origin_for_direction = new cpp.Callable<cpp.Object->Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime",
 		"lime_hb_font_get_glyph_origin_for_direction", "oiio", false));
-	private static var lime_hb_font_get_parent = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_parent", "oo", false));
+	private static var lime_hb_font_get_parent = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_parent", "oo",
+		false));
 	private static var lime_hb_font_get_ppem = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_ppem", "oo", false));
 	private static var lime_hb_font_get_scale = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_scale", "oo", false));
 	private static var lime_hb_font_glyph_from_string = new cpp.Callable<cpp.Object->String->Int>(cpp.Prime._loadPrime("lime",
@@ -6318,7 +6351,8 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_hb_buffer_set_cluster_level") private static function lime_hb_buffer_set_cluster_level(buffer:CFFIPointer, clusterLevel:Int):Void {}
+	@:hlNative("lime", "hl_hb_buffer_set_cluster_level") private static function lime_hb_buffer_set_cluster_level(buffer:CFFIPointer,
+		clusterLevel:Int):Void {}
 
 	@:hlNative("lime", "hl_hb_buffer_set_content_type") private static function lime_hb_buffer_set_content_type(buffer:CFFIPointer, contentType:Int):Void {}
 
@@ -6477,8 +6511,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_hb_font_set_scale") private static function lime_hb_font_set_scale(font:CFFIPointer, xScale:Int, yScale:Int):Void {}
 
 	@:hlNative("lime",
-		"hl_hb_font_subtract_glyph_origin_for_direction") private static function lime_hb_font_subtract_glyph_origin_for_direction(font:CFFIPointer, glyph:Int,
-		direction:Int, x:Int, y:Int):Void {}
+		"hl_hb_font_subtract_glyph_origin_for_direction") private static function lime_hb_font_subtract_glyph_origin_for_direction(font:CFFIPointer,
+		glyph:Int, direction:Int, x:Int, y:Int):Void {}
 
 	@:hlNative("lime", "hl_hb_ft_font_create") private static function lime_hb_ft_font_create(font:CFFIPointer):CFFIPointer
 	{
@@ -6599,7 +6633,8 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_hb_set_union") private static function lime_hb_set_union(set:CFFIPointer, other:CFFIPointer):Void {}
 
-	@:hlNative("lime", "hl_hb_shape") private static function lime_hb_shape(font:CFFIPointer, buffer:CFFIPointer, features:hl.NativeArray<CFFIPointer>):Void {}
+	@:hlNative("lime", "hl_hb_shape") private static function lime_hb_shape(font:CFFIPointer, buffer:CFFIPointer,
+		features:hl.NativeArray<CFFIPointer>):Void {}
 	#end
 	#end
 	#if (lime_cffi && !macro && lime_vorbis)
@@ -6796,7 +6831,8 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_vorbis_file_pcm_seek_lap") private static function lime_vorbis_file_pcm_seek_lap(vorbisFile:CFFIPointer, posLow:Int, posHigh:Int):Int
+	@:hlNative("lime", "hl_vorbis_file_pcm_seek_lap") private static function lime_vorbis_file_pcm_seek_lap(vorbisFile:CFFIPointer, posLow:Int,
+			posHigh:Int):Int
 	{
 		return 0;
 	}
@@ -6818,7 +6854,8 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_vorbis_file_raw_seek_lap") private static function lime_vorbis_file_raw_seek_lap(vorbisFile:CFFIPointer, posLow:Int, posHigh:Int):Int
+	@:hlNative("lime", "hl_vorbis_file_raw_seek_lap") private static function lime_vorbis_file_raw_seek_lap(vorbisFile:CFFIPointer, posLow:Int,
+			posHigh:Int):Int
 	{
 		return 0;
 	}

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -1,14 +1,14 @@
 package lime._internal.backend.native;
 
 import haxe.io.Bytes;
+import lime.graphics.Image;
+import lime.graphics.ImageBuffer;
 import lime.graphics.opengl.GLBuffer;
 import lime.graphics.opengl.GLFramebuffer;
 import lime.graphics.opengl.GLProgram;
 import lime.graphics.opengl.GLRenderbuffer;
 import lime.graphics.opengl.GLShader;
 import lime.graphics.opengl.GLTexture;
-import lime.graphics.Image;
-import lime.graphics.ImageBuffer;
 import lime.math.Rectangle;
 import lime.media.openal.ALAuxiliaryEffectSlot;
 import lime.utils.DataPointer;
@@ -18,9 +18,9 @@ import lime.graphics.cairo.CairoGlyph;
 import lime.graphics.opengl.GL;
 import lime.math.Matrix3;
 import lime.math.Vector2;
+import lime.media.AudioBuffer;
 import lime.media.openal.ALContext;
 import lime.media.openal.ALDevice;
-import lime.media.AudioBuffer;
 import lime.system.DisplayMode;
 import lime.utils.ArrayBufferView;
 #end
@@ -156,6 +156,8 @@ class NativeCFFI
 	@:cffi private static function lime_gamepad_get_device_guid(id:Int):Dynamic;
 
 	@:cffi private static function lime_gamepad_get_device_name(id:Int):Dynamic;
+
+	@:cffi private static function lime_gamepad_rumble(id:Int, duration:Int, largeStrength:Float, smallStrength:Float):Void;
 
 	@:cffi private static function lime_gamepad_event_manager_register(callback:Dynamic, eventObject:Dynamic):Void;
 
@@ -413,8 +415,7 @@ class NativeCFFI
 		"lime_file_watcher_add_directory", "oobo", false));
 	private static var lime_file_watcher_remove_directory = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_file_watcher_remove_directory", "oov", false));
-	private static var lime_file_watcher_update = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_file_watcher_update", "ov",
-		false));
+	private static var lime_file_watcher_update = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_file_watcher_update", "ov", false));
 	private static var lime_font_get_ascender = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_font_get_ascender", "oi", false));
 	private static var lime_font_get_descender = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_font_get_descender", "oi", false));
 	private static var lime_font_get_family_name = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_font_get_family_name", "oo",
@@ -447,6 +448,8 @@ class NativeCFFI
 	private static var lime_gamepad_get_device_guid = new cpp.Callable<Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_gamepad_get_device_guid", "io",
 		false));
 	private static var lime_gamepad_get_device_name = new cpp.Callable<Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_gamepad_get_device_name", "io",
+		false));
+	private static var lime_gamepad_rumble = new cpp.Callable<Int->Int->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_gamepad_rumble", "iiddv",
 		false));
 	private static var lime_gamepad_event_manager_register = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_gamepad_event_manager_register", "oov", false));
@@ -553,8 +556,7 @@ class NativeCFFI
 	private static var lime_window_alert = new cpp.Callable<cpp.Object->String->String->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_alert", "ossv",
 		false));
 	private static var lime_window_close = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_close", "ov", false));
-	private static var lime_window_context_flip = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_context_flip", "ov",
-		false));
+	private static var lime_window_context_flip = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_context_flip", "ov", false));
 	private static var lime_window_context_lock = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_window_context_lock", "oo",
 		false));
 	private static var lime_window_context_make_current = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -572,8 +574,7 @@ class NativeCFFI
 		"oo", false));
 	private static var lime_window_get_height = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_window_get_height", "oi", false));
 	private static var lime_window_get_id = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_window_get_id", "oi", false));
-	private static var lime_window_get_mouse_lock = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_window_get_mouse_lock", "ob",
-		false));
+	private static var lime_window_get_mouse_lock = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_window_get_mouse_lock", "ob", false));
 	private static var lime_window_get_opacity = new cpp.Callable<cpp.Object->Float>(cpp.Prime._loadPrime("lime", "lime_window_get_opacity", "od", false));
 	private static var lime_window_get_scale = new cpp.Callable<cpp.Object->Float>(cpp.Prime._loadPrime("lime", "lime_window_get_scale", "od", false));
 	private static var lime_window_get_text_input_enabled = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime",
@@ -584,12 +585,11 @@ class NativeCFFI
 	private static var lime_window_move = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_move", "oiiv", false));
 	private static var lime_window_read_pixels = new cpp.Callable<cpp.Object->cpp.Object->cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime",
 		"lime_window_read_pixels", "oooo", false));
-	private static var lime_window_resize = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_resize", "oiiv",
-		false));
-	private static var lime_window_set_minimum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_set_minimum_size", "oiiv",
-		false));
-	private static var lime_window_set_maximum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_set_maximum_size", "oiiv",
-		false));
+	private static var lime_window_resize = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_resize", "oiiv", false));
+	private static var lime_window_set_minimum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
+		"lime_window_set_minimum_size", "oiiv", false));
+	private static var lime_window_set_maximum_size = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
+		"lime_window_set_maximum_size", "oiiv", false));
 	private static var lime_window_set_borderless = new cpp.Callable<cpp.Object->Bool->Bool>(cpp.Prime._loadPrime("lime", "lime_window_set_borderless", "obb",
 		false));
 	private static var lime_window_set_cursor = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_set_cursor", "oiv",
@@ -680,6 +680,7 @@ class NativeCFFI
 	private static var lime_gamepad_add_mappings = CFFI.load("lime", "lime_gamepad_add_mappings", 1);
 	private static var lime_gamepad_get_device_guid = CFFI.load("lime", "lime_gamepad_get_device_guid", 1);
 	private static var lime_gamepad_get_device_name = CFFI.load("lime", "lime_gamepad_get_device_name", 1);
+	private static var lime_gamepad_rumble = CFFI.load("lime", "lime_gamepad_rumble", 4);
 	private static var lime_gamepad_event_manager_register = CFFI.load("lime", "lime_gamepad_event_manager_register", 2);
 	private static var lime_gzip_compress = CFFI.load("lime", "lime_gzip_compress", 2);
 	private static var lime_gzip_decompress = CFFI.load("lime", "lime_gzip_decompress", 2);
@@ -881,8 +882,7 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_file_dialog_open_file") private static function lime_file_dialog_open_file(title:String, filter:String,
-			defaultPath:String):hl.Bytes
+	@:hlNative("lime", "hl_file_dialog_open_file") private static function lime_file_dialog_open_file(title:String, filter:String, defaultPath:String):hl.Bytes
 	{
 		return null;
 	}
@@ -893,8 +893,7 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_file_dialog_save_file") private static function lime_file_dialog_save_file(title:String, filter:String,
-			defaultPath:String):hl.Bytes
+	@:hlNative("lime", "hl_file_dialog_save_file") private static function lime_file_dialog_save_file(title:String, filter:String, defaultPath:String):hl.Bytes
 	{
 		return null;
 	}
@@ -910,8 +909,7 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_file_watcher_remove_directory") private static function lime_file_watcher_remove_directory(handle:CFFIPointer,
-		watchID:Int):Void {}
+	@:hlNative("lime", "hl_file_watcher_remove_directory") private static function lime_file_watcher_remove_directory(handle:CFFIPointer, watchID:Int):Void {}
 
 	@:hlNative("lime", "hl_file_watcher_update") private static function lime_file_watcher_update(handle:CFFIPointer):Void {}
 
@@ -1011,6 +1009,8 @@ class NativeCFFI
 	{
 		return null;
 	}
+
+	@:hlNative("lime", "hl_gamepad_rumble") private static function lime_gamepad_rumble(id:Int, duration:Int, largeStrength:Float, smallStrength:Float):Void {}
 
 	@:hlNative("lime", "hl_gamepad_event_manager_register") private static function lime_gamepad_event_manager_register(callback:Void->Void,
 		eventObject:GamepadEventInfo):Void {}
@@ -1372,11 +1372,9 @@ class NativeCFFI
 		return false;
 	}
 
-	@:hlNative("lime", "hl_window_set_text_input_enabled") private static function lime_window_set_text_input_enabled(handle:CFFIPointer,
-		enabled:Bool):Void {}
+	@:hlNative("lime", "hl_window_set_text_input_enabled") private static function lime_window_set_text_input_enabled(handle:CFFIPointer, enabled:Bool):Void {}
 
-	@:hlNative("lime", "hl_window_set_text_input_rect") private static function lime_window_set_text_input_rect(handle:CFFIPointer,
-		rect:Rectangle):Void {}
+	@:hlNative("lime", "hl_window_set_text_input_rect") private static function lime_window_set_text_input_rect(handle:CFFIPointer, rect:Rectangle):Void {}
 
 	@:hlNative("lime", "hl_window_set_title") private static function lime_window_set_title(handle:CFFIPointer, title:String):String
 	{
@@ -1390,7 +1388,10 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_window_warp_mouse") private static function lime_window_warp_mouse(handle:CFFIPointer, x:Int, y:Int):Void {}
 
-	@:hlNative("lime", "hl_window_get_opacity") private static function lime_window_get_opacity(handle:CFFIPointer):Float { return 0.0; }
+	@:hlNative("lime", "hl_window_get_opacity") private static function lime_window_get_opacity(handle:CFFIPointer):Float
+	{
+		return 0.0;
+	}
 
 	@:hlNative("lime", "hl_window_set_opacity") private static function lime_window_set_opacity(handle:CFFIPointer, value:Float):Void {}
 
@@ -1730,10 +1731,8 @@ class NativeCFFI
 	private static var lime_al_get_booleanv = new cpp.Callable<Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_booleanv", "iio", false));
 	private static var lime_al_gen_buffer = new cpp.Callable<Void->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_gen_buffer", "o", false));
 	private static var lime_al_gen_buffers = new cpp.Callable<Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_gen_buffers", "io", false));
-	private static var lime_al_get_buffer3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3f", "oio",
-		false));
-	private static var lime_al_get_buffer3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3i", "oio",
-		false));
+	private static var lime_al_get_buffer3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3f", "oio", false));
+	private static var lime_al_get_buffer3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_buffer3i", "oio", false));
 	private static var lime_al_get_bufferf = new cpp.Callable<cpp.Object->Int->cpp.Float32>(cpp.Prime._loadPrime("lime", "lime_al_get_bufferf", "oif", false));
 	private static var lime_al_get_bufferfv = new cpp.Callable<cpp.Object->Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_bufferfv", "oiio",
 		false));
@@ -1755,10 +1754,8 @@ class NativeCFFI
 	private static var lime_al_get_listeneri = new cpp.Callable<Int->Int>(cpp.Prime._loadPrime("lime", "lime_al_get_listeneri", "ii", false));
 	private static var lime_al_get_listeneriv = new cpp.Callable<Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_listeneriv", "iio", false));
 	private static var lime_al_get_proc_address = new cpp.Callable<String->Float>(cpp.Prime._loadPrime("lime", "lime_al_get_proc_address", "sd", false));
-	private static var lime_al_get_source3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3f", "oio",
-		false));
-	private static var lime_al_get_source3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3i", "oio",
-		false));
+	private static var lime_al_get_source3f = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3f", "oio", false));
+	private static var lime_al_get_source3i = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_source3i", "oio", false));
 	private static var lime_al_get_sourcef = new cpp.Callable<cpp.Object->Int->cpp.Float32>(cpp.Prime._loadPrime("lime", "lime_al_get_sourcef", "oif", false));
 	private static var lime_al_get_sourcefv = new cpp.Callable<cpp.Object->Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_sourcefv", "oiio",
 		false));
@@ -1768,8 +1765,7 @@ class NativeCFFI
 	private static var lime_al_get_string = new cpp.Callable<Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_get_string", "io", false));
 	private static var lime_al_is_buffer = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_buffer", "ob", false));
 	private static var lime_al_is_enabled = new cpp.Callable<Int->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_enabled", "ib", false));
-	private static var lime_al_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_extension_present", "sb",
-		false));
+	private static var lime_al_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_extension_present", "sb", false));
 	private static var lime_al_is_source = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_source", "ob", false));
 	private static var lime_al_listener3f = new cpp.Callable<Int->cpp.Float32->cpp.Float32->cpp.Float32->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_al_listener3f", "ifffv", false));
@@ -1779,8 +1775,7 @@ class NativeCFFI
 	private static var lime_al_listeneri = new cpp.Callable<Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_listeneri", "iiv", false));
 	private static var lime_al_listeneriv = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_listeneriv", "iov", false));
 	private static var lime_al_source_pause = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_pause", "ov", false));
-	private static var lime_al_source_pausev = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_pausev", "iov",
-		false));
+	private static var lime_al_source_pausev = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_pausev", "iov", false));
 	private static var lime_al_source_play = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_play", "ov", false));
 	private static var lime_al_source_playv = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_source_playv", "iov", false));
 	private static var lime_al_source_queue_buffers = new cpp.Callable<cpp.Object->Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -1808,8 +1803,7 @@ class NativeCFFI
 	private static var lime_alc_close_device = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_alc_close_device", "ob", false));
 	private static var lime_alc_create_context = new cpp.Callable<cpp.Object->cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_create_context",
 		"ooo", false));
-	private static var lime_alc_destroy_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_destroy_context", "ov",
-		false));
+	private static var lime_alc_destroy_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_destroy_context", "ov", false));
 	private static var lime_alc_get_contexts_device = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_get_contexts_device",
 		"oo", false));
 	private static var lime_alc_get_current_context = new cpp.Callable<Void->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_get_current_context", "o",
@@ -1822,11 +1816,9 @@ class NativeCFFI
 		false));
 	private static var lime_alc_open_device = new cpp.Callable<String->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_open_device", "so", false));
 	private static var lime_alc_pause_device = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_pause_device", "ov", false));
-	private static var lime_alc_process_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_process_context", "ov",
-		false));
+	private static var lime_alc_process_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_process_context", "ov", false));
 	private static var lime_alc_resume_device = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_resume_device", "ov", false));
-	private static var lime_alc_suspend_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_suspend_context", "ov",
-		false));
+	private static var lime_alc_suspend_context = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_alc_suspend_context", "ov", false));
 	private static var lime_al_gen_filter = new cpp.Callable<Void->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_al_gen_filter", "o", false));
 	private static var lime_al_filteri = new cpp.Callable<cpp.Object->Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_filteri", "oiov",
 		false));
@@ -2235,8 +2227,7 @@ class NativeCFFI
 	@:hlNative("lime", "hl_al_source3f") private static function lime_al_source3f(source:CFFIPointer, param:Int, value1:hl.F32, value2:hl.F32,
 		value3:hl.F32):Void {}
 
-	@:hlNative("lime", "hl_al_source3i") private static function lime_al_source3i(source:CFFIPointer, param:Int, value1:Dynamic, value2:Int,
-		value3:Int):Void {}
+	@:hlNative("lime", "hl_al_source3i") private static function lime_al_source3i(source:CFFIPointer, param:Int, value1:Dynamic, value2:Int, value3:Int):Void {}
 
 	@:hlNative("lime", "hl_al_sourcef") private static function lime_al_sourcef(source:CFFIPointer, param:Int, value:hl.F32):Void {}
 
@@ -2605,8 +2596,7 @@ class NativeCFFI
 	private static var lime_cairo_arc_negative = new cpp.Callable<cpp.Object->Float->Float->Float->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_arc_negative", "odddddv", false));
 	private static var lime_cairo_clip = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_clip", "ov", false));
-	private static var lime_cairo_clip_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_clip_preserve", "ov",
-		false));
+	private static var lime_cairo_clip_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_clip_preserve", "ov", false));
 	private static var lime_cairo_clip_extents = new cpp.Callable<cpp.Object->Float->Float->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_clip_extents", "oddddv", false));
 	private static var lime_cairo_close_path = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_close_path", "ov", false));
@@ -2617,8 +2607,7 @@ class NativeCFFI
 	private static var lime_cairo_fill = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_fill", "ov", false));
 	private static var lime_cairo_fill_extents = new cpp.Callable<cpp.Object->Float->Float->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_fill_extents", "oddddv", false));
-	private static var lime_cairo_fill_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_fill_preserve", "ov",
-		false));
+	private static var lime_cairo_fill_preserve = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_fill_preserve", "ov", false));
 	private static var lime_cairo_get_antialias = new cpp.Callable<cpp.Object->Int>(cpp.Prime._loadPrime("lime", "lime_cairo_get_antialias", "oi", false));
 	private static var lime_cairo_get_current_point = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_cairo_get_current_point",
 		"oo", false));
@@ -2645,10 +2634,8 @@ class NativeCFFI
 		false));
 	private static var lime_cairo_identity_matrix = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_identity_matrix", "ov",
 		false));
-	private static var lime_cairo_in_clip = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_clip", "oddb",
-		false));
-	private static var lime_cairo_in_fill = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_fill", "oddb",
-		false));
+	private static var lime_cairo_in_clip = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_clip", "oddb", false));
+	private static var lime_cairo_in_fill = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_fill", "oddb", false));
 	private static var lime_cairo_in_stroke = new cpp.Callable<cpp.Object->Float->Float->Bool>(cpp.Prime._loadPrime("lime", "lime_cairo_in_stroke", "oddb",
 		false));
 	private static var lime_cairo_line_to = new cpp.Callable<cpp.Object->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_line_to", "oddv",
@@ -2680,8 +2667,7 @@ class NativeCFFI
 	private static var lime_cairo_restore = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_restore", "ov", false));
 	private static var lime_cairo_rotate = new cpp.Callable<cpp.Object->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_rotate", "odv", false));
 	private static var lime_cairo_save = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_save", "ov", false));
-	private static var lime_cairo_scale = new cpp.Callable<cpp.Object->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_scale", "oddv",
-		false));
+	private static var lime_cairo_scale = new cpp.Callable<cpp.Object->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_scale", "oddv", false));
 	private static var lime_cairo_set_antialias = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_set_antialias", "oiv",
 		false));
 	private static var lime_cairo_set_dash = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_set_dash", "oov",
@@ -2799,8 +2785,7 @@ class NativeCFFI
 		"lime_cairo_pattern_set_filter", "oiv", false));
 	private static var lime_cairo_pattern_set_matrix = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_cairo_pattern_set_matrix", "oov", false));
-	private static var lime_cairo_surface_flush = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_surface_flush", "ov",
-		false));
+	private static var lime_cairo_surface_flush = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_cairo_surface_flush", "ov", false));
 	#end
 	#end
 	#if (neko || cppia)
@@ -2945,8 +2930,8 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_cairo_curve_to") private static function lime_cairo_curve_to(handle:CFFIPointer, x1:Float, y1:Float, x2:Float, y2:Float,
-		x3:Float, y3:Float):Void {}
+	@:hlNative("lime", "hl_cairo_curve_to") private static function lime_cairo_curve_to(handle:CFFIPointer, x1:Float, y1:Float, x2:Float, y2:Float, x3:Float,
+		y3:Float):Void {}
 
 	@:hlNative("lime", "hl_cairo_fill") private static function lime_cairo_fill(handle:CFFIPointer):Void {}
 
@@ -3086,8 +3071,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_cairo_push_group") private static function lime_cairo_push_group(handle:CFFIPointer):Void {}
 
-	@:hlNative("lime", "hl_cairo_push_group_with_content") private static function lime_cairo_push_group_with_content(handle:CFFIPointer,
-		content:Int):Void {}
+	@:hlNative("lime", "hl_cairo_push_group_with_content") private static function lime_cairo_push_group_with_content(handle:CFFIPointer, content:Int):Void {}
 
 	@:hlNative("lime", "hl_cairo_rectangle") private static function lime_cairo_rectangle(handle:CFFIPointer, x:Float, y:Float, width:Float,
 		height:Float):Void {}
@@ -3140,8 +3124,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_cairo_set_source_rgba") private static function lime_cairo_set_source_rgba(handle:CFFIPointer, r:Float, g:Float, b:Float,
 		a:Float):Void {}
 
-	@:hlNative("lime", "hl_cairo_set_source_surface") private static function lime_cairo_set_source_surface(handle:CFFIPointer, surface:CFFIPointer,
-		x:Float, y:Float):Void {}
+	@:hlNative("lime", "hl_cairo_set_source_surface") private static function lime_cairo_set_source_surface(handle:CFFIPointer, surface:CFFIPointer, x:Float,
+		y:Float):Void {}
 
 	@:hlNative("lime", "hl_cairo_set_tolerance") private static function lime_cairo_set_tolerance(handle:CFFIPointer, tolerance:Float):Void {}
 
@@ -3209,14 +3193,12 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_cairo_font_options_set_antialias") private static function lime_cairo_font_options_set_antialias(handle:CFFIPointer,
-		v:Int):Void {}
+	@:hlNative("lime", "hl_cairo_font_options_set_antialias") private static function lime_cairo_font_options_set_antialias(handle:CFFIPointer, v:Int):Void {}
 
 	@:hlNative("lime", "hl_cairo_font_options_set_hint_metrics") private static function lime_cairo_font_options_set_hint_metrics(handle:CFFIPointer,
 		v:Int):Void {}
 
-	@:hlNative("lime", "hl_cairo_font_options_set_hint_style") private static function lime_cairo_font_options_set_hint_style(handle:CFFIPointer,
-		v:Int):Void {}
+	@:hlNative("lime", "hl_cairo_font_options_set_hint_style") private static function lime_cairo_font_options_set_hint_style(handle:CFFIPointer, v:Int):Void {}
 
 	@:hlNative("lime", "hl_cairo_font_options_set_subpixel_order") private static function lime_cairo_font_options_set_subpixel_order(handle:CFFIPointer,
 		v:Int):Void {}
@@ -3226,8 +3208,7 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_cairo_image_surface_create") private static function lime_cairo_image_surface_create(format:Int, width:Int,
-			height:Int):CFFIPointer
+	@:hlNative("lime", "hl_cairo_image_surface_create") private static function lime_cairo_image_surface_create(format:Int, width:Int, height:Int):CFFIPointer
 	{
 		return null;
 	}
@@ -3263,8 +3244,8 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_cairo_pattern_add_color_stop_rgb") private static function lime_cairo_pattern_add_color_stop_rgb(handle:CFFIPointer,
-		offset:Float, red:Float, green:Float, blue:Float):Void {}
+	@:hlNative("lime", "hl_cairo_pattern_add_color_stop_rgb") private static function lime_cairo_pattern_add_color_stop_rgb(handle:CFFIPointer, offset:Float,
+		red:Float, green:Float, blue:Float):Void {}
 
 	@:hlNative("lime", "hl_cairo_pattern_add_color_stop_rgba") private static function lime_cairo_pattern_add_color_stop_rgba(handle:CFFIPointer,
 		offset:Float, red:Float, green:Float, blue:Float, alpha:Float):Void {}
@@ -4384,8 +4365,7 @@ class NativeCFFI
 	private static var lime_gl_get_vertex_attribi = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribi", "iii", false));
 	private static var lime_gl_get_vertex_attribiv = new cpp.Callable<Int->Int->lime.utils.DataPointer->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_gl_get_vertex_attribiv", "iidv", false));
-	private static var lime_gl_get_vertex_attribii = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribii", "iii",
-		false));
+	private static var lime_gl_get_vertex_attribii = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribii", "iii", false));
 	private static var lime_gl_get_vertex_attribiiv = new cpp.Callable<Int->Int->lime.utils.DataPointer->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_gl_get_vertex_attribiiv", "iidv", false));
 	private static var lime_gl_get_vertex_attribiui = new cpp.Callable<Int->Int->Int>(cpp.Prime._loadPrime("lime", "lime_gl_get_vertex_attribiui", "iii",
@@ -4894,8 +4874,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_gl_buffer_data") private static function lime_gl_buffer_data(target:Int, size:Int, srcData:DataPointer, usage:Int):Void {}
 
-	@:hlNative("lime", "hl_gl_buffer_sub_data") private static function lime_gl_buffer_sub_data(target:Int, offset:Int, size:Int,
-		srcData:DataPointer):Void {}
+	@:hlNative("lime", "hl_gl_buffer_sub_data") private static function lime_gl_buffer_sub_data(target:Int, offset:Int, size:Int, srcData:DataPointer):Void {}
 
 	@:hlNative("lime", "hl_gl_check_framebuffer_status") private static function lime_gl_check_framebuffer_status(target:Int):Int
 	{
@@ -4912,8 +4891,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_gl_clear_bufferuiv") private static function lime_gl_clear_bufferuiv(buffer:Int, drawBuffer:Int, data:DataPointer):Void {}
 
-	@:hlNative("lime", "hl_gl_client_wait_sync") private static function lime_gl_client_wait_sync(sync:CFFIPointer, flags:Int, timeoutA:Int,
-			timeoutB:Int):Int
+	@:hlNative("lime", "hl_gl_client_wait_sync") private static function lime_gl_client_wait_sync(sync:CFFIPointer, flags:Int, timeoutA:Int, timeoutB:Int):Int
 	{
 		return 0;
 	}
@@ -5136,8 +5114,7 @@ class NativeCFFI
 	@:hlNative("lime", "hl_gl_get_buffer_parameteri64v") private static function lime_gl_get_buffer_parameteri64v(target:Int, index:Int,
 		params:DataPointer):Void {}
 
-	@:hlNative("lime", "hl_gl_get_buffer_parameteriv") private static function lime_gl_get_buffer_parameteriv(target:Int, pname:Int,
-		params:DataPointer):Void {}
+	@:hlNative("lime", "hl_gl_get_buffer_parameteriv") private static function lime_gl_get_buffer_parameteriv(target:Int, pname:Int, params:DataPointer):Void {}
 
 	@:hlNative("lime", "hl_gl_get_buffer_pointerv") private static function lime_gl_get_buffer_pointerv(target:Int, pname:Int):DataPointer
 	{
@@ -5499,8 +5476,8 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_gl_scissor") private static function lime_gl_scissor(x:Int, y:Int, width:Int, height:Int):Void {}
 
-	@:hlNative("lime", "hl_gl_shader_binary") private static function lime_gl_shader_binary(shaders:hl.NativeArray<Int>, binaryformat:Int,
-		binary:DataPointer, length:Int):Void {}
+	@:hlNative("lime", "hl_gl_shader_binary") private static function lime_gl_shader_binary(shaders:hl.NativeArray<Int>, binaryformat:Int, binary:DataPointer,
+		length:Int):Void {}
 
 	@:hlNative("lime", "hl_gl_shader_source") private static function lime_gl_shader_source(shader:Int, source:String):Void {}
 
@@ -5532,8 +5509,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_gl_tex_storage_3d") private static function lime_gl_tex_storage_3d(target:Int, level:Int, internalformat:Int, width:Int,
 		height:Int, depth:Int):Void {}
 
-	@:hlNative("lime", "hl_gl_tex_sub_image_2d") private static function lime_gl_tex_sub_image_2d(target:Int, level:Int, xoffset:Int, yoffset:Int,
-		width:Int, height:Int, format:Int, type:Int, data:DataPointer):Void {}
+	@:hlNative("lime", "hl_gl_tex_sub_image_2d") private static function lime_gl_tex_sub_image_2d(target:Int, level:Int, xoffset:Int, yoffset:Int, width:Int,
+		height:Int, format:Int, type:Int, data:DataPointer):Void {}
 
 	@:hlNative("lime", "hl_gl_tex_sub_image_3d") private static function lime_gl_tex_sub_image_3d(target:Int, level:Int, xoffset:Int, yoffset:Int,
 		zoffset:Int, width:Int, height:Int, depth:Int, format:Int, type:Int, data:DataPointer):Void {}
@@ -5900,8 +5877,7 @@ class NativeCFFI
 	private static var lime_hb_blob_is_immutable = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_hb_blob_is_immutable", "ob", false));
 	private static var lime_hb_blob_make_immutable = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_blob_make_immutable", "ov",
 		false));
-	private static var lime_hb_buffer_add = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add", "oiiv",
-		false));
+	private static var lime_hb_buffer_add = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add", "oiiv", false));
 	private static var lime_hb_buffer_add_codepoints = new cpp.Callable<cpp.Object->lime.utils.DataPointer->Int->Int->Int->
 		cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add_codepoints", "odiiiv", false));
 	private static var lime_hb_buffer_add_utf8 = new cpp.Callable<cpp.Object->String->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -5986,8 +5962,7 @@ class NativeCFFI
 		"oiv", false));
 	private static var lime_hb_face_set_index = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_face_set_index", "oiv",
 		false));
-	private static var lime_hb_face_set_upem = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_face_set_upem", "oiv",
-		false));
+	private static var lime_hb_face_set_upem = new cpp.Callable<cpp.Object->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_face_set_upem", "oiv", false));
 	private static var lime_hb_feature_from_string = new cpp.Callable<String->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_feature_from_string", "so",
 		false));
 	private static var lime_hb_feature_to_string = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_feature_to_string", "oo",
@@ -6005,8 +5980,7 @@ class NativeCFFI
 		"lime_hb_font_get_glyph_kerning_for_direction", "oiiio", false));
 	private static var lime_hb_font_get_glyph_origin_for_direction = new cpp.Callable<cpp.Object->Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime",
 		"lime_hb_font_get_glyph_origin_for_direction", "oiio", false));
-	private static var lime_hb_font_get_parent = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_parent", "oo",
-		false));
+	private static var lime_hb_font_get_parent = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_parent", "oo", false));
 	private static var lime_hb_font_get_ppem = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_ppem", "oo", false));
 	private static var lime_hb_font_get_scale = new cpp.Callable<cpp.Object->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_hb_font_get_scale", "oo", false));
 	private static var lime_hb_font_glyph_from_string = new cpp.Callable<cpp.Object->String->Int>(cpp.Prime._loadPrime("lime",
@@ -6344,8 +6318,7 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_hb_buffer_set_cluster_level") private static function lime_hb_buffer_set_cluster_level(buffer:CFFIPointer,
-		clusterLevel:Int):Void {}
+	@:hlNative("lime", "hl_hb_buffer_set_cluster_level") private static function lime_hb_buffer_set_cluster_level(buffer:CFFIPointer, clusterLevel:Int):Void {}
 
 	@:hlNative("lime", "hl_hb_buffer_set_content_type") private static function lime_hb_buffer_set_content_type(buffer:CFFIPointer, contentType:Int):Void {}
 
@@ -6504,8 +6477,8 @@ class NativeCFFI
 	@:hlNative("lime", "hl_hb_font_set_scale") private static function lime_hb_font_set_scale(font:CFFIPointer, xScale:Int, yScale:Int):Void {}
 
 	@:hlNative("lime",
-		"hl_hb_font_subtract_glyph_origin_for_direction") private static function lime_hb_font_subtract_glyph_origin_for_direction(font:CFFIPointer,
-		glyph:Int, direction:Int, x:Int, y:Int):Void {}
+		"hl_hb_font_subtract_glyph_origin_for_direction") private static function lime_hb_font_subtract_glyph_origin_for_direction(font:CFFIPointer, glyph:Int,
+		direction:Int, x:Int, y:Int):Void {}
 
 	@:hlNative("lime", "hl_hb_ft_font_create") private static function lime_hb_ft_font_create(font:CFFIPointer):CFFIPointer
 	{
@@ -6626,8 +6599,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_hb_set_union") private static function lime_hb_set_union(set:CFFIPointer, other:CFFIPointer):Void {}
 
-	@:hlNative("lime", "hl_hb_shape") private static function lime_hb_shape(font:CFFIPointer, buffer:CFFIPointer,
-		features:hl.NativeArray<CFFIPointer>):Void {}
+	@:hlNative("lime", "hl_hb_shape") private static function lime_hb_shape(font:CFFIPointer, buffer:CFFIPointer, features:hl.NativeArray<CFFIPointer>):Void {}
 	#end
 	#end
 	#if (lime_cffi && !macro && lime_vorbis)
@@ -6824,8 +6796,7 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_vorbis_file_pcm_seek_lap") private static function lime_vorbis_file_pcm_seek_lap(vorbisFile:CFFIPointer, posLow:Int,
-			posHigh:Int):Int
+	@:hlNative("lime", "hl_vorbis_file_pcm_seek_lap") private static function lime_vorbis_file_pcm_seek_lap(vorbisFile:CFFIPointer, posLow:Int, posHigh:Int):Int
 	{
 		return 0;
 	}
@@ -6847,8 +6818,7 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_vorbis_file_raw_seek_lap") private static function lime_vorbis_file_raw_seek_lap(vorbisFile:CFFIPointer, posLow:Int,
-			posHigh:Int):Int
+	@:hlNative("lime", "hl_vorbis_file_raw_seek_lap") private static function lime_vorbis_file_raw_seek_lap(vorbisFile:CFFIPointer, posLow:Int, posHigh:Int):Int
 	{
 		return 0;
 	}

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -157,7 +157,7 @@ class NativeCFFI
 
 	@:cffi private static function lime_gamepad_get_device_name(id:Int):Dynamic;
 
-	@:cffi private static function lime_gamepad_rumble(id:Int, duration:Int, largeStrength:Float, smallStrength:Float):Void;
+	@:cffi private static function lime_gamepad_rumble(id:Int, lowFrequencyRumble:Float, highFrequencyRumble:Float, duration:Int):Void;
 
 	@:cffi private static function lime_gamepad_event_manager_register(callback:Dynamic, eventObject:Dynamic):Void;
 
@@ -1017,7 +1017,7 @@ class NativeCFFI
 		return null;
 	}
 
-	@:hlNative("lime", "hl_gamepad_rumble") private static function lime_gamepad_rumble(id:Int, duration:Int, largeStrength:Float, smallStrength:Float):Void {}
+	@:hlNative("lime", "hl_gamepad_rumble") private static function lime_gamepad_rumble(id:Int, lowFrequencyRumble:Float, highFrequencyRumble:Float, duration:Int):Void {}
 
 	@:hlNative("lime", "hl_gamepad_event_manager_register") private static function lime_gamepad_event_manager_register(callback:Void->Void,
 		eventObject:GamepadEventInfo):Void {}

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -450,7 +450,7 @@ class NativeCFFI
 		false));
 	private static var lime_gamepad_get_device_name = new cpp.Callable<Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_gamepad_get_device_name", "io",
 		false));
-	private static var lime_gamepad_rumble = new cpp.Callable<Int->Int->Float->Float->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_gamepad_rumble", "iiddv",
+	private static var lime_gamepad_rumble = new cpp.Callable<Int->Float->Float->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_gamepad_rumble", "iddiv",
 		false));
 	private static var lime_gamepad_event_manager_register = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_gamepad_event_manager_register", "oov", false));

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -92,4 +92,17 @@ class Gamepad
 		return null;
 		#end
 	}
+	
+	// Rumble
+	@:noCompletion private inline function rumble(duration:Int, largeStrength:Double, smallStrength:Double):Void
+	{
+		#if (lime_cffi && !macro)
+		NativeCFFI.lime_gamepad_rumble(this.id, duration, largeStrength, smallStrength);
+		#elseif (js && html5)
+		// TODO: HTML5 Rumble
+		return null;
+		#else
+		return null;
+		#end
+	}
 }

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -94,15 +94,15 @@ class Gamepad
 	}
 	
 	// Rumble
-	@:noCompletion private inline function rumble(duration:Int, largeStrength:Double, smallStrength:Double):Void
+	public inline function rumble(duration:Int, largeStrength:Float, smallStrength:Float):Void
 	{
 		#if (lime_cffi && !macro)
 		NativeCFFI.lime_gamepad_rumble(this.id, duration, largeStrength, smallStrength);
 		#elseif (js && html5)
 		// TODO: HTML5 Rumble
-		return null;
+		return;
 		#else
-		return null;
+		return;
 		#end
 	}
 }

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -42,6 +42,13 @@ class Gamepad
 		#end
 	}
 
+	/**
+	    @param	lowFrequencyRumble	The intensity of the low frequency (left)
+		rumble motor, from 0 to 1.
+	    @param	highFrequencyRumble	The intensity of the high frequency (right)
+		rumble motor, from 0 to 1.
+		@param	duration	The duration of the rumble effect, in milliseconds.
+	**/
 	public inline function rumble(lowFrequencyRumble:Float, highFrequencyRumble:Float, duration:Int):Void
 	{
 		#if (lime_cffi && !macro)

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -94,10 +94,10 @@ class Gamepad
 	}
 	
 	// Rumble
-	public inline function rumble(duration:Int, largeStrength:Float, smallStrength:Float):Void
+	public inline function rumble(lowFrequencyRumble:Float, highFrequencyRumble:Float, duration:Int):Void
 	{
 		#if (lime_cffi && !macro)
-		NativeCFFI.lime_gamepad_rumble(this.id, duration, largeStrength, smallStrength);
+		NativeCFFI.lime_gamepad_rumble(this.id, lowFrequencyRumble, highFrequencyRumble, duration);
 		#elseif (js && html5)
 		// TODO: HTML5 Rumble
 		return;

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -23,10 +23,19 @@ class Gamepad
 	public var onButtonUp = new Event<GamepadButton->Void>();
 	public var onDisconnect = new Event<Void->Void>();
 
+	#if (js && html5)
+	private var __jsGamepad:js.html.Gamepad;
+	#end
+
 	public function new(id:Int)
 	{
 		this.id = id;
 		connected = true;
+
+		#if (js && html5)
+		var devices = Joystick.__getDeviceData();
+		__jsGamepad = devices[this.id];
+		#end
 	}
 
 	public static function addMappings(mappings:Array<String>):Void
@@ -43,10 +52,11 @@ class Gamepad
 	}
 
 	/**
-		@param	lowFrequencyRumble	The intensity of the low frequency (left)
+		@param	lowFrequencyRumble	The intensity of the low frequency (strong)
 		rumble motor, from 0 to 1.
-		@param	highFrequencyRumble	The intensity of the high frequency (right)
-		rumble motor, from 0 to 1.
+		@param	highFrequencyRumble	The intensity of the high frequency (weak)
+		rumble motor, from 0 to 1. Will be ignored in situations where only one
+		motor is available.
 		@param	duration	The duration of the rumble effect, in milliseconds.
 	**/
 	public inline function rumble(lowFrequencyRumble:Float, highFrequencyRumble:Float, duration:Int):Void
@@ -54,8 +64,23 @@ class Gamepad
 		#if (lime_cffi && !macro)
 		NativeCFFI.lime_gamepad_rumble(this.id, lowFrequencyRumble, highFrequencyRumble, duration);
 		#elseif (js && html5)
-		// TODO: HTML5 Rumble
-		return;
+		var actuator:Dynamic = (untyped __jsGamepad.vibrationActuator) ? untyped __jsGamepad.vibrationActuator
+			: (untyped __jsGamepad.hapticActuators) ? untyped __jsGamepad.hapticActuators[0]
+			: null;
+		if (actuator == null) return;
+
+		if (untyped actuator.playEffect)
+		{
+			untyped actuator.playEffect("dual-rumble", {
+				duration: duration,
+				strongMagnitude: lowFrequencyRumble,
+				weakMagnitude: highFrequencyRumble
+			});
+		}
+		else if (untyped actuator.pulse)
+		{
+			untyped actuator.pulse(lowFrequencyRumble, duration);
+		}
 		#else
 		return;
 		#end
@@ -89,8 +114,7 @@ class Gamepad
 		return NativeCFFI.lime_gamepad_get_device_guid(this.id);
 		#end
 		#elseif (js && html5)
-		var devices = Joystick.__getDeviceData();
-		return devices[this.id].id;
+		return __jsGamepad.id;
 		#else
 		return null;
 		#end
@@ -105,8 +129,7 @@ class Gamepad
 		return NativeCFFI.lime_gamepad_get_device_name(this.id);
 		#end
 		#elseif (js && html5)
-		var devices = Joystick.__getDeviceData();
-		return devices[this.id].id;
+		return __jsGamepad.id;
 		#else
 		return null;
 		#end

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -42,6 +42,18 @@ class Gamepad
 		#end
 	}
 
+	public inline function rumble(lowFrequencyRumble:Float, highFrequencyRumble:Float, duration:Int):Void
+	{
+		#if (lime_cffi && !macro)
+		NativeCFFI.lime_gamepad_rumble(this.id, lowFrequencyRumble, highFrequencyRumble, duration);
+		#elseif (js && html5)
+		// TODO: HTML5 Rumble
+		return;
+		#else
+		return;
+		#end
+	}
+
 	@:noCompletion private static function __connect(id:Int):Void
 	{
 		if (!devices.exists(id))
@@ -90,19 +102,6 @@ class Gamepad
 		return devices[this.id].id;
 		#else
 		return null;
-		#end
-	}
-	
-	// Rumble
-	public inline function rumble(lowFrequencyRumble:Float, highFrequencyRumble:Float, duration:Int):Void
-	{
-		#if (lime_cffi && !macro)
-		NativeCFFI.lime_gamepad_rumble(this.id, lowFrequencyRumble, highFrequencyRumble, duration);
-		#elseif (js && html5)
-		// TODO: HTML5 Rumble
-		return;
-		#else
-		return;
 		#end
 	}
 }

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -43,9 +43,9 @@ class Gamepad
 	}
 
 	/**
-	    @param	lowFrequencyRumble	The intensity of the low frequency (left)
+		@param	lowFrequencyRumble	The intensity of the low frequency (left)
 		rumble motor, from 0 to 1.
-	    @param	highFrequencyRumble	The intensity of the high frequency (right)
+		@param	highFrequencyRumble	The intensity of the high frequency (right)
 		rumble motor, from 0 to 1.
 		@param	duration	The duration of the rumble effect, in milliseconds.
 	**/

--- a/src/lime/ui/Joystick.hx
+++ b/src/lime/ui/Joystick.hx
@@ -53,11 +53,11 @@ class Joystick
 	}
 
 	#if (js && html5)
-	@:noCompletion private static function __getDeviceData():Array<Dynamic>
+	@:noCompletion private static function __getDeviceData():Array<js.html.Gamepad>
 	{
-		var res:Dynamic = null;
-		
-		try 
+		var res:Array<js.html.Gamepad> = null;
+
+		try
 		{
 			res = (untyped navigator.getGamepads) ? untyped navigator.getGamepads() : (untyped navigator.webkitGetGamepads) ? untyped navigator.webkitGetGamepads() : null;
 		}
@@ -66,7 +66,7 @@ class Joystick
 			// if something went wrong, treat it the same as when navigator.getGamepads doesn't exist
 			// we probably don't have permission to use this feature
 		}
-		
+
 		return res;
 	}
 	#end


### PR DESCRIPTION
This PR adds a controller rumble method to the ui/Gamepad class.
At this time, it only implements the native/SDL2 backend. HTML5 should be simple as well, although browser support for rumble is lacking as of writing this.

Closes #869 