### PR TITLE
Fix error when locating Lime's bundled NDLLs.

### DIFF
--- a/src/lime/system/CFFI.hx
+++ b/src/lime/system/CFFI.hx
@@ -207,39 +207,29 @@ class CFFI
 	private static function __findHaxelib(library:String):String
 	{
 		#if (sys && !macro && !html5)
+		var proc:Process;
 		try
 		{
-			var proc = new Process("haxelib", ["path", library]);
+			proc = new Process("haxelib", ["libpath", library]);
+			if (proc == null) return "";
+		} catch (e:Dynamic) {}
 
-			if (proc != null)
-			{
-				var stream = proc.stdout;
+		var stream = proc.stdout;
+		var path:String = "";
 
-				try
-				{
-					while (true)
-					{
-						var s = stream.readLine();
+		try
+		{
+			path = stream.readLine();
+			__loaderTrace("Found haxelib " + path);
+		} catch (e:Dynamic) {}
 
-						if (s.substr(0, 1) != "-")
-						{
-							stream.close();
-							proc.close();
-							__loaderTrace("Found haxelib " + s);
-							return s;
-						}
-					}
-				}
-				catch (e:Dynamic) {}
+		stream.close();
+		proc.close();
 
-				stream.close();
-				proc.close();
-			}
-		}
-		catch (e:Dynamic) {}
-		#end
-
+		return path;
+		#else
 		return "";
+		#end
 	}
 
 	private static function __loaderTrace(message:String)

--- a/src/lime/system/CFFI.hx
+++ b/src/lime/system/CFFI.hx
@@ -207,12 +207,12 @@ class CFFI
 	private static function __findHaxelib(library:String):String
 	{
 		#if (sys && !macro && !html5)
-		var proc:Process;
+		var proc:Process = null;
 		try
 		{
 			proc = new Process("haxelib", ["libpath", library]);
-			if (proc == null) return "";
 		} catch (e:Dynamic) {}
+		if (proc == null) return "";
 
 		var stream = proc.stdout;
 		var path:String = "";


### PR DESCRIPTION
We _could_ fall back to `haxelib path` for very old versions of Haxelib, but most likely no one uses a version that old. Even if you're stuck on Haxe 3, you can still update Haxelib. Also, `haxelib path` gave incorrect results in the first place, so falling back wouldn't do any good.

I believe this will resolve #1786.