### PR TITLE
Don't compile `armv7` if the `architecture` excluded it.

### DIFF
--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -145,7 +145,7 @@ class AndroidPlatform extends PlatformTarget
 		var architectures = [];
 
 		if (hasARMV5) architectures.push(Architecture.ARMV5);
-		if (hasARMV7 || (!hasARMV5 && !hasX86)) architectures.push(Architecture.ARMV7);
+		if (hasARMV7) architectures.push(Architecture.ARMV7);
 		if (hasARM64) architectures.push(Architecture.ARM64);
 		if (hasX86) architectures.push(Architecture.X86);
 		if (hasX64) architectures.push(Architecture.X64);

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -150,7 +150,12 @@ class AndroidPlatform extends PlatformTarget
 		if (hasX86) architectures.push(Architecture.X86);
 		if (hasX64) architectures.push(Architecture.X64);
 
-		if (architectures.length == 0) architectures.push(Architecture.ARM64);
+		if (architectures.length == 0)
+		{
+			hasARM64 = true;
+
+			architectures.push(Architecture.ARM64);
+		}
 
 		for (architecture in architectures)
 		{

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -152,7 +152,7 @@ class AndroidPlatform extends PlatformTarget
 
 		if (architectures.length == 0)
 		{
-			Log.warn("No architecture selected, resorting to arm64.");
+			Log.warn("No architecture selected, defaulting to ARM64.");
 
 			hasARM64 = true;
 

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -150,6 +150,8 @@ class AndroidPlatform extends PlatformTarget
 		if (hasX86) architectures.push(Architecture.X86);
 		if (hasX64) architectures.push(Architecture.X64);
 
+		if (architectures.length == 0) architectures.push(Architecture.ARM64);
+
 		for (architecture in architectures)
 		{
 			var haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-21"];

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -152,6 +152,8 @@ class AndroidPlatform extends PlatformTarget
 
 		if (architectures.length == 0)
 		{
+			Log.warn("No architecture selected, resorting to arm64.");
+
 			hasARM64 = true;
 
 			architectures.push(Architecture.ARM64);


### PR DESCRIPTION
Previously only the ndll was excluded from being added to the app, now that part of the compilation won't even happen anymore decreasing the compile time.