### PR TITLE
[tools] Cross compile to x86 from arm64 on mac

### DIFF
--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -450,7 +450,14 @@ class MacPlatform extends PlatformTarget
 			case X86:
 				commands.push(["-Dmac", "-DHXCPP_CLANG", "-DHXCPP_M32"]);
 			case ARM64:
-				commands.push(["-Dmac", "-DHXCPP_CLANG", "-DHXCPP_ARM64"]);
+				if (targetFlags.exists("64"))
+				{
+					commands.push(["-Dmac", "-DHXCPP_CLANG", "-DHXCPP_ARCH=x86_64"]);
+				}
+				else
+				{
+					commands.push(["-Dmac", "-DHXCPP_CLANG", "-DHXCPP_ARM64"]);
+				}
 			default:
 		}
 


### PR DESCRIPTION
I'm not sure if `-64` is the right flag to use here (since arm64 is a 64 bit architecture too), maybe it would be better to use something more specific like `-x86-64`?