### PR TITLE
Fix `lime.text.Font` don't know how to cast array to `hl.types.ArrayBytes_Int` with `analyzer-optimize`

### DIFF
--- a/src/lime/text/Font.hx
+++ b/src/lime/text/Font.hx
@@ -189,7 +189,7 @@ class Font
 	{
 		#if (lime_cffi && !macro)
 		var glyphs:Dynamic = NativeCFFI.lime_font_get_glyph_indices(src, characters);
-		return glyphs;
+		return cast glyphs;
 		#else
 		return null;
 		#end

--- a/src/lime/text/Font.hx
+++ b/src/lime/text/Font.hx
@@ -189,6 +189,8 @@ class Font
 	{
 		#if (lime_cffi && !macro)
 		var glyphs:Dynamic = NativeCFFI.lime_font_get_glyph_indices(src, characters);
+		// lime_font_get_glyph_indices returns Array<Int>
+		// cast it to Array<Glyph> instead (Glyph is an abstract)
 		return cast glyphs;
 		#else
 		return null;


### PR DESCRIPTION
When compiling my flixel project to hashlink with `-release` and `analyzer-optimize` I get this error:

```cmd
C:/HaxeToolkit/haxe/lib/lime/8,1,1/src/lime/text/Font.hx:192: characters 10-16 : Don't know how to cast array to hl.types.ArrayBytes_Int
```

Tried to make a minimal repro, but didn't succeed.

Problem can be bypassed in two ways

1. `--macro haxe.macro.Compiler.addMetadata('@:analyzer(no_optimize)', 'lime.text.Font')`
2. explicitly cast value (`return cast glyphs`) for problem line of code:
    https://github.com/openfl/lime/blob/e6205bf3aaace23c7e2458841da4435ff9879eaf/src/lime/text/Font.hx#L188-L196