### PR TITLE
Create a placeholder object to send `Matrix3`s to C++ code.

### DIFF
--- a/project/src/math/Matrix3.cpp
+++ b/project/src/math/Matrix3.cpp
@@ -67,6 +67,18 @@ namespace lime {
 
 	value Matrix3::Value (value matrix3) {
 
+		if (!init) {
+
+			id_a = val_id ("a");
+			id_b = val_id ("b");
+			id_c = val_id ("c");
+			id_d = val_id ("d");
+			id_tx = val_id ("tx");
+			id_ty = val_id ("ty");
+			init = true;
+
+		}
+
 		alloc_field (matrix3, id_a, alloc_float (a));
 		alloc_field (matrix3, id_b, alloc_float (b));
 		alloc_field (matrix3, id_c, alloc_float (c));

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -3000,7 +3000,7 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_cairo_get_matrix") private static function lime_cairo_get_matrix(handle:CFFIPointer, out:Matrix3):Matrix3
+	@:hlNative("lime", "hl_cairo_get_matrix") private static function lime_cairo_get_matrix(handle:CFFIPointer, out:CairoMatrix3):CairoMatrix3
 	{
 		return null;
 	}
@@ -3117,7 +3117,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_cairo_set_line_width") private static function lime_cairo_set_line_width(handle:CFFIPointer, width:Float):Void {}
 
-	@:hlNative("lime", "hl_cairo_set_matrix") private static function lime_cairo_set_matrix(handle:CFFIPointer, matrix:Matrix3):Void {}
+	@:hlNative("lime", "hl_cairo_set_matrix") private static function lime_cairo_set_matrix(handle:CFFIPointer, matrix:CairoMatrix3):Void {}
 
 	@:hlNative("lime", "hl_cairo_set_miter_limit") private static function lime_cairo_set_miter_limit(handle:CFFIPointer, miterLimit:Float):Void {}
 
@@ -3155,7 +3155,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_cairo_text_path") private static function lime_cairo_text_path(handle:CFFIPointer, text:String):Void {}
 
-	@:hlNative("lime", "hl_cairo_transform") private static function lime_cairo_transform(handle:CFFIPointer, matrix:Matrix3):Void {}
+	@:hlNative("lime", "hl_cairo_transform") private static function lime_cairo_transform(handle:CFFIPointer, matrix:CairoMatrix3):Void {}
 
 	@:hlNative("lime", "hl_cairo_translate") private static function lime_cairo_translate(handle:CFFIPointer, x:Float, y:Float):Void {}
 
@@ -3301,7 +3301,7 @@ class NativeCFFI
 		return 0;
 	}
 
-	@:hlNative("lime", "hl_cairo_pattern_get_matrix") private static function lime_cairo_pattern_get_matrix(handle:CFFIPointer, out:Matrix3):Matrix3
+	@:hlNative("lime", "hl_cairo_pattern_get_matrix") private static function lime_cairo_pattern_get_matrix(handle:CFFIPointer, out:CairoMatrix3):CairoMatrix3
 	{
 		return null;
 	}
@@ -3310,7 +3310,7 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_cairo_pattern_set_filter") private static function lime_cairo_pattern_set_filter(handle:CFFIPointer, filter:Int):Void {}
 
-	@:hlNative("lime", "hl_cairo_pattern_set_matrix") private static function lime_cairo_pattern_set_matrix(handle:CFFIPointer, matrix:Matrix3):Void {}
+	@:hlNative("lime", "hl_cairo_pattern_set_matrix") private static function lime_cairo_pattern_set_matrix(handle:CFFIPointer, matrix:CairoMatrix3):Void {}
 
 	@:hlNative("lime", "hl_cairo_surface_flush") private static function lime_cairo_surface_flush(surface:CFFIPointer):Void {}
 	#end

--- a/src/lime/graphics/cairo/Cairo.hx
+++ b/src/lime/graphics/cairo/Cairo.hx
@@ -425,7 +425,7 @@ class Cairo
 	public function transform(matrix:Matrix3):Void
 	{
 		#if (lime_cffi && lime_cairo && !macro)
-		NativeCFFI.lime_cairo_transform(handle, matrix);
+		NativeCFFI.lime_cairo_transform(handle, matrix.toCairoMatrix3());
 		#end
 	}
 
@@ -643,7 +643,7 @@ class Cairo
 	{
 		#if (lime_cffi && lime_cairo && !macro)
 		#if hl
-		return NativeCFFI.lime_cairo_get_matrix(handle, new Matrix3());
+		return NativeCFFI.lime_cairo_get_matrix(handle, new CairoMatrix3());
 		#else
 		var m:Dynamic = NativeCFFI.lime_cairo_get_matrix(handle);
 		return new Matrix3(m.a, m.b, m.c, m.d, m.tx, m.ty);
@@ -657,7 +657,7 @@ class Cairo
 	{
 		#if (lime_cffi && lime_cairo && !macro)
 		#if hl
-		NativeCFFI.lime_cairo_set_matrix(handle, value);
+		NativeCFFI.lime_cairo_set_matrix(handle, value.toCairoMatrix3());
 		#else
 		NativeCFFI.lime_cairo_set_matrix(handle, value.a, value.b, value.c, value.d, value.tx, value.ty);
 		// NativeCFFI.lime_cairo_set_matrix (handle, value);

--- a/src/lime/math/Matrix3.hx
+++ b/src/lime/math/Matrix3.hx
@@ -330,6 +330,11 @@ abstract Matrix3(Float32Array) from Float32Array to Float32Array
 		return result;
 	}
 
+	@:from private static inline function fromCairoMatrix3(matrix:CairoMatrix3):Matrix3
+	{
+		return new Matrix3(matrix.a, matrix.b, matrix.c, matrix.d, matrix.tx, matrix.ty);
+	}
+
 	/**
 		Resets the matrix to default identity values
 	**/
@@ -501,6 +506,11 @@ abstract Matrix3(Float32Array) from Float32Array to Float32Array
 		}
 	}
 
+	@:dox(hide) @:noCompletion @:to public inline function toCairoMatrix3():CairoMatrix3
+	{
+		return new CairoMatrix3(a, b, c, d, tx, ty);
+	}
+
 	@:dox(hide) public inline function toString():String
 	{
 		return "matrix(" + a + ", " + b + ", " + c + ", " + d + ", " + tx + ", " + ty + ")";
@@ -638,5 +648,28 @@ abstract Matrix3(Float32Array) from Float32Array to Float32Array
 	{
 		this[index] = value;
 		return value;
+	}
+}
+
+/**
+	An object with the same data as a `Matrix3`, in Cairo's expected format.
+**/
+class CairoMatrix3
+{
+	public var a:Float;
+	public var b:Float;
+	public var c:Float;
+	public var d:Float;
+	public var tx:Float;
+	public var ty:Float;
+
+	public function new(a:Float = 1, b:Float = 0, c:Float = 0, d:Float = 1, tx:Float = 0, ty:Float = 0)
+	{
+		this.a = a;
+		this.b = b;
+		this.c = c;
+		this.d = d;
+		this.tx = tx;
+		this.ty = ty;
 	}
 }


### PR DESCRIPTION
The C++ code was written with an object in mind, rather than an array buffer. The easiest workaround is to give it what it expects.