### PR TITLE
Ignore system environment variables with the same name as common targets.

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -184,6 +184,10 @@ class HXProject extends Script
 		else
 		{
 			environment = Sys.environment();
+			for (conflict in ["air", "android", "cpp", "flash", "hl", "html5", "ios", "linux", "mac", "neko", "webassembly", "windows"])
+			{
+				environment.remove(conflict);
+			}
 		}
 
 		haxedefs = new Map<String, Dynamic>();


### PR DESCRIPTION
If you have a `<section if="cpp">` tag in your project.xml, you don't want it to be active just because a system environment variable happens to be named "cpp". You only want it active if actually targeting C++.

Resolves #1394.