### PR TITLE
Automatically delete stale assets and dependency files.

### DIFF
--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -191,25 +191,6 @@ class AssetHelper
 		return manifests;
 	}
 
-	public static function deleteStaleAssets(project:HXProject, targetDirectory:String):Void
-	{
-		var newAssets = [for (asset in project.assets) asset.targetPath];
-
-		var recordFile:String = targetDirectory + "/.assets";
-		if (FileSystem.exists(recordFile))
-		{
-			for (oldAsset in File.getContent(recordFile).split("\n"))
-			{
-				if (oldAsset.length > 0 && newAssets.indexOf(oldAsset) < 0)
-				{
-					System.deleteFile(targetDirectory + "/bin/" + oldAsset);
-				}
-			}
-		}
-
-		File.saveContent(recordFile, newAssets.join("\n"));
-	}
-
 	private static function getAssetData(project:HXProject, pathGroups:Map<String, Array<String>>, libraries:Map<String, Library>, library:String,
 			asset:Asset):Dynamic
 	{

--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -191,6 +191,25 @@ class AssetHelper
 		return manifests;
 	}
 
+	public static function deleteStaleAssets(project:HXProject, targetDirectory:String):Void
+	{
+		var newAssets = [for (asset in project.assets) asset.targetPath];
+
+		var recordFile:String = targetDirectory + "/.assets";
+		if (FileSystem.exists(recordFile))
+		{
+			for (oldAsset in File.getContent(recordFile).split("\n"))
+			{
+				if (oldAsset.length > 0 && newAssets.indexOf(oldAsset) < 0)
+				{
+					System.deleteFile(targetDirectory + "/bin/" + oldAsset);
+				}
+			}
+		}
+
+		File.saveContent(recordFile, newAssets.join("\n"));
+	}
+
 	private static function getAssetData(project:HXProject, pathGroups:Map<String, Array<String>>, libraries:Map<String, Library>, library:String,
 			asset:Asset):Dynamic
 	{

--- a/src/lime/tools/PlatformTarget.hx
+++ b/src/lime/tools/PlatformTarget.hx
@@ -103,6 +103,8 @@ class PlatformTarget
 			// AssetHelper.processLibraries (project, targetDirectory);
 			// #end
 			update();
+
+			AssetHelper.deleteStaleAssets(project, targetDirectory);
 		}
 
 		if (command == "build" || command == "test")

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -561,17 +561,17 @@ class AndroidPlatform extends PlatformTarget
 			{
 				if (FileSystem.isDirectory(javaPath))
 				{
-					System.recursiveCopy(javaPath, sourceSet + "/java", context, true);
+					recursiveCopy(javaPath, sourceSet + "/java", context, true);
 				}
 				else
 				{
 					if (Path.extension(javaPath) == "jar")
 					{
-						System.copyIfNewer(javaPath, destination + "/app/libs/" + Path.withoutDirectory(javaPath));
+						copyIfNewer(javaPath, destination + "/app/libs/" + Path.withoutDirectory(javaPath));
 					}
 					else
 					{
-						System.copyIfNewer(javaPath, sourceSet + "/java/" + Path.withoutDirectory(javaPath));
+						copyIfNewer(javaPath, sourceSet + "/java/" + Path.withoutDirectory(javaPath));
 					}
 				}
 			}
@@ -584,7 +584,7 @@ class AndroidPlatform extends PlatformTarget
 
 		for (library in cast(context.ANDROID_LIBRARY_PROJECTS, Array<Dynamic>))
 		{
-			System.recursiveCopy(library.source, destination + "/deps/" + library.name, context, true);
+			recursiveCopy(library.source, destination + "/deps/" + library.name, context, true);
 		}
 
 		ProjectHelper.recursiveSmartCopyTemplate(project, "android/template", destination, context);

--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -429,7 +429,7 @@ class HTML5Platform extends PlatformTarget
 					var name = Path.withoutDirectory(dependency.path);
 
 					context.linkedLibraries.push("./" + dependencyPath + "/" + name);
-					System.copyIfNewer(dependency.path, Path.combine(destination, Path.combine(dependencyPath, name)));
+					copyIfNewer(dependency.path, Path.combine(destination, Path.combine(dependencyPath, name)));
 				}
 			}
 		}

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -851,7 +851,7 @@ class IOSPlatform extends PlatformTarget
 						fileName = "lib" + fileName;
 					}
 
-					System.copyIfNewer(dependency.path, projectDirectory + "/lib/" + arch + "/" + fileName);
+					copyIfNewer(dependency.path, projectDirectory + "/lib/" + arch + "/" + fileName);
 				}
 			}
 		}

--- a/tools/platforms/TVOSPlatform.hx
+++ b/tools/platforms/TVOSPlatform.hx
@@ -628,7 +628,7 @@ class TVOSPlatform extends PlatformTarget
 						fileName = "lib" + fileName;
 					}
 
-					System.copyIfNewer(dependency.path, projectDirectory + "/lib/" + arch + "/" + fileName);
+					copyIfNewer(dependency.path, projectDirectory + "/lib/" + arch + "/" + fileName);
 				}
 			}
 		}

--- a/tools/platforms/WebAssemblyPlatform.hx
+++ b/tools/platforms/WebAssemblyPlatform.hx
@@ -466,7 +466,7 @@ class WebAssemblyPlatform extends PlatformTarget
 					var name = Path.withoutDirectory(dependency.path);
 
 					context.linkedLibraries.push("./" + dependencyPath + "/" + name);
-					System.copyIfNewer(dependency.path, Path.combine(destination, Path.combine(dependencyPath, name)));
+					copyIfNewer(dependency.path, Path.combine(destination, Path.combine(dependencyPath, name)));
 				}
 			}
 		}

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -286,7 +286,7 @@ class WindowsPlatform extends PlatformTarget
 				if (StringTools.endsWith(dependency.path, ".dll"))
 				{
 					var fileName = Path.withoutDirectory(dependency.path);
-					System.copyIfNewer(dependency.path, applicationDirectory + "/" + fileName);
+					copyIfNewer(dependency.path, applicationDirectory + "/" + fileName);
 				}
 			}
 
@@ -1037,7 +1037,7 @@ class WindowsPlatform extends PlatformTarget
 				var name = Path.withoutDirectory(dependency.path);
 
 				context.linkedLibraries.push("./js/lib/" + name);
-				System.copyIfNewer(dependency.path, Path.combine(destination, Path.combine("js/lib", name)));
+				copyIfNewer(dependency.path, Path.combine(destination, Path.combine("js/lib", name)));
 			}
 		}
 


### PR DESCRIPTION
This is yet another attempt to solve #1546, and has several advantages over the previous attempts.

- The code is much more concise.
- No change to HXP is required, meaning there's no need for a synchronized update.
- Unlike #1547, it does not need to iterate over all files in the output directory.
- Unlike #1550, it handles all types of assets, not just templates.