### PR TITLE
Update HashLink to 1.14

### DIFF
--- a/project/BuildHashlink.xml
+++ b/project/BuildHashlink.xml
@@ -55,20 +55,50 @@
 		<file name="${HASHLINK_PATH}/src/std/track.c" />
 		<file name="${HASHLINK_PATH}/src/std/ucs2.c" />
 
-		<!-- PCRE -->
+		<!-- PCRE2 -->
 		<file name="${HASHLINK_PATH}/include/pcre/pcre16_ord2utf16.c" />
+		<compilerflag value="-DHAVE_CONFIG_H" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_globals.c" />
+		<compilerflag value="-DPCRE2_CODE_UNIT_WIDTH=16" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre16_valid_utf16.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_auto_possess.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_newline.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_chartables.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_chartables.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_compile.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_string_utils.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_config.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_compile.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_context.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_tables.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_convert.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_dfa_exec.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_dfa_match.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_ucd.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_error.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_exec.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_extuni.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_xclass.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_find_bracket.c" />
 		<file name="${HASHLINK_PATH}/include/pcre/pcre_fullinfo.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_jit_compile.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_maketables.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_match_data.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_match.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_newline.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_ord2utf.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_pattern_info.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_script_run.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_serialize.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_string_utils.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_study.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_substitute.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_substring.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_tables.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_ucd.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_ucptables.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_valid_utf.c" />
+		<file name="${HASHLINK_PATH}/include/pcre/pcre2_xclass.c" />
 
 		<!-- macOS debugging -->
 		<file name="${HASHLINK_PATH}/include/mdbg/mdbg.c" if="mac" />


### PR DESCRIPTION
Update HashLink from version 1.12 to version 1.14. This requires updating references to PCRE in the build file to PCRE2.