### PR TITLE
Remove conditional compilation from `AssetsMacro` class.

### DIFF
--- a/src/haxe/io/Bytes.hx
+++ b/src/haxe/io/Bytes.hx
@@ -945,7 +945,7 @@ class Bytes
 }
 #elseif hl
 #if !macro
-@:autoBuild(lime._internal.macros.AssetsMacro.embedBytesHL()) // Enable @:bytes embed metadata
+@:autoBuild(lime._internal.macros.AssetsMacro.embedBytes()) // Enable @:bytes embed metadata
 #end
 @:coreApi
 class Bytes

--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -46,25 +46,6 @@ class AssetsMacro
 		return fields;
 	}
 
-	macro public static function embedBytesHL():Array<Field>
-	{
-		var fields = embedData(":file");
-		if (fields == null) return null;
-
-		var definition = macro class Temp
-		{
-			public function new(?length:Int, ?bytesData:haxe.io.BytesData)
-			{
-				var bytes = haxe.Resource.getBytes(resourceName);
-				super(bytes.b, bytes.length);
-			}
-		};
-
-		fields.push(definition.fields[0]);
-
-		return fields;
-	}
-
 	macro public static function embedByteArray():Array<Field>
 	{
 		var fields = embedData(":file");

--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -30,7 +30,9 @@ class AssetsMacro
 		if (fields != null)
 		{
 			#if !display
-			var constructor = macro
+			var definition = macro class Temp
+			{
+				public function new(?length:Int, ?bytesData:haxe.io.BytesData)
 				{
 					var bytes = haxe.Resource.getBytes(resourceName);
 					#if html5
@@ -40,25 +42,10 @@ class AssetsMacro
 					#else
 					super(bytes.length, bytes.b);
 					#end
-				};
+				}
+			};
 
-			var args = [
-				{name: "length", opt: true, type: macro:Int},
-				{name: "bytesData", opt: true, type: macro:haxe.io.BytesData}
-			];
-			fields.push(
-				{
-					name: "new",
-					access: [APublic],
-					kind: FFun(
-						{
-							args: args,
-							expr: constructor,
-							params: [],
-							ret: null
-						}),
-					pos: Context.currentPos()
-				});
+			fields.push(definition.fields[0]);
 			#end
 		}
 
@@ -72,29 +59,16 @@ class AssetsMacro
 		if (fields != null)
 		{
 			#if !display
-			var constructor = macro
+			var definition = macro class Temp
+			{
+				public function new(?length:Int, ?bytesData:haxe.io.BytesData)
 				{
 					var bytes = haxe.Resource.getBytes(resourceName);
 					super(bytes.b, bytes.length);
-				};
+				}
+			};
 
-			var args = [
-				{name: "length", opt: true, type: macro:Int},
-				{name: "bytesData", opt: true, type: macro:haxe.io.BytesData}
-			];
-			fields.push(
-				{
-					name: "new",
-					access: [APublic],
-					kind: FFun(
-						{
-							args: args,
-							expr: constructor,
-							params: [],
-							ret: null
-						}),
-					pos: Context.currentPos()
-				});
+			fields.push(definition.fields[0]);
 			#end
 		}
 
@@ -108,35 +82,18 @@ class AssetsMacro
 		if (fields != null)
 		{
 			#if !display
-			var constructor = macro
+			var definition = macro class Temp
+			{
+				public function new(?length:Int = 0)
 				{
 					super();
 
 					var bytes = haxe.Resource.getBytes(resourceName);
 					__fromBytes(bytes);
-				};
-
-			var args = [
-				{
-					name: "length",
-					opt: true,
-					type: macro:Int,
-					value: macro 0
 				}
-			];
-			fields.push(
-				{
-					name: "new",
-					access: [APublic],
-					kind: FFun(
-						{
-							args: args,
-							expr: constructor,
-							params: [],
-							ret: null
-						}),
-					pos: Context.currentPos()
-				});
+			};
+
+			fields.push(definition.fields[0]);
 			#end
 		}
 
@@ -200,14 +157,12 @@ class AssetsMacro
 									resourceType = "image/gif";
 								}
 
-								var fieldValue = {pos: position, expr: EConst(CString(resourceType))};
-								fields.push(
-									{
-										kind: FVar(macro:String, fieldValue),
-										name: "resourceType",
-										access: [APrivate, AStatic],
-										pos: position
-									});
+								var definition = macro class Temp
+								{
+									private static var resourceType:String = $v{ resourceType };
+								};
+
+								fields.push(definition.fields[0]);
 
 								var base64 = Base64.encode(bytes);
 								Context.addResource(resourceName, Bytes.ofString(base64));
@@ -217,14 +172,12 @@ class AssetsMacro
 								Context.addResource(resourceName, bytes);
 							}
 
-							var fieldValue = {pos: position, expr: EConst(CString(resourceName))};
-							fields.push(
-								{
-									kind: FVar(macro:String, fieldValue),
-									name: "resourceName",
-									access: [APrivate, AStatic],
-									pos: position
-								});
+							var definition = macro class Temp
+							{
+								private static var resourceName:String = $v{ resourceName };
+							};
+
+							fields.push(definition.fields[0]);
 
 							return fields;
 
@@ -294,35 +247,20 @@ class AssetsMacro
 				}
 			}
 
-			var fieldValue = {pos: position, expr: EConst(CString(resourceName))};
-			fields.push(
-				{
-					kind: FVar(macro:String, fieldValue),
-					name: "resourceName",
-					access: [APublic, AStatic],
-					pos: position
-				});
+			var definition = macro class Temp
+			{
+				private static var resourceName:String = $v{ resourceName };
 
-			var constructor = macro
+				public function new()
 				{
 					super();
 
 					__fromBytes(haxe.Resource.getBytes(resourceName));
-				};
+				}
+			};
 
-			fields.push(
-				{
-					name: "new",
-					access: [APublic],
-					kind: FFun(
-						{
-							args: [],
-							expr: constructor,
-							params: [],
-							ret: null
-						}),
-					pos: Context.currentPos()
-				});
+			fields.push(definition.fields[0]);
+			fields.push(definition.fields[1]);
 
 			return fields;
 		}
@@ -342,7 +280,12 @@ class AssetsMacro
 		if (fields != null)
 		{
 			#if !display
-			var constructor = macro
+			var definition = macro class Temp
+			{
+				public function new(?buffer:lime.graphics.ImageBuffer,
+					?offsetX:Int, ?offsetY:Int, ?width:Int, ?height:Int,
+					?color:Null<Int>, ?type:lime.graphics.ImageType
+					#if html5 , ?onload:Dynamic = true #end)
 				{
 					#if html5
 					super();
@@ -376,85 +319,18 @@ class AssetsMacro
 
 					__fromBytes(haxe.Resource.getBytes(resourceName), null);
 					#end
-				};
-
-			var args = [
-				{
-					name: "buffer",
-					opt: true,
-					type: macro:lime.graphics.ImageBuffer,
-					value: null
-				},
-				{
-					name: "offsetX",
-					opt: true,
-					type: macro:Int,
-					value: null
-				},
-				{
-					name: "offsetY",
-					opt: true,
-					type: macro:Int,
-					value: null
-				},
-				{
-					name: "width",
-					opt: true,
-					type: macro:Int,
-					value: null
-				},
-				{
-					name: "height",
-					opt: true,
-					type: macro:Int,
-					value: null
-				},
-				{
-					name: "color",
-					opt: true,
-					type: macro:Null<Int>,
-					value: null
-				},
-				{
-					name: "type",
-					opt: true,
-					type: macro:lime.graphics.ImageType,
-					value: null
 				}
-			];
+
+				#if html5
+				public static var preload:js.html.Image;
+				#end
+			};
 
 			#if html5
-			args.push(
-				{
-					name: "onload",
-					opt: true,
-					type: macro:Dynamic,
-					value: null
-				});
-			fields.push(
-				{
-					kind: FVar(macro:js.html.Image, null),
-					name: "preload",
-					doc: null,
-					meta: [],
-					access: [APublic, AStatic],
-					pos: Context.currentPos()
-				});
+			fields.push(definition.fields[1]);
 			#end
 
-			fields.push(
-				{
-					name: "new",
-					access: [APublic],
-					kind: FFun(
-						{
-							args: args,
-							expr: constructor,
-							params: [],
-							ret: null
-						}),
-					pos: Context.currentPos()
-				});
+			fields.push(definition.fields[0]);
 			#end
 		}
 
@@ -468,48 +344,20 @@ class AssetsMacro
 		if (fields != null)
 		{
 			#if (openfl && !html5 && !display) // CFFILoader.h(248) : NOT Implemented:api_buffer_data
-
-			var constructor = macro
+			var definition = macro class Temp
+			{
+				public function new(?stream:openfl.net.URLRequest,
+					?context:openfl.media.SoundLoaderContext,
+					?forcePlayAsMusic:Bool = false)
 				{
 					super();
 
 					var byteArray = openfl.utils.ByteArray.fromBytes(haxe.Resource.getBytes(resourceName));
 					loadCompressedDataFromByteArray(byteArray, byteArray.length, forcePlayAsMusic);
-				};
-
-			var args = [
-				{
-					name: "stream",
-					opt: true,
-					type: macro:openfl.net.URLRequest,
-					value: null
-				},
-				{
-					name: "context",
-					opt: true,
-					type: macro:openfl.media.SoundLoaderContext,
-					value: null
-				},
-				{
-					name: "forcePlayAsMusic",
-					opt: true,
-					type: macro:Bool,
-					value: macro false
 				}
-			];
-			fields.push(
-				{
-					name: "new",
-					access: [APublic],
-					kind: FFun(
-						{
-							args: args,
-							expr: constructor,
-							params: [],
-							ret: null
-						}),
-					pos: Context.currentPos()
-				});
+			};
+
+			fields.push(definition.fields[0]);
 			#end
 		}
 

--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -26,28 +26,24 @@ class AssetsMacro
 	macro public static function embedBytes():Array<Field>
 	{
 		var fields = embedData(":file");
+		if (fields == null) return null;
 
-		if (fields != null)
+		var definition = macro class Temp
 		{
-			#if !display
-			var definition = macro class Temp
+			public function new(?length:Int, ?bytesData:haxe.io.BytesData)
 			{
-				public function new(?length:Int, ?bytesData:haxe.io.BytesData)
-				{
-					var bytes = haxe.Resource.getBytes(resourceName);
-					#if html5
-					super(bytes.b.buffer);
-					#elseif hl
-					super(bytes.b, bytes.length);
-					#else
-					super(bytes.length, bytes.b);
-					#end
-				}
-			};
+				var bytes = haxe.Resource.getBytes(resourceName);
+				#if html5
+				super(bytes.b.buffer);
+				#elseif hl
+				super(bytes.b, bytes.length);
+				#else
+				super(bytes.length, bytes.b);
+				#end
+			}
+		};
 
-			fields.push(definition.fields[0]);
-			#end
-		}
+		fields.push(definition.fields[0]);
 
 		return fields;
 	}
@@ -55,22 +51,18 @@ class AssetsMacro
 	macro public static function embedBytesHL():Array<Field>
 	{
 		var fields = embedData(":file");
+		if (fields == null) return null;
 
-		if (fields != null)
+		var definition = macro class Temp
 		{
-			#if !display
-			var definition = macro class Temp
+			public function new(?length:Int, ?bytesData:haxe.io.BytesData)
 			{
-				public function new(?length:Int, ?bytesData:haxe.io.BytesData)
-				{
-					var bytes = haxe.Resource.getBytes(resourceName);
-					super(bytes.b, bytes.length);
-				}
-			};
+				var bytes = haxe.Resource.getBytes(resourceName);
+				super(bytes.b, bytes.length);
+			}
+		};
 
-			fields.push(definition.fields[0]);
-			#end
-		}
+		fields.push(definition.fields[0]);
 
 		return fields;
 	}
@@ -78,31 +70,28 @@ class AssetsMacro
 	macro public static function embedByteArray():Array<Field>
 	{
 		var fields = embedData(":file");
+		if (fields == null) return null;
 
-		if (fields != null)
+		var definition = macro class Temp
 		{
-			#if !display
-			var definition = macro class Temp
+			public function new(?length:Int = 0)
 			{
-				public function new(?length:Int = 0)
-				{
-					super();
+				super();
 
-					var bytes = haxe.Resource.getBytes(resourceName);
-					__fromBytes(bytes);
-				}
-			};
+				var bytes = haxe.Resource.getBytes(resourceName);
+				__fromBytes(bytes);
+			}
+		};
 
-			fields.push(definition.fields[0]);
-			#end
-		}
+		fields.push(definition.fields[0]);
 
 		return fields;
 	}
 
 	private static function embedData(metaName:String, encode:Bool = false):Array<Field>
 	{
-		#if !display
+		if (Context.defined("display")) return null;
+
 		var classType = Context.getLocalClass().get();
 		var metaData = classType.meta.get();
 		var position = Context.currentPos();
@@ -186,13 +175,14 @@ class AssetsMacro
 				}
 			}
 		}
-		#end
 
 		return null;
 	}
 
 	macro public static function embedFont():Array<Field>
 	{
+		if (Context.defined("display")) return Context.getBuildFields();
+
 		var fields = null;
 
 		var classType = Context.getLocalClass().get();
@@ -203,7 +193,6 @@ class AssetsMacro
 		var path = "";
 		var glyphs = "32-255";
 
-		#if !display
 		for (meta in metaData)
 		{
 			if (meta.name == ":font")
@@ -264,7 +253,6 @@ class AssetsMacro
 
 			return fields;
 		}
-		#end
 
 		return fields;
 	}
@@ -276,63 +264,59 @@ class AssetsMacro
 		#else
 		var fields = embedData(":image");
 		#end
+		if (fields == null) return null;
 
-		if (fields != null)
+		var definition = macro class Temp
 		{
-			#if !display
-			var definition = macro class Temp
+			public function new(?buffer:lime.graphics.ImageBuffer,
+				?offsetX:Int, ?offsetY:Int, ?width:Int, ?height:Int,
+				?color:Null<Int>, ?type:lime.graphics.ImageType
+				#if html5 , ?onload:Dynamic = true #end)
 			{
-				public function new(?buffer:lime.graphics.ImageBuffer,
-					?offsetX:Int, ?offsetY:Int, ?width:Int, ?height:Int,
-					?color:Null<Int>, ?type:lime.graphics.ImageType
-					#if html5 , ?onload:Dynamic = true #end)
-				{
-					#if html5
-					super();
-
-					if (preload != null)
-					{
-						var buffer = new lime.graphics.ImageBuffer();
-						buffer.__srcImage = preload;
-						buffer.width = preload.width;
-						buffer.width = preload.height;
-
-						__fromImageBuffer(buffer);
-					}
-					else
-					{
-						__fromBase64(haxe.Resource.getString(resourceName), resourceType, function(image)
-						{
-							if (preload == null)
-							{
-								preload = image.buffer.__srcImage;
-							}
-
-							if (onload != null)
-							{
-								onload(image);
-							}
-						});
-					}
-					#else
-					super();
-
-					__fromBytes(haxe.Resource.getBytes(resourceName), null);
-					#end
-				}
-
 				#if html5
-				public static var preload:js.html.Image;
+				super();
+
+				if (preload != null)
+				{
+					var buffer = new lime.graphics.ImageBuffer();
+					buffer.__srcImage = preload;
+					buffer.width = preload.width;
+					buffer.width = preload.height;
+
+					__fromImageBuffer(buffer);
+				}
+				else
+				{
+					__fromBase64(haxe.Resource.getString(resourceName), resourceType, function(image)
+					{
+						if (preload == null)
+						{
+							preload = image.buffer.__srcImage;
+						}
+
+						if (onload != null)
+						{
+							onload(image);
+						}
+					});
+				}
+				#else
+				super();
+
+				__fromBytes(haxe.Resource.getBytes(resourceName), null);
 				#end
-			};
+			}
 
 			#if html5
-			fields.push(definition.fields[1]);
+			public static var preload:js.html.Image;
 			#end
+		};
 
-			fields.push(definition.fields[0]);
-			#end
-		}
+		#if html5
+		fields.push(definition.fields[1]);
+		#end
+
+		fields.push(definition.fields[0]);
 
 		return fields;
 	}
@@ -340,26 +324,24 @@ class AssetsMacro
 	macro public static function embedSound():Array<Field>
 	{
 		var fields = embedData(":sound");
+		if (fields == null) return null;
 
-		if (fields != null)
+		#if (openfl && !html5) // CFFILoader.h(248) : NOT Implemented:api_buffer_data
+		var definition = macro class Temp
 		{
-			#if (openfl && !html5 && !display) // CFFILoader.h(248) : NOT Implemented:api_buffer_data
-			var definition = macro class Temp
+			public function new(?stream:openfl.net.URLRequest,
+				?context:openfl.media.SoundLoaderContext,
+				?forcePlayAsMusic:Bool = false)
 			{
-				public function new(?stream:openfl.net.URLRequest,
-					?context:openfl.media.SoundLoaderContext,
-					?forcePlayAsMusic:Bool = false)
-				{
-					super();
+				super();
 
-					var byteArray = openfl.utils.ByteArray.fromBytes(haxe.Resource.getBytes(resourceName));
-					loadCompressedDataFromByteArray(byteArray, byteArray.length, forcePlayAsMusic);
-				}
-			};
+				var byteArray = openfl.utils.ByteArray.fromBytes(haxe.Resource.getBytes(resourceName));
+				loadCompressedDataFromByteArray(byteArray, byteArray.length, forcePlayAsMusic);
+			}
+		};
 
-			fields.push(definition.fields[0]);
-			#end
-		}
+		fields.push(definition.fields[0]);
+		#end
 
 		return fields;
 	}

--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -144,7 +144,7 @@ class AssetsMacro
 
 						var definition = macro class Temp
 						{
-							private static var resourceType:String = $v{ resourceType };
+							private static inline var resourceType:String = $v{ resourceType };
 						};
 
 						fields.push(definition.fields[0]);
@@ -159,7 +159,7 @@ class AssetsMacro
 
 					var definition = macro class Temp
 					{
-						private static var resourceName:String = $v{ resourceName };
+						private static inline var resourceName:String = $v{ resourceName };
 					};
 
 					fields.push(definition.fields[0]);

--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -15,8 +15,11 @@ import sys.FileSystem;
 
 class AssetsMacro
 {
-	#if !macro
-	macro public static function cacheVersion() {}
+	#if (!macro || display)
+	macro public static function cacheVersion()
+	{
+		return macro 0;
+	}
 	#else
 	macro public static function cacheVersion()
 	{


### PR DESCRIPTION
A [recent change](https://github.com/HaxeFoundation/haxe/commit/342b1387e287241fac6b8300a29e7955d7bf4429) to the macro context seems to prevent us from using some conditional compilation flags. I have only ever relied on `#if macro` working during a macro context, and suspect it was a fluke that `#if html5` ever worked.

In fact, it seems that `#if hl` never worked. ddd19afe5273aea61a2a6487618dcad438c2dfbd adds the check but prefers to call `embedBytesHL()` instead, so it doesn't get checked. Similarly, `#if js` and Haxe-provided flags never work in macros; only Lime's flags ever stood a chance.

This PR switches to a more future-proof approach, and also tries to make the code more readable. I believe this closes #1763 (unless more errors get revealed once these are fixed).