### PR TITLE
Fix curl static linking on mac

### DIFF
--- a/templates/cpp/static/BuildMain.xml
+++ b/templates/cpp/static/BuildMain.xml
@@ -63,6 +63,7 @@
 			<vflag name="-framework" value="Carbon" />
 			<vflag name="-framework" value="AppKit" />
 			<vflag name="-framework" value="OpenAL"/>
+			<vflag name="-framework" value="SystemConfiguration"/>
 
 			<lib name="/opt/local/lib/libgc.a" if="LIME_NEKO" />
 			<lib name="-lm" if="LIME_NEKO" />


### PR DESCRIPTION
When linking lime statically, we also need to add this -framework flag for curl. Otherwise a link error occurs:
```
Undefined symbols for architecture x86_64:
  "_SCDynamicStoreCopyProxies", referenced from:
      _Curl_resolv in liblime.a(9a49273bb93d215bdc76ffe1cf488a.o)
ld: symbol(s) not found for architecture x86_64
```

This was overlooked in #1682.