### PR TITLE
Create event functions for precise input handling.

### DIFF
--- a/project/include/system/System.h
+++ b/project/include/system/System.h
@@ -30,6 +30,7 @@ namespace lime {
 			static void GCExitBlocking ();
 			static void GCTryEnterBlocking ();
 			static void GCTryExitBlocking ();
+			static int GetTicks ();
 			static bool GetAllowScreenTimeout ();
 			static std::wstring* GetDeviceModel ();
 			static std::wstring* GetDeviceVendor ();

--- a/project/include/ui/GamepadEvent.h
+++ b/project/include/ui/GamepadEvent.h
@@ -28,6 +28,7 @@ namespace lime {
 		int id;
 		GamepadEventType type;
 		double axisValue;
+		int timestamp;
 
 		static ValuePointer* callback;
 		static ValuePointer* eventObject;

--- a/project/include/ui/KeyEvent.h
+++ b/project/include/ui/KeyEvent.h
@@ -25,6 +25,7 @@ namespace lime {
 		int modifier;
 		KeyEventType type;
 		int windowID;
+		int timestamp;
 
 		static ValuePointer* callback;
 		static ValuePointer* eventObject;

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -2648,6 +2648,18 @@ namespace lime {
 
 	}
 
+	int lime_sdl_get_ticks () {
+
+		return System::GetTicks();
+
+	}
+
+
+	HL_PRIM int HL_NAME(hl_sdl_get_ticks) () {
+
+		return System::GetTicks();
+
+	}
 
 	bool lime_system_get_allow_screen_timeout () {
 
@@ -3997,6 +4009,7 @@ namespace lime {
 	DEFINE_PRIME3 (lime_png_decode_file);
 	DEFINE_PRIME2v (lime_render_event_manager_register);
 	DEFINE_PRIME2v (lime_sensor_event_manager_register);
+	DEFINE_PRIME0 (lime_sdl_get_ticks);
 	DEFINE_PRIME0 (lime_system_get_allow_screen_timeout);
 	DEFINE_PRIME0 (lime_system_get_device_model);
 	DEFINE_PRIME0 (lime_system_get_device_vendor);
@@ -4069,9 +4082,9 @@ namespace lime {
 	#define _TCLIPBOARD_EVENT _OBJ (_I32)
 	#define _TDISPLAYMODE _OBJ (_I32 _I32 _I32 _I32)
 	#define _TDROP_EVENT _OBJ (_BYTES _I32)
-	#define _TGAMEPAD_EVENT _OBJ (_I32 _I32 _I32 _I32 _F64)
+	#define _TGAMEPAD_EVENT _OBJ (_I32 _I32 _I32 _I32 _F64 _I32)
 	#define _TJOYSTICK_EVENT _OBJ (_I32 _I32 _I32 _I32 _F64 _F64)
-	#define _TKEY_EVENT _OBJ (_F64 _I32 _I32 _I32)
+	#define _TKEY_EVENT _OBJ (_F64 _I32 _I32 _I32 _I32)
 	#define _TMOUSE_EVENT _OBJ (_I32 _F64 _F64 _I32 _I32 _F64 _F64 _I32)
 	#define _TRECTANGLE _OBJ (_F64 _F64 _F64 _F64)
 	#define _TRENDER_EVENT _OBJ (_I32)
@@ -4185,6 +4198,7 @@ namespace lime {
 	DEFINE_HL_PRIM (_TIMAGEBUFFER, hl_png_decode_file, _STRING _BOOL _TIMAGEBUFFER);
 	DEFINE_HL_PRIM (_VOID, hl_render_event_manager_register, _FUN (_VOID, _NO_ARG) _TRENDER_EVENT);
 	DEFINE_HL_PRIM (_VOID, hl_sensor_event_manager_register, _FUN (_VOID, _NO_ARG) _TSENSOR_EVENT);
+	DEFINE_HL_PRIM (_I32, hl_sdl_get_ticks, _NO_ARG);
 	DEFINE_HL_PRIM (_BOOL, hl_system_get_allow_screen_timeout, _NO_ARG);
 	DEFINE_HL_PRIM (_BYTES, hl_system_get_device_model, _NO_ARG);
 	DEFINE_HL_PRIM (_BYTES, hl_system_get_device_vendor, _NO_ARG);

--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -401,6 +401,7 @@ namespace lime {
 
 					gamepadsAxisMap[event->caxis.which][event->caxis.axis] = event->caxis.value;
 					gamepadEvent.axisValue = event->caxis.value / (event->caxis.value > 0 ? 32767.0 : 32768.0);
+					gamepadEvent.timestamp = event->common.timestamp;
 
 					GamepadEvent::Dispatch (&gamepadEvent);
 					break;
@@ -410,6 +411,7 @@ namespace lime {
 					gamepadEvent.type = GAMEPAD_BUTTON_DOWN;
 					gamepadEvent.button = event->cbutton.button;
 					gamepadEvent.id = event->cbutton.which;
+					gamepadEvent.timestamp = event->common.timestamp;
 
 					GamepadEvent::Dispatch (&gamepadEvent);
 					break;
@@ -419,6 +421,7 @@ namespace lime {
 					gamepadEvent.type = GAMEPAD_BUTTON_UP;
 					gamepadEvent.button = event->cbutton.button;
 					gamepadEvent.id = event->cbutton.which;
+					gamepadEvent.timestamp = event->common.timestamp;
 
 					GamepadEvent::Dispatch (&gamepadEvent);
 					break;
@@ -429,6 +432,7 @@ namespace lime {
 
 						gamepadEvent.type = GAMEPAD_CONNECT;
 						gamepadEvent.id = SDLGamepad::GetInstanceID (event->cdevice.which);
+						gamepadEvent.timestamp = event->common.timestamp;
 
 						GamepadEvent::Dispatch (&gamepadEvent);
 
@@ -440,6 +444,7 @@ namespace lime {
 
 					gamepadEvent.type = GAMEPAD_DISCONNECT;
 					gamepadEvent.id = event->cdevice.which;
+					gamepadEvent.timestamp = event->common.timestamp;
 
 					GamepadEvent::Dispatch (&gamepadEvent);
 					SDLGamepad::Disconnect (event->cdevice.which);
@@ -561,6 +566,7 @@ namespace lime {
 			keyEvent.keyCode = event->key.keysym.sym;
 			keyEvent.modifier = event->key.keysym.mod;
 			keyEvent.windowID = event->key.windowID;
+			keyEvent.timestamp = event->common.timestamp;
 
 			if (keyEvent.type == KEY_DOWN) {
 

--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -91,6 +91,13 @@ namespace lime {
 	}
 
 
+	int System::GetTicks () {
+
+		return SDL_GetTicks ();
+
+	}
+
+
 	bool System::GetAllowScreenTimeout () {
 
 		return SDL_IsScreenSaverEnabled ();

--- a/project/src/ui/GamepadEvent.cpp
+++ b/project/src/ui/GamepadEvent.cpp
@@ -13,6 +13,7 @@ namespace lime {
 	static int id_id;
 	static int id_type;
 	static int id_value;
+	static int id_timestamp;
 	static bool init = false;
 
 
@@ -23,6 +24,7 @@ namespace lime {
 		button = 0;
 		id = 0;
 		type = GAMEPAD_AXIS_MOVE;
+		timestamp = 0;
 
 	}
 
@@ -40,6 +42,7 @@ namespace lime {
 					id_id = val_id ("id");
 					id_type = val_id ("type");
 					id_value = val_id ("axisValue");
+					id_timestamp = val_id ("timestamp");
 					init = true;
 
 				}
@@ -51,6 +54,7 @@ namespace lime {
 				alloc_field (object, id_id, alloc_int (event->id));
 				alloc_field (object, id_type, alloc_int (event->type));
 				alloc_field (object, id_value, alloc_float (event->axisValue));
+				alloc_field (object, id_timestamp, alloc_int (event->timestamp));
 
 			} else {
 
@@ -61,6 +65,7 @@ namespace lime {
 				eventObject->id = event->id;
 				eventObject->type = event->type;
 				eventObject->axisValue = event->axisValue;
+				eventObject->timestamp = event->timestamp;
 
 			}
 

--- a/project/src/ui/KeyEvent.cpp
+++ b/project/src/ui/KeyEvent.cpp
@@ -12,6 +12,7 @@ namespace lime {
 	static int id_modifier;
 	static int id_type;
 	static int id_windowID;
+	static int id_timestamp;
 	static bool init = false;
 
 
@@ -21,6 +22,7 @@ namespace lime {
 		modifier = 0;
 		type = KEY_DOWN;
 		windowID = 0;
+		timestamp = 0;
 
 	}
 
@@ -37,6 +39,7 @@ namespace lime {
 					id_modifier = val_id ("modifier");
 					id_type = val_id ("type");
 					id_windowID = val_id ("windowID");
+					id_timestamp = val_id ("timestamp");
 					init = true;
 
 				}
@@ -47,6 +50,7 @@ namespace lime {
 				alloc_field (object, id_modifier, alloc_int (event->modifier));
 				alloc_field (object, id_type, alloc_int (event->type));
 				alloc_field (object, id_windowID, alloc_int (event->windowID));
+				alloc_field (object, id_timestamp, alloc_int (event->timestamp));
 
 			} else {
 

--- a/src/lime/_internal/backend/html5/HTML5Application.hx
+++ b/src/lime/_internal/backend/html5/HTML5Application.hx
@@ -412,12 +412,14 @@ class HTML5Application
 
 			var keyCode = cast convertKeyCode(event.keyCode != null ? event.keyCode : event.which);
 			var modifier = (event.shiftKey ? (KeyModifier.SHIFT) : 0) | (event.ctrlKey ? (KeyModifier.CTRL) : 0) | (event.altKey ? (KeyModifier.ALT) : 0) | (event.metaKey ? (KeyModifier.META) : 0);
+			var timestamp = haxe.Int64.fromFloat(event.timeStamp);
 
 			if (event.type == "keydown")
 			{
 				parent.window.onKeyDown.dispatch(keyCode, modifier);
+				parent.window.onKeyDownPrecise.dispatch(keyCode, modifier, timestamp);
 
-				if (parent.window.onKeyDown.canceled && event.cancelable)
+				if ((parent.window.onKeyDown.canceled || parent.window.onKeyDownPrecise.canceled) && event.cancelable)
 				{
 					event.preventDefault();
 				}
@@ -425,8 +427,9 @@ class HTML5Application
 			else
 			{
 				parent.window.onKeyUp.dispatch(keyCode, modifier);
+				parent.window.onKeyUpPrecise.dispatch(keyCode, modifier, timestamp);
 
-				if (parent.window.onKeyUp.canceled && event.cancelable)
+				if ((parent.window.onKeyUp.canceled || parent.window.onKeyUpPrecise.canceled) && event.cancelable)
 				{
 					event.preventDefault();
 				}
@@ -615,13 +618,17 @@ class HTML5Application
 									default: continue;
 								}
 
+								var timestamp = haxe.Int64.fromFloat(js.Browser.window.performance.now());
+
 								if (value > 0)
 								{
 									gamepad.onButtonDown.dispatch(button);
+									gamepad.onButtonDownPrecise.dispatch(button, timestamp);
 								}
 								else
 								{
 									gamepad.onButtonUp.dispatch(button);
+									gamepad.onButtonUpPrecise.dispatch(button, timestamp);
 								}
 							}
 						}

--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -198,15 +198,24 @@ class NativeApplication
 		{
 			case AXIS_MOVE:
 				var gamepad = Gamepad.devices.get(gamepadEventInfo.id);
-				if (gamepad != null) gamepad.onAxisMove.dispatch(gamepadEventInfo.axis, gamepadEventInfo.axisValue);
+				if (gamepad != null) {
+					gamepad.onAxisMove.dispatch(gamepadEventInfo.axis, gamepadEventInfo.axisValue);
+					gamepad.onAxisMovePrecise.dispatch(gamepadEventInfo.axis, gamepadEventInfo.axisValue, gamepadEventInfo.timestamp);
+				}
 
 			case BUTTON_DOWN:
 				var gamepad = Gamepad.devices.get(gamepadEventInfo.id);
-				if (gamepad != null) gamepad.onButtonDown.dispatch(gamepadEventInfo.button);
+				if (gamepad != null) {
+					gamepad.onButtonDown.dispatch(gamepadEventInfo.button);
+					gamepad.onButtonDownPrecise.dispatch(gamepadEventInfo.button, gamepadEventInfo.timestamp);
+				}
 
 			case BUTTON_UP:
 				var gamepad = Gamepad.devices.get(gamepadEventInfo.id);
-				if (gamepad != null) gamepad.onButtonUp.dispatch(gamepadEventInfo.button);
+				if (gamepad != null) {
+					gamepad.onButtonUp.dispatch(gamepadEventInfo.button);
+					gamepad.onButtonUpPrecise.dispatch(gamepadEventInfo.button, gamepadEventInfo.timestamp);
+				}
 
 			case CONNECT:
 				Gamepad.__connect(gamepadEventInfo.id);
@@ -696,13 +705,17 @@ class NativeApplication
 	public var type:GamepadEventType;
 	public var axisValue:Float;
 
-	public function new(type:GamepadEventType = null, id:Int = 0, button:Int = 0, axis:Int = 0, value:Float = 0)
+	// TODO: This should probably be an Int64
+	public var timestamp:Int = 0;
+
+	public function new(type:GamepadEventType = null, id:Int = 0, button:Int = 0, axis:Int = 0, value:Float = 0, timestamp:Int = 0)
 	{
 		this.type = type;
 		this.id = id;
 		this.button = button;
 		this.axis = axis;
 		this.axisValue = value;
+		this.timestamp = timestamp;
 	}
 
 	public function clone():GamepadEventInfo
@@ -762,17 +775,21 @@ class NativeApplication
 	public var type:KeyEventType;
 	public var windowID:Int;
 
-	public function new(type:KeyEventType = null, windowID:Int = 0, keyCode: Float = 0, modifier:Int = 0)
+	// TODO: This should probably be an Int64
+	public var timestamp:Int = 0;
+
+	public function new(type:KeyEventType = null, windowID:Int = 0, keyCode: Float = 0, modifier:Int = 0, timestamp:Int = 0)
 	{
 		this.type = type;
 		this.windowID = windowID;
 		this.keyCode = keyCode;
 		this.modifier = modifier;
+		this.timestamp = timestamp;
 	}
 
 	public function clone():KeyEventInfo
 	{
-		return new KeyEventInfo(type, windowID, keyCode, modifier);
+		return new KeyEventInfo(type, windowID, keyCode, modifier, timestamp);
 	}
 }
 

--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -263,14 +263,17 @@ class NativeApplication
 			var int32:Float = keyEventInfo.keyCode;
 			var keyCode:KeyCode = Std.int(int32);
 			var modifier:KeyModifier = keyEventInfo.modifier;
+			var timestamp = keyEventInfo.timestamp;
 
 			switch (type)
 			{
 				case KEY_DOWN:
 					window.onKeyDown.dispatch(keyCode, modifier);
+					window.onKeyDownPrecise.dispatch(keyCode, modifier, timestamp);
 
 				case KEY_UP:
 					window.onKeyUp.dispatch(keyCode, modifier);
+					window.onKeyUpPrecise.dispatch(keyCode, modifier, timestamp);
 			}
 
 			#if (windows || linux)

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -241,6 +241,8 @@ class NativeCFFI
 
 	@:cffi private static function lime_sensor_event_manager_register(callback:Dynamic, eventObject:Dynamic):Void;
 
+	@:cffi private static function lime_sdl_get_ticks():Int;
+
 	@:cffi private static function lime_system_get_allow_screen_timeout():Bool;
 
 	@:cffi private static function lime_system_set_allow_screen_timeout(value:Bool):Bool;
@@ -520,6 +522,7 @@ class NativeCFFI
 		"lime_render_event_manager_register", "oov", false));
 	private static var lime_sensor_event_manager_register = new cpp.Callable<cpp.Object->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_sensor_event_manager_register", "oov", false));
+	private static var lime_sdl_get_ticks = new cpp.Callable<Void->Int>(cpp.Prime._loadPrime("lime", "lime_sdl_get_ticks", "i", false));
 	private static var lime_system_get_allow_screen_timeout = new cpp.Callable<Void->Bool>(cpp.Prime._loadPrime("lime",
 		"lime_system_get_allow_screen_timeout", "b", false));
 	private static var lime_system_set_allow_screen_timeout = new cpp.Callable<Bool->Bool>(cpp.Prime._loadPrime("lime",
@@ -716,6 +719,7 @@ class NativeCFFI
 	private static var lime_png_decode_file = CFFI.load("lime", "lime_png_decode_file", 3);
 	private static var lime_render_event_manager_register = CFFI.load("lime", "lime_render_event_manager_register", 2);
 	private static var lime_sensor_event_manager_register = CFFI.load("lime", "lime_sensor_event_manager_register", 2);
+	private static var lime_sdl_get_ticks = CFFI.load("lime", "lime_sdl_get_ticks", 0);
 	private static var lime_system_get_allow_screen_timeout = CFFI.load("lime", "lime_system_get_allow_screen_timeout", 0);
 	private static var lime_system_set_allow_screen_timeout = CFFI.load("lime", "lime_system_set_allow_screen_timeout", 1);
 	private static var lime_system_get_device_model = CFFI.load("lime", "lime_system_get_device_model", 0);
@@ -1163,6 +1167,11 @@ class NativeCFFI
 
 	@:hlNative("lime", "hl_sensor_event_manager_register") private static function lime_sensor_event_manager_register(callback:Void->Void,
 		eventObject:SensorEventInfo):Void {}
+
+	@:hlNative("lime", "hl_sdl_get_ticks") private static function lime_sdl_get_ticks():Int
+	{
+		return 0;
+	}
 
 	@:hlNative("lime", "hl_system_get_allow_screen_timeout") private static function lime_system_get_allow_screen_timeout():Bool
 	{

--- a/src/lime/app/Application.hx
+++ b/src/lime/app/Application.hx
@@ -1,5 +1,6 @@
 package lime.app;
 
+import haxe.Int64;
 import lime.graphics.RenderContext;
 import lime.system.System;
 import lime.ui.Gamepad;
@@ -173,6 +174,31 @@ class Application extends Module
 	public function onGamepadButtonUp(gamepad:Gamepad, button:GamepadButton):Void {}
 
 	/**
+		Called when a gamepad axis move event is fired
+		@param	gamepad	The current gamepad
+		@param	axis	The axis that was moved
+		@param	value	The axis value (between 0 and 1)
+		@param	timestamp 	The timestamp of the event
+	**/
+	public function onGamepadAxisMovePrecise(gamepad:Gamepad, axis:GamepadAxis, value:Float, timestamp:Int64):Void {}
+
+	/**
+		Called when a gamepad button down event is fired
+		@param	gamepad	The current gamepad
+		@param	button	The button that was pressed
+		@param	timestamp 	The timestamp of the event
+	**/
+	public function onGamepadButtonDownPrecise(gamepad:Gamepad, button:GamepadButton, timestamp:Int64):Void {}
+
+	/**
+		Called when a gamepad button up event is fired
+		@param	gamepad	The current gamepad
+		@param	button	The button that was released
+		@param	timestamp 	The timestamp of the event
+	**/
+	public function onGamepadButtonUpPrecise(gamepad:Gamepad, button:GamepadButton, timestamp:Int64):Void {}
+
+	/**
 		Called when a gamepad is connected
 		@param	gamepad	The gamepad that was connected
 	**/
@@ -239,6 +265,22 @@ class Application extends Module
 		@param	modifier	The modifier of the key that was released
 	**/
 	public function onKeyUp(keyCode:KeyCode, modifier:KeyModifier):Void {}
+
+	/**
+		Called when a key down event is fired on the primary window
+		@param	keyCode	The code of the key that was pressed
+		@param	modifier	The modifier of the key that was pressed
+		@param	timestamp 	The timestamp of the event
+	**/
+	public function onKeyDownPrecise(keyCode:KeyCode, modifier:KeyModifier, timestamp:Int64):Void {}
+
+	/**
+		Called when a key up event is fired on the primary window
+		@param	keyCode	The code of the key that was released
+		@param	modifier	The modifier of the key that was released
+		@param	timestamp 	The timestamp of the event
+	**/
+	public function onKeyUpPrecise(keyCode:KeyCode, modifier:KeyModifier, timestamp:Int64):Void {}
 
 	/**
 		Called when the module is exiting
@@ -473,6 +515,8 @@ class Application extends Module
 				window.onFullscreen.add(onWindowFullscreen);
 				window.onKeyDown.add(onKeyDown);
 				window.onKeyUp.add(onKeyUp);
+				window.onKeyDownPrecise.add(onKeyDownPrecise);
+				window.onKeyUpPrecise.add(onKeyUpPrecise);
 				window.onLeave.add(onWindowLeave);
 				window.onMinimize.add(onWindowMinimize);
 				window.onMouseDown.add(onMouseDown);
@@ -564,6 +608,9 @@ class Application extends Module
 		gamepad.onAxisMove.add(onGamepadAxisMove.bind(gamepad));
 		gamepad.onButtonDown.add(onGamepadButtonDown.bind(gamepad));
 		gamepad.onButtonUp.add(onGamepadButtonUp.bind(gamepad));
+		gamepad.onAxisMovePrecise.add(onGamepadAxisMovePrecise.bind(gamepad));
+		gamepad.onButtonDownPrecise.add(onGamepadButtonDownPrecise.bind(gamepad));
+		gamepad.onButtonUpPrecise.add(onGamepadButtonUpPrecise.bind(gamepad));
 		gamepad.onDisconnect.add(onGamepadDisconnect.bind(gamepad));
 	}
 

--- a/src/lime/ui/Gamepad.hx
+++ b/src/lime/ui/Gamepad.hx
@@ -22,6 +22,9 @@ class Gamepad
 	public var onAxisMove = new Event<GamepadAxis->Float->Void>();
 	public var onButtonDown = new Event<GamepadButton->Void>();
 	public var onButtonUp = new Event<GamepadButton->Void>();
+	public var onAxisMovePrecise = new Event<GamepadAxis->Float->haxe.Int64->Void>();
+	public var onButtonDownPrecise = new Event<GamepadButton->haxe.Int64->Void>();
+	public var onButtonUpPrecise = new Event<GamepadButton->haxe.Int64->Void>();
 	public var onDisconnect = new Event<Void->Void>();
 
 	public function new(id:Int)

--- a/src/lime/ui/Window.hx
+++ b/src/lime/ui/Window.hx
@@ -69,6 +69,8 @@ class Window
 	public var onHide(default, null) = new Event<Void->Void>();
 	public var onKeyDown(default, null) = new Event<KeyCode->KeyModifier->Void>();
 	public var onKeyUp(default, null) = new Event<KeyCode->KeyModifier->Void>();
+	public var onKeyDownPrecise(default, null) = new Event<KeyCode->KeyModifier->haxe.Int64->Void>();
+	public var onKeyUpPrecise(default, null) = new Event<KeyCode->KeyModifier->haxe.Int64->Void>();
 	public var onLeave(default, null) = new Event<Void->Void>();
 	public var onMaximize(default, null) = new Event<Void->Void>();
 	public var onMinimize(default, null) = new Event<Void->Void>();


### PR DESCRIPTION
This feature adds several functions which allow for precise tracking of inputs using timestamps provided by SDL.

SDL provides a `timestamp` field on each Keyboard key press, and each Gamepad button press and axis change. By recording these timestamps and including them in the event objects, developers can receive a precise record of when the input was pressed.

Using this information requires knowing the current SDL timestamp, thus a `lime_sdl_get_ticks()` function is provided.

**Notes:**
- This feature was developed for, and is actively used by, [Friday Night Funkin'](https://github.com/FunkinCrew/Funkin) in order to precisely track and rate user inputs.
  - This code has been tested and proven, however that was in our `develop` branch and porting the changes over to `8.2.0-Dev` may cause some issues.
- This creates 5 new events, rather than modifying the existing ones, because adding a new argument is a hard breaking change that prevents applications which use the existing events from building.
- Timestamps currently use millisecond timings. SDL version 3, which is currently [nearing a stable release](https://discourse.libsdl.org/t/announcing-the-sdl-3-1-0-preview-release/50076), provides support for nanosecond timestamps, which should be used as soon as convenient.