### PR TITLE
Support `VIEW` intents on Android.

### DIFF
--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
 
 			</intent-filter>
 
-			::foreach ANDROID_MIME_TYPES::
+			::foreach ANDROID_ACCEPT_FILE_INTENT::
 			<intent-filter>
 
 				<action android:name="android.intent.action.VIEW" />

--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
 
 			</intent-filter>
 
-			::foreach ANDROID_SUPPORTED_MIME_TYPES::
+			::foreach ANDROID_MIME_TYPES::
 			<intent-filter>
 
 				<action android:name="android.intent.action.VIEW" />

--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -25,6 +25,14 @@
 
 			</intent-filter>
 
+			<intent-filter>
+
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<data android:mimeType="*/*" />
+
+			</intent-filter>
+
 		</activity>
 
 	</application>

--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -25,13 +25,15 @@
 
 			</intent-filter>
 
+			::foreach ANDROID_SUPPORTED_MIME_TYPES::
 			<intent-filter>
 
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
-				<data android:mimeType="*/*" />
+				<data android:mimeType="::__current__::" />
 
 			</intent-filter>
+			::end::
 
 		</activity>
 

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -493,6 +493,7 @@ class AndroidPlatform extends PlatformTarget
 			"android:configChanges": project.config.getArrayString("android.configChanges", ["keyboardHidden", "orientation", "screenSize", "screenLayout", "uiMode"]).join("|"),
 			"android:screenOrientation": project.window.orientation == PORTRAIT ? "sensorPortrait" : (project.window.orientation == LANDSCAPE ? "sensorLandscape" : null)
 		});
+		context.ANDROID_SUPPORTED_MIME_TYPES = project.config.getArrayString("android.supportedMimeTypes", []);
 
 		if (!project.environment.exists("ANDROID_SDK") || !project.environment.exists("ANDROID_NDK_ROOT"))
 		{

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -493,7 +493,7 @@ class AndroidPlatform extends PlatformTarget
 			"android:configChanges": project.config.getArrayString("android.configChanges", ["keyboardHidden", "orientation", "screenSize", "screenLayout", "uiMode"]).join("|"),
 			"android:screenOrientation": project.window.orientation == PORTRAIT ? "sensorPortrait" : (project.window.orientation == LANDSCAPE ? "sensorLandscape" : null)
 		});
-		context.ANDROID_MIME_TYPES = project.config.getArrayString("android.mimeType", []);
+		context.ANDROID_ACCEPT_FILE_INTENT = project.config.getArrayString("android.accept-file-intent", []);
 
 		if (!project.environment.exists("ANDROID_SDK") || !project.environment.exists("ANDROID_NDK_ROOT"))
 		{

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -493,7 +493,7 @@ class AndroidPlatform extends PlatformTarget
 			"android:configChanges": project.config.getArrayString("android.configChanges", ["keyboardHidden", "orientation", "screenSize", "screenLayout", "uiMode"]).join("|"),
 			"android:screenOrientation": project.window.orientation == PORTRAIT ? "sensorPortrait" : (project.window.orientation == LANDSCAPE ? "sensorLandscape" : null)
 		});
-		context.ANDROID_SUPPORTED_MIME_TYPES = project.config.getArrayString("android.supportedMimeTypes", []);
+		context.ANDROID_MIME_TYPES = project.config.getArrayString("android.mimeType", []);
 
 		if (!project.environment.exists("ANDROID_SDK") || !project.environment.exists("ANDROID_NDK_ROOT"))
 		{


### PR DESCRIPTION
This pr adds Drop file event support by including the intent-filter [reference](https://github.com/libsdl-org/SDL/blob/9651ca59187c16079846918483c40d6b5c2f454c/android-project/app/src/main/AndroidManifest.xml#L95-L102) on`AndroidManifest.xml`.