### PR TITLE
Build.xml: Add `/opt/homebrew/lib` as rpath on arm64 macos

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -447,6 +447,7 @@
 					/usr/local/lib, but we need it for neko
 				-->
 				<vflag name="-rpath" value="/usr/local/lib" />
+				<vflag name="-rpath" value="/opt/homebrew/lib" if="HXCPP_ARM64"/>
 
 				<vflag name="-l" value="iconv" />
 				<vflag name="-framework" value="IOKit" />


### PR DESCRIPTION
This is where arm64 homebrew installs `libneko.dylib`. However, it may still be in `/usr/local/lib` if installed via the haxe .pkg installer, so we add both. See the discussion in: https://github.com/openfl/lime/commit/c70ec9fbe02b8d98f6562ee7a403f812549ea387.

Closes #1750.

We should use `install_name_tool -delete-rpath [path]` to remove rpaths when copying `lime.ndll` into a cpp build, because we only need the rpath for neko builds (where `libneko.dylib` is going to be loaded), and having an unnecessary rpath is a security concern. I'm not too sure where to do this, I guess maybe here after copying it? @joshtynjala 
https://github.com/openfl/lime/blob/c70ec9fbe02b8d98f6562ee7a403f812549ea387/tools/platforms/MacPlatform.hx#L175-L178.