### PR TITLE
Make `Matrix3` use column-major order.

### DIFF
--- a/src/lime/math/Matrix3.hx
+++ b/src/lime/math/Matrix3.hx
@@ -22,7 +22,7 @@ import lime.utils.Float32Array;
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
-abstract Matrix3(Float32Array) from Float32Array to Float32Array
+abstract Matrix3(Float32Array) to Float32Array
 {
 	/**
 		The matrix a component, used in scaling and skewing (default is 1)
@@ -333,6 +333,16 @@ abstract Matrix3(Float32Array) from Float32Array to Float32Array
 	@:from private static inline function fromCairoMatrix3(matrix:CairoMatrix3):Matrix3
 	{
 		return new Matrix3(matrix.a, matrix.b, matrix.c, matrix.d, matrix.tx, matrix.ty);
+	}
+
+	@:from private static inline function fromFloat32Array(array:Float32Array):Matrix3
+	{
+		if (array.length != 9)
+		{
+			throw "Expected array of length 9, got " + array.length;
+		}
+
+		return cast array;
 	}
 
 	/**

--- a/src/lime/math/Matrix3.hx
+++ b/src/lime/math/Matrix3.hx
@@ -54,8 +54,6 @@ abstract Matrix3(Float32Array) to Float32Array
 	**/
 	public var ty(get, set):Float;
 
-	private static var __identity = new Matrix3();
-
 	/**
 		Creates a new `Matrix` instance
 		@param	a	(Optional) An initial a component value (default is 1)
@@ -389,12 +387,6 @@ abstract Matrix3(Float32Array) to Float32Array
 		return this;
 	}
 
-	// public inline function mult (m:Matrix3) {
-	// 	var result = clone ();
-	// 	result.concat (m);
-	// 	return result;
-	// }
-
 	/**
 		Applies rotation to the current matrix
 		@param	theta	A rotation value in degrees
@@ -480,40 +472,6 @@ abstract Matrix3(Float32Array) to Float32Array
 		set_d(d);
 		set_tx(tx);
 		set_ty(ty);
-	}
-
-	@:dox(hide) @:noCompletion public inline function to3DString(roundPixels:Bool = false):String
-	{
-		// identity matrix
-		//  [a,b,tx,0],
-		//  [c,d,ty,0],
-		//  [0,0,1, 0],
-		//  [0,0,0, 1]
-		//
-		// matrix3d(a,       b, 0, 0, c, d,       0, 0, 0, 0, 1, 0, tx,     ty, 0, 1)
-
-		if (roundPixels)
-		{
-			return "matrix3d("
-				+ a
-				+ ", "
-				+ b
-				+ ", "
-				+ "0, 0, "
-				+ c
-				+ ", "
-				+ d
-				+ ", "
-				+ "0, 0, 0, 0, 1, 0, "
-				+ Std.int(tx)
-				+ ", "
-				+ Std.int(ty)
-				+ ", 0, 1)";
-		}
-		else
-		{
-			return "matrix3d(" + a + ", " + b + ", " + "0, 0, " + c + ", " + d + ", " + "0, 0, 0, 0, 1, 0, " + tx + ", " + ty + ", 0, 1)";
-		}
 	}
 
 	@:dox(hide) @:noCompletion @:to public inline function toCairoMatrix3():CairoMatrix3

--- a/src/lime/math/Matrix3.hx
+++ b/src/lime/math/Matrix3.hx
@@ -1,5 +1,7 @@
 package lime.math;
 
+import lime.utils.Float32Array;
+
 /**
 	`Matrix3` is a 3x3 transformation matrix particularly useful for
 	two-dimensional transformation. It can be used for rotation, scale
@@ -13,8 +15,9 @@ package lime.math;
 	[ b, d, ty ]
 	[ 0, 0,  1 ]
 	```
+
+	Values are stored in column-major order for GLSL compatibility.
 **/
-import lime.utils.Float32Array;
 #if hl
 @:keep
 #end
@@ -65,10 +68,11 @@ abstract Matrix3(Float32Array) to Float32Array
 	**/
 	public function new(a:Float = 1, b:Float = 0, c:Float = 0, d:Float = 1, tx:Float = 0, ty:Float = 0)
 	{
+		// Column-major order means adjacent values form a column, not a row.
 		this = new Float32Array([
-			a, c, 0,
-			b, d, 0,
-			tx, ty, 1
+			a,  b,  0, // column 0
+			c,  d,  0, // column 1
+			tx, ty, 1  // column 2
 		]);
 	}
 
@@ -396,9 +400,9 @@ abstract Matrix3(Float32Array) to Float32Array
 		/*
 			Rotate object "after" other transforms
 
-			[  a  b   0 ][  ma mb  0 ]
-			[  c  d   0 ][  mc md  0 ]
-			[  tx ty  1 ][  mtx mty 1 ]
+			[  a  c  tx ][  ma  mc  mtx ]
+			[  b  d  ty ][  mb  md  mty ]
+			[  0  0   1 ][   0   0    1 ]
 
 			ma = md = cos
 			mb = sin
@@ -434,9 +438,9 @@ abstract Matrix3(Float32Array) to Float32Array
 
 			Scale object "after" other transforms
 
-			[  a  b   0 ][  sx  0   0 ]
-			[  c  d   0 ][  0   sy  0 ]
-			[  tx ty  1 ][  0   0   1 ]
+			[  a  c  tx ][  sx  0   0 ]
+			[  b  d  ty ][  0   sy  0 ]
+			[  0  0   1 ][  0   0   1 ]
 		 */
 
 		a *= sx;
@@ -481,7 +485,7 @@ abstract Matrix3(Float32Array) to Float32Array
 
 	@:dox(hide) public inline function toString():String
 	{
-		return "matrix(" + a + ", " + b + ", " + c + ", " + d + ", " + tx + ", " + ty + ")";
+		return 'matrix($a, $b, $c, $d, $tx, $ty)';
 	}
 
 	/**
@@ -564,20 +568,20 @@ abstract Matrix3(Float32Array) to Float32Array
 
 	inline function get_b():Float
 	{
-		return this[3];
+		return this[1];
 	}
 	inline function set_b(value: Float):Float
 	{
-		return this[3] = value;
+		return this[1] = value;
 	}
 
 	inline function get_c():Float
 	{
-		return this[1];
+		return this[3];
 	}
 	inline function set_c(value: Float):Float
 	{
-		return this[1] = value;
+		return this[3] = value;
 	}
 
 	inline function get_d():Float


### PR DESCRIPTION
[What "column-major" means](https://en.wikipedia.org/wiki/Row-_and_column-major_order)

Now that `Matrix3` is stored as a one-dimensional array (see #1778), it's important to keep careful track of what order data is stored in. I chose column-major order because [that's what GLSL uses](https://www.khronos.org/opengl/wiki/Data_Type_\(GLSL\)#Matrices), and it's also how `Matrix4` works.

This PR swaps `b` and `c` (which had been backwards), adds documentation, and tidies up.