### PR TITLE
Increase audio length limit majorly on desktop

### DIFF
--- a/project/src/media/AudioBuffer.cpp
+++ b/project/src/media/AudioBuffer.cpp
@@ -6,7 +6,7 @@ namespace lime {
 
 	static int id_bitsPerSample;
 	static int id_channels;
-	static int id_data;
+	static long long id_data;
 	static int id_sampleRate;
 	static bool init = false;
 

--- a/project/src/media/containers/OGG.cpp
+++ b/project/src/media/containers/OGG.cpp
@@ -28,8 +28,8 @@ namespace lime {
 		#endif
 
 		int bitStream;
-		float bytes = 1;
-		float totalBytes = 0.0;
+		long long bytes = 1;
+		long long totalBytes = 0;
 
 		#define BUFFER_SIZE 4096
 
@@ -47,7 +47,7 @@ namespace lime {
 
 		audioBuffer->bitsPerSample = 16;
 
-		float dataLength = double(ov_pcm_total (oggFile, -1)) * audioBuffer->channels * audioBuffer->bitsPerSample * 0.125;
+		long long dataLength = ov_pcm_total (oggFile, -1) * audioBuffer->channels * audioBuffer->bitsPerSample / 8;
 		audioBuffer->data->Resize (dataLength);
 
 		while (bytes > 0) {

--- a/project/src/media/containers/OGG.cpp
+++ b/project/src/media/containers/OGG.cpp
@@ -11,19 +11,13 @@ namespace lime {
 		Bytes *data = NULL;
 
 		if (resource->path) {
-
 			oggFile = VorbisFile::FromFile (resource->path);
-
 		} else {
-
 			oggFile = VorbisFile::FromBytes (resource->data);
-
 		}
 
 		if (!oggFile) {
-
 			return false;
-
 		}
 
 		// 0 for Little-Endian, 1 for Big-Endian
@@ -34,21 +28,18 @@ namespace lime {
 		#endif
 
 		int bitStream;
-		long bytes = 1;
-		int totalBytes = 0;
+		float bytes = 1;
+		float totalBytes = 0.0;
 
 		#define BUFFER_SIZE 4096
 
 		vorbis_info *pInfo = ov_info (oggFile, -1);
 
 		if (pInfo == NULL) {
-
-			//LOG_SOUND("FAILED TO READ OGG SOUND INFO, IS THIS EVEN AN OGG FILE?\n");
 			ov_clear (oggFile);
 			delete oggFile;
 
 			return false;
-
 		}
 
 		audioBuffer->channels = pInfo->channels;
@@ -56,35 +47,24 @@ namespace lime {
 
 		audioBuffer->bitsPerSample = 16;
 
-		int dataLength = ov_pcm_total (oggFile, -1) * audioBuffer->channels * audioBuffer->bitsPerSample / 8;
+		float dataLength = double(ov_pcm_total (oggFile, -1)) * audioBuffer->channels * audioBuffer->bitsPerSample * 0.125;
 		audioBuffer->data->Resize (dataLength);
 
 		while (bytes > 0) {
-
 			bytes = ov_read (oggFile, (char *)audioBuffer->data->buffer->b + totalBytes, BUFFER_SIZE, BUFFER_READ_TYPE, 2, 1, &bitStream);
-
 			if (bytes > 0) {
-
 				totalBytes += bytes;
-
 			}
-
 		}
 
 		if (dataLength != totalBytes) {
-
 			audioBuffer->data->Resize (totalBytes);
-
 		}
 
 		ov_clear (oggFile);
 		delete oggFile;
 
 		#undef BUFFER_READ_TYPE
-
 		return true;
-
 	}
-
-
 }

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -20,8 +20,8 @@ import lime.utils.UInt8Array;
 class NativeAudioSource
 {
 	private static var STREAM_BUFFER_SIZE:Int = 8192;
-	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 16 #end ;
-	private static var STREAM_TIMER_FREQUENCY:Int = 80;
+	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 32 #end ;
+	private static var STREAM_TIMER_FREQUENCY:Int = 50;
 
 	private var buffers:Array<ALBuffer>;
 	private var bufferTimeBlocks:Array<Float>;
@@ -161,11 +161,9 @@ class NativeAudioSource
 		var buffer = new UInt8Array(Math.floor(length));
 		var read = 0.0, total = 0.0, readMax = 0.0;
 
-		var num_buffers:Int = Std.int(STREAM_NUM_BUFFERS * getPitch());
-
-		for (i in 0...num_buffers-1)
+		for (i in 0...STREAM_NUM_BUFFERS-1)
 			bufferTimeBlocks[i] = bufferTimeBlocks[i + 1];
-		bufferTimeBlocks[num_buffers-1] = vorbisFile.timeTell();
+		bufferTimeBlocks[STREAM_NUM_BUFFERS-1] = vorbisFile.timeTell();
 
 		while (total < length)
 		{
@@ -331,7 +329,7 @@ class NativeAudioSource
 				AL.sourceStop(handle);
 
 				parent.buffer.__srcVorbisFile.timeSeek((value + parent.offset) * 0.001);
-				AL.sourceUnqueueBuffers(handle, Std.int(STREAM_NUM_BUFFERS * getPitch()));
+				AL.sourceUnqueueBuffers(handle, STREAM_NUM_BUFFERS);
 				refillBuffers(buffers);
 
 				if (playing)
@@ -436,7 +434,7 @@ class NativeAudioSource
 		if (handle != null)
 			return AL.getSourcef(handle, AL.PITCH);
 		else
-			return 0.0;
+			return 1;
 	}
 
 	public function setPitch(value:Float):Float

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -22,7 +22,7 @@ class NativeAudioSource
 	// TODO: Fix a bug where the length decreases when the main thread is paused.
 	private static var STREAM_BUFFER_SIZE:Int = 48000;
 	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 2 #end;
-	private static var STREAM_TIMER_FREQUENCY:Float = 19.987;
+	private static var STREAM_TIMER_FREQUENCY:Float = 100;
 
 	private var buffers:Array<ALBuffer>;
 	private var bufferTimeBlocks:Array<Float>;

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -8,7 +8,7 @@ import lime.media.openal.ALBuffer;
 import lime.media.openal.ALSource;
 import lime.media.vorbis.VorbisFile;
 import lime.media.AudioManager;
-import zenith.system.AudioSource;
+import lime.media.AudioSource;
 import lime.utils.UInt8Array;
 
 #if !lime_debug
@@ -46,22 +46,19 @@ class NativeAudioSource
 		position = new Vector4();
 	}
 
-	public function dispose():Void
-	{
-		if (handle != null)
-		{
+	public function dispose():Void {
+		disposed = true;
+
+		if (handle != null) {
 			stop();
 			AL.sourcei(handle, AL.BUFFER, null);
 			AL.deleteSource(handle);
-			if (buffers != null)
-			{
-				for (buffer in buffers)
-				{
-					AL.deleteBuffer(buffer);
-				}
-				buffers = null;
-			}
 			handle = null;
+		}
+
+		if (buffers != null) {
+			AL.deleteBuffers(buffers);
+			buffers = null;
 		}
 	}
 
@@ -103,6 +100,9 @@ class NativeAudioSource
 		}
 		else
 		{
+			if (handle != null)
+				AL.sourcei(handle, AL.BUFFER, parent.buffer.__srcBuffer);
+
 			if (parent.buffer.__srcBuffer == null)
 			{
 				parent.buffer.__srcBuffer = AL.createBuffer();
@@ -252,7 +252,7 @@ class NativeAudioSource
 		#end
 	}
 
-	public function stop():Void
+	inline public function stop():Void
 	{
 		if (playing && handle != null && AL.getSourcei(handle, AL.SOURCE_STATE) == AL.PLAYING)
 			AL.sourceStop(handle);
@@ -376,7 +376,7 @@ class NativeAudioSource
 		return value;
 	}
 
-	public function getGain():Float
+	inline public function getGain():Float
 	{
 		if (handle != null)
 			return AL.getSourcef(handle, AL.GAIN);
@@ -384,7 +384,7 @@ class NativeAudioSource
 			return 1.0;
 	}
 
-	public function setGain(value:Float):Float
+	inline public function setGain(value:Float):Float
 	{
 		if (handle != null)
 			AL.sourcef(handle, AL.GAIN, value);
@@ -392,7 +392,7 @@ class NativeAudioSource
 		return value;
 	}
 
-	public function getLength():Float
+	inline public function getLength():Float
 	{
 		if (length != null)
 			return length;
@@ -419,17 +419,17 @@ class NativeAudioSource
 		return length = value;
 	}
 
-	public function getLoops():Int
+	inline public function getLoops():Int
 	{
 		return loops;
 	}
 
-	public function setLoops(value:Int):Int
+	inline public function setLoops(value:Int):Int
 	{
 		return loops = value;
 	}
 
-	public function getPitch():Float
+	inline public function getPitch():Float
 	{
 		if (handle != null)
 			return AL.getSourcef(handle, AL.PITCH);
@@ -461,7 +461,7 @@ class NativeAudioSource
 		return value;
 	}
 
-	public function getPosition():Vector4
+	inline public function getPosition():Vector4
 	{
 		if (handle != null)
 		{
@@ -476,7 +476,7 @@ class NativeAudioSource
 		return position;
 	}
 
-	public function setPosition(value:Vector4):Vector4
+	inline public function setPosition(value:Vector4):Vector4
 	{
 		position.x = value.x;
 		position.y = value.y;

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -19,9 +19,9 @@ import lime.utils.UInt8Array;
 @:access(lime.media.vorbis.VorbisFile)
 class NativeAudioSource
 {
-	private static var STREAM_BUFFER_SIZE:Int = 16000;
-	private static var STREAM_NUM_BUFFERS:Int = 8;
-	private static var STREAM_TIMER_FREQUENCY:Int = 120;
+	private static var STREAM_BUFFER_SIZE:Int = 12000;
+	private static var STREAM_NUM_BUFFERS:Int = 20;
+	private static var STREAM_TIMER_FREQUENCY:Int = 100;
 
 	private var buffers:Array<ALBuffer>;
 	private var bufferTimeBlocks:Array<Float>;

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -21,7 +21,7 @@ class NativeAudioSource
 {
 	// TODO: Fix a bug where the length decreases when the main thread is paused.
 	private static var STREAM_BUFFER_SIZE:Int = 48000;
-	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 2 #end;
+	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 3 #end;
 	private static var STREAM_TIMER_FREQUENCY:Float = 100;
 
 	private var buffers:Array<ALBuffer>;

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -187,7 +187,9 @@ class NativeAudioSource
 	}
 
 	function int64ToFloat(i:Int64):Float
+	{
 		return Std.parseFloat(Int64.toStr(i));
+	}
 
 	private function refillBuffers(buffers:Array<ALBuffer> = null):Void
 	{

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -20,7 +20,7 @@ import lime.utils.UInt8Array;
 class NativeAudioSource
 {
 	private static var STREAM_BUFFER_SIZE:Int = 4096;
-	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 4 #end ;
+	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 16 #end ;
 	private static var STREAM_TIMER_FREQUENCY:Int = 60;
 
 	private var buffers:Array<ALBuffer>;

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -166,7 +166,8 @@ class NativeAudioSource
 	private function readVorbisFileBuffer(vorbisFile:VorbisFile, length:Float):UInt8Array
 	{
 		#if lime_vorbis
-		var buffer = new UInt8Array(Math.floor(length));
+		var len:Int = Math.floor(length);
+		var buffer = new UInt8Array(len);
 		var read = 0.0, total = 0.0, readMax = 0.0;
 
 		for (i in 0...STREAM_NUM_BUFFERS-1)
@@ -180,7 +181,7 @@ class NativeAudioSource
 			if (readMax > length - total)
 				readMax = length - total;
 
-			read = vorbisFile.read(buffer.buffer, Math.floor(total), Math.floor(readMax));
+			read = vorbisFile.read(buffer.buffer, len, Math.floor(readMax));
 
 			if (read > 0)
 				total += read;

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -47,8 +47,6 @@ class NativeAudioSource
 	}
 
 	public function dispose():Void {
-		disposed = true;
-
 		if (handle != null) {
 			stop();
 			AL.sourcei(handle, AL.BUFFER, null);

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -126,17 +126,17 @@ class NativeAudioSource
 		if (playing || handle == null)
 			return;
 
-		// Fix current time issue when a sound stream is complete
-		if (completed)
-		{
-			setCurrentTime(0);
-			completed = false;
-		}
-
 		playing = true;
 
 		if (stream)
 		{
+			// Fix current time issue when a sound stream is complete
+			if (completed)
+			{
+				setCurrentTime(0);
+				completed = false;
+			}
+
 			setCurrentTime(getCurrentTime());
 
 			streamTimer = new Timer(Math.max(STREAM_TIMER_FREQUENCY / getPitch(), 0.07)); // Bugfix on higher pitches where parts of the audio buffer stop.

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -186,8 +186,8 @@ class NativeAudioSource
 		#end
 	}
 
-	inline function int64ToFloat(i:haxe.Int64):Float
-		return Std.parseFloat(haxe.Int64.toStr(i));
+	inline function int64ToFloat(i:Int64):Float
+		return Std.parseFloat(Int64.toStr(i));
 
 	private function refillBuffers(buffers:Array<ALBuffer> = null):Void
 	{

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -19,9 +19,9 @@ import lime.utils.UInt8Array;
 @:access(lime.media.vorbis.VorbisFile)
 class NativeAudioSource
 {
-	private static var STREAM_BUFFER_SIZE:Int = 12000;
-	private static var STREAM_NUM_BUFFERS:Int = 20;
-	private static var STREAM_TIMER_FREQUENCY:Int = 100;
+	private static var STREAM_BUFFER_SIZE:Int = 4096;
+	private static var STREAM_NUM_BUFFERS:Int = #if (native_audio_buffers && !macro) Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers")) #else 4 #end ;
+	private static var STREAM_TIMER_FREQUENCY:Int = 60;
 
 	private var buffers:Array<ALBuffer>;
 	private var bufferTimeBlocks:Array<Float>;
@@ -186,7 +186,7 @@ class NativeAudioSource
 		#end
 	}
 
-	inline function int64ToFloat(i:Int64):Float
+	function int64ToFloat(i:Int64):Float
 		return Std.parseFloat(Int64.toStr(i));
 
 	private function refillBuffers(buffers:Array<ALBuffer> = null):Void
@@ -250,7 +250,7 @@ class NativeAudioSource
 		#end
 	}
 
-	inline public function stop():Void
+	public function stop():Void
 	{
 		if (playing && handle != null && AL.getSourcei(handle, AL.SOURCE_STATE) == AL.PLAYING)
 			AL.sourceStop(handle);
@@ -374,7 +374,7 @@ class NativeAudioSource
 		return value;
 	}
 
-	inline public function getGain():Float
+	public function getGain():Float
 	{
 		if (handle != null)
 			return AL.getSourcef(handle, AL.GAIN);
@@ -382,7 +382,7 @@ class NativeAudioSource
 			return 1.0;
 	}
 
-	inline public function setGain(value:Float):Float
+	public function setGain(value:Float):Float
 	{
 		if (handle != null)
 			AL.sourcef(handle, AL.GAIN, value);
@@ -390,7 +390,7 @@ class NativeAudioSource
 		return value;
 	}
 
-	inline public function getLength():Float
+	public function getLength():Float
 	{
 		if (length != null)
 			return length;
@@ -417,17 +417,17 @@ class NativeAudioSource
 		return length = value;
 	}
 
-	inline public function getLoops():Int
+	public function getLoops():Int
 	{
 		return loops;
 	}
 
-	inline public function setLoops(value:Int):Int
+	public function setLoops(value:Int):Int
 	{
 		return loops = value;
 	}
 
-	inline public function getPitch():Float
+	public function getPitch():Float
 	{
 		if (handle != null)
 			return AL.getSourcef(handle, AL.PITCH);
@@ -459,7 +459,7 @@ class NativeAudioSource
 		return value;
 	}
 
-	inline public function getPosition():Vector4
+	public function getPosition():Vector4
 	{
 		if (handle != null)
 		{
@@ -474,7 +474,7 @@ class NativeAudioSource
 		return position;
 	}
 
-	inline public function setPosition(value:Vector4):Vector4
+	public function setPosition(value:Vector4):Vector4
 	{
 		position.x = value.x;
 		position.y = value.y;

--- a/src/lime/media/AudioSource.hx
+++ b/src/lime/media/AudioSource.hx
@@ -24,7 +24,7 @@ class AudioSource
 
 	@:noCompletion private var __backend:AudioSourceBackend;
 
-	inline public function new(buffer:AudioBuffer = null, offset:Int = 0, length:Null<Float> = null, loops:Int = 0)
+	public function new(buffer:AudioBuffer = null, offset:Int = 0, length:Null<Float> = null, loops:Int = 0)
     {
 		this.buffer = buffer;
 		this.offset = offset;
@@ -40,56 +40,56 @@ class AudioSource
 		    init();
     }
 
-	inline public function dispose():Void
+	public function dispose():Void
 	    __backend.dispose();
 
-	@:noCompletion inline private function init():Void
+	@:noCompletion private function init():Void
 	    __backend.init();
 
-	inline public function play():Void
+	public function play():Void
 		__backend.play();
 
-	inline public function pause():Void
+	public function pause():Void
 		__backend.pause();
 
-	inline public function stop():Void
+	public function stop():Void
 		__backend.stop();
 
 	// Get & Set Methods
-	@:noCompletion inline private function get_currentTime():Float
+	@:noCompletion private function get_currentTime():Float
 		return __backend.getCurrentTime();
 
-	@:noCompletion inline private function set_currentTime(value:Float):Float
+	@:noCompletion private function set_currentTime(value:Float):Float
 		return __backend.setCurrentTime(value);
 
-	@:noCompletion inline private function get_gain():Float
+	@:noCompletion private function get_gain():Float
 		return __backend.getGain();
 
-	@:noCompletion inline private function set_gain(value:Float):Float
+	@:noCompletion private function set_gain(value:Float):Float
 		return __backend.setGain(value);
 
-	@:noCompletion inline private function get_length():Float
+	@:noCompletion private function get_length():Float
 		return __backend.getLength();
 
-	@:noCompletion inline private function set_length(value:Float):Float
+	@:noCompletion private function set_length(value:Float):Float
 		return __backend.setLength(value);
 
-	@:noCompletion inline private function get_loops():Int
+	@:noCompletion private function get_loops():Int
 		return __backend.getLoops();
 
-	@:noCompletion inline private function set_loops(value:Int):Int
+	@:noCompletion private function set_loops(value:Int):Int
 		return __backend.setLoops(value);
 
-	@:noCompletion inline private function get_pitch():Float
+	@:noCompletion private function get_pitch():Float
 		return __backend.getPitch();
 
-	@:noCompletion inline private function set_pitch(value:Float):Float
+	@:noCompletion private function set_pitch(value:Float):Float
 		return __backend.setPitch(value);
 
-	@:noCompletion inline private function get_position():Vector4
+	@:noCompletion private function get_position():Vector4
 		return __backend.getPosition();
 
-	@:noCompletion inline private function set_position(value:Vector4):Vector4
+	@:noCompletion private function set_position(value:Vector4):Vector4
 		return __backend.setPosition(value);
 }
 

--- a/src/lime/media/AudioSource.hx
+++ b/src/lime/media/AudioSource.hx
@@ -41,56 +41,90 @@ class AudioSource
     }
 
 	public function dispose():Void
+	{
 	    __backend.dispose();
+	}
 
 	@:noCompletion private function init():Void
+	{
 	    __backend.init();
+	}
 
 	public function play():Void
+	{
 		__backend.play();
+	}
 
 	public function pause():Void
+	{
 		__backend.pause();
+	}
 
 	public function stop():Void
+	{
 		__backend.stop();
+	}
 
 	// Get & Set Methods
 	@:noCompletion private function get_currentTime():Float
+	{
 		return __backend.getCurrentTime();
+	}
 
 	@:noCompletion private function set_currentTime(value:Float):Float
+	{
 		return __backend.setCurrentTime(value);
+	}
 
 	@:noCompletion private function get_gain():Float
+	{
 		return __backend.getGain();
+	}
 
 	@:noCompletion private function set_gain(value:Float):Float
+	{
 		return __backend.setGain(value);
+	}
 
 	@:noCompletion private function get_length():Float
+	{
 		return __backend.getLength();
+	}
 
 	@:noCompletion private function set_length(value:Float):Float
+	{
 		return __backend.setLength(value);
+	}
 
 	@:noCompletion private function get_loops():Int
+	{
 		return __backend.getLoops();
+	}
 
 	@:noCompletion private function set_loops(value:Int):Int
+	{
 		return __backend.setLoops(value);
+	}
 
 	@:noCompletion private function get_pitch():Float
+	{
 		return __backend.getPitch();
+	}
 
 	@:noCompletion private function set_pitch(value:Float):Float
+	{
 		return __backend.setPitch(value);
+	}
 
 	@:noCompletion private function get_position():Vector4
+	{
 		return __backend.getPosition();
+	}
 
 	@:noCompletion private function set_position(value:Vector4):Vector4
+	{
 		return __backend.setPosition(value);
+	}
 }
 
 #if flash

--- a/src/lime/media/AudioSource.hx
+++ b/src/lime/media/AudioSource.hx
@@ -1,6 +1,7 @@
 package lime.media;
 
 import lime.app.Event;
+import lime.media.AudioBuffer;
 import lime.media.openal.AL;
 import lime.media.openal.ALSource;
 import lime.math.Vector4;
@@ -11,11 +12,11 @@ import lime.math.Vector4;
 #end
 class AudioSource
 {
-	public var onComplete = new Event<Void->Void>();
+	public var onComplete:Event<Void->Void> = new Event<Void->Void>();
 	public var buffer:AudioBuffer;
-	public var currentTime(get, set):Int;
+	public var currentTime(get, set):Float;
 	public var gain(get, set):Float;
-	public var length(get, set):Int;
+	public var length(get, set):Float;
 	public var loops(get, set):Int;
 	public var pitch(get, set):Float;
 	public var offset:Int;
@@ -23,111 +24,73 @@ class AudioSource
 
 	@:noCompletion private var __backend:AudioSourceBackend;
 
-	public function new(buffer:AudioBuffer = null, offset:Int = 0, length:Null<Int> = null, loops:Int = 0)
-	{
+	inline public function new(buffer:AudioBuffer = null, offset:Int = 0, length:Null<Float> = null, loops:Int = 0)
+    {
 		this.buffer = buffer;
 		this.offset = offset;
 
 		__backend = new AudioSourceBackend(this);
 
-		if (length != null && length != 0)
-		{
-			this.length = length;
-		}
+		if (length != null && length != 0.0)
+		    this.length = length;
 
 		this.loops = loops;
 
 		if (buffer != null)
-		{
-			init();
-		}
-	}
+		    init();
+    }
 
-	public function dispose():Void
-	{
-		__backend.dispose();
-	}
+	inline public function dispose():Void
+	    __backend.dispose();
 
-	@:noCompletion private function init():Void
-	{
-		__backend.init();
-	}
+	@:noCompletion inline private function init():Void
+	    __backend.init();
 
-	public function play():Void
-	{
+	inline public function play():Void
 		__backend.play();
-	}
 
-	public function pause():Void
-	{
+	inline public function pause():Void
 		__backend.pause();
-	}
 
-	public function stop():Void
-	{
+	inline public function stop():Void
 		__backend.stop();
-	}
 
 	// Get & Set Methods
-	@:noCompletion private function get_currentTime():Int
-	{
+	@:noCompletion inline private function get_currentTime():Float
 		return __backend.getCurrentTime();
-	}
 
-	@:noCompletion private function set_currentTime(value:Int):Int
-	{
+	@:noCompletion inline private function set_currentTime(value:Float):Float
 		return __backend.setCurrentTime(value);
-	}
 
-	@:noCompletion private function get_gain():Float
-	{
+	@:noCompletion inline private function get_gain():Float
 		return __backend.getGain();
-	}
 
-	@:noCompletion private function set_gain(value:Float):Float
-	{
+	@:noCompletion inline private function set_gain(value:Float):Float
 		return __backend.setGain(value);
-	}
 
-	@:noCompletion private function get_length():Int
-	{
+	@:noCompletion inline private function get_length():Float
 		return __backend.getLength();
-	}
 
-	@:noCompletion private function set_length(value:Int):Int
-	{
+	@:noCompletion inline private function set_length(value:Float):Float
 		return __backend.setLength(value);
-	}
 
-	@:noCompletion private function get_loops():Int
-	{
+	@:noCompletion inline private function get_loops():Int
 		return __backend.getLoops();
-	}
 
-	@:noCompletion private function set_loops(value:Int):Int
-	{
+	@:noCompletion inline private function set_loops(value:Int):Int
 		return __backend.setLoops(value);
-	}
 
-	@:noCompletion private function get_pitch():Float
-	{
+	@:noCompletion inline private function get_pitch():Float
 		return __backend.getPitch();
-	}
 
-	@:noCompletion private function set_pitch(value:Float):Float
-	{
+	@:noCompletion inline private function set_pitch(value:Float):Float
 		return __backend.setPitch(value);
-	}
 
-	@:noCompletion private function get_position():Vector4
-	{
+	@:noCompletion inline private function get_position():Vector4
 		return __backend.getPosition();
-	}
 
-	@:noCompletion private function set_position(value:Vector4):Vector4
-	{
+	@:noCompletion inline private function set_position(value:Vector4):Vector4
 		return __backend.setPosition(value);
-	}
 }
 
 #if flash


### PR DESCRIPTION
So, there was an int64 conversion in the way of making ``time``, ``length``, ``dataLength``, and ``samples`` floats, causing an overflow once you get past the int64 limit. To fix that, I simply converted it to a float, and now you can load audio files over 6.6 hours with 44.1k sample rate!

I did make ``project/src/media/containers/OGG.cpp`` readable too.

I'm also planning to fix the memory leak problem and another problem with audio buffer when streaming audio. But I don't even know how I would fix that because I simply have never heard of some way to fix it entirely when doing ``new AudioSource(AudioBuffer.fromVorbisFile(VorbisFile.fromFile(sourceFile)))`` for the audio source (Which streams the ogg audio).