### PR TITLE
Use `namespace` for gradle projects to fix deprecation warnings.

### DIFF
--- a/dependencies/extension-api/build.gradle
+++ b/dependencies/extension-api/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+	namespace 'org.haxe.extension'
 	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
 	buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 

--- a/dependencies/extension-api/src/main/AndroidManifest.xml
+++ b/dependencies/extension-api/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.haxe.extension" >
-    
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -13,6 +13,7 @@ System.setProperty('java.awt.headless','false')
 } */
 
 android {
+	namespace "::APP_PACKAGE::"
 	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
 	buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 	::if (ANDROID_GRADLE_PLUGIN>="4.0")::ndkPath '::ANDROID_NDK_ROOT_ESCAPED::'::end::

--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="::APP_PACKAGE::" android:versionCode="::APP_BUILD_NUMBER::" android:versionName="::APP_VERSION::" android:installLocation="::ANDROID_INSTALL_LOCATION::">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="::APP_BUILD_NUMBER::" android:versionName="::APP_VERSION::" android:installLocation="::ANDROID_INSTALL_LOCATION::">
 
 	<uses-feature android:glEsVersion="0x00020000" android:required="true" />
 	<uses-feature android:name="android.hardware.touchscreen" android:required="false" />

--- a/templates/extension/dependencies/android/build.gradle
+++ b/templates/extension/dependencies/android/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+	namespace "org.haxe.extension.::extensionLowerCase::"
 	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
 	buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 }

--- a/templates/extension/dependencies/android/src/main/AndroidManifest.xml
+++ b/templates/extension/dependencies/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.haxe.extension.::extensionLowerCase::" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/templates/extension/dependencies/android/src/main/AndroidManifest.xml
+++ b/templates/extension/dependencies/android/src/main/AndroidManifest.xml
@@ -1,6 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.haxe.extension.::extensionLowerCase::" >
-	
-	
-	
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.haxe.extension.::extensionLowerCase::" />


### PR DESCRIPTION
This pr updates all `Gradle` project files to use `namespaces`, fixing deprecation warnings.
