### PR TITLE
Add deleteEffect, deleteFilter to AL Class

### DIFF
--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -1496,6 +1496,10 @@ class NativeCFFI
 
 	@:cffi private static function lime_al_delete_buffers(n:Int, buffers:Dynamic):Void;
 
+	@:cffi private static function lime_al_delete_effect(effect:CFFIPointer):Void;
+
+	@:cffi private static function lime_al_delete_filter(filter:CFFIPointer):Void;
+
 	@:cffi private static function lime_al_delete_source(source:CFFIPointer):Void;
 
 	@:cffi private static function lime_al_delete_sources(n:Int, sources:Dynamic):Void;
@@ -1715,6 +1719,8 @@ class NativeCFFI
 	private static var lime_al_delete_buffer = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_buffer", "ov", false));
 	private static var lime_al_delete_buffers = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_buffers", "iov",
 		false));
+	private static var lime_al_delete_effect = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_effect", "ov", false));
+	private static var lime_al_delete_filter = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_filter", "ov", false));
 	private static var lime_al_delete_source = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_source", "ov", false));
 	private static var lime_al_delete_sources = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_sources", "iov",
 		false));
@@ -1865,6 +1871,8 @@ class NativeCFFI
 	private static var lime_al_cleanup = CFFI.load("lime", "lime_al_cleanup", 0);
 	private static var lime_al_delete_buffer = CFFI.load("lime", "lime_al_delete_buffer", 1);
 	private static var lime_al_delete_buffers = CFFI.load("lime", "lime_al_delete_buffers", 2);
+	private static var lime_al_delete_effect = CFFI.load("lime", "lime_al_delete_effect", 1);
+	private static var lime_al_delete_filter = CFFI.load("lime", "lime_al_delete_filter", 1);
 	private static var lime_al_delete_source = CFFI.load("lime", "lime_al_delete_source", 1);
 	private static var lime_al_delete_sources = CFFI.load("lime", "lime_al_delete_sources", 2);
 	private static var lime_al_disable = CFFI.load("lime", "lime_al_disable", 1);
@@ -1990,6 +1998,10 @@ class NativeCFFI
 	@:hlNative("lime", "hl_al_delete_buffer") private static function lime_al_delete_buffer(buffer:CFFIPointer):Void {}
 
 	@:hlNative("lime", "hl_al_delete_buffers") private static function lime_al_delete_buffers(n:Int, buffers:hl.NativeArray<CFFIPointer>):Void {}
+
+	@:hlNative("lime", "hl_al_delete_effect") private static function lime_al_delete_effect(effect:CFFIPointer):Void {}
+
+	@:hlNative("lime", "hl_al_delete_filter") private static function lime_al_delete_filter(filter:CFFIPointer):Void {}
 
 	@:hlNative("lime", "hl_al_delete_source") private static function lime_al_delete_source(source:CFFIPointer):Void {}
 

--- a/src/lime/media/openal/AL.hx
+++ b/src/lime/media/openal/AL.hx
@@ -412,6 +412,20 @@ class AL
 		#end
 	}
 
+	public static function deleteEffect(effect:ALEffect):Void
+	{
+		#if (lime_cffi && lime_openal && !macro)
+		NativeCFFI.lime_al_delete_effect(effect);
+		#end
+	}
+
+	public static function deleteFilter(filter:ALFilter):Void
+	{
+		#if (lime_cffi && lime_openal && !macro)
+		NativeCFFI.lime_al_delete_filter(filter);
+		#end
+	}
+
 	public static function deleteSource(source:ALSource):Void
 	{
 		#if (lime_cffi && lime_openal && !macro)


### PR DESCRIPTION
Adds missing function from OpenALBindings.cpp to AL, NativeCFFI Class
I'm aware that it does have a finalizer for gc, though just incase i'm adding this in