### PR TITLE
Expose more `ThreadPool` functionality through `Future.withEventualValue()`.

### DIFF
--- a/src/lime/app/Future.hx
+++ b/src/lime/app/Future.hx
@@ -388,9 +388,26 @@ enum FutureStatus<T>
 #end
 @:dox(hide) class FutureWork
 {
-	public static var singleThread(default, null):FutureWork = new FutureWork(SINGLE_THREADED);
+	public static var singleThread(get, null):FutureWork;
+	private static inline function get_singleThread():FutureWork
+	{
+		if (singleThread == null)
+		{
+			singleThread = new FutureWork(SINGLE_THREADED);
+		}
+		return singleThread;
+	}
+
 	#if lime_threads
-	public static var multiThread(default, null):FutureWork = new FutureWork(MULTI_THREADED);
+	public static var multiThread(get, null):FutureWork;
+	private static inline function get_multiThread():FutureWork
+	{
+		if (multiThread == null)
+		{
+			multiThread = new FutureWork(MULTI_THREADED);
+		}
+		return multiThread;
+	}
 	#end
 
 	public static var totalActiveJobs(get, never):Int;

--- a/src/lime/app/Future.hx
+++ b/src/lime/app/Future.hx
@@ -67,12 +67,12 @@ import lime.utils.Log;
 	@:noCompletion private var __progressListeners:Array<Int->Int->Void>;
 
 	/**
-		@param work 	Deprecated; use `Future.withEventualValue()` instead.
+		@param doWork 	Deprecated; use `Future.withEventualValue()` instead.
 		@param useThreads 	Deprecated; use `Future.withEventualValue()` instead.
 	**/
-	public function new(work:WorkFunction<Void->T> = null, useThreads:Bool = false)
+	public function new(doWork:WorkFunction<Void->T> = null, useThreads:Bool = false)
 	{
-		if (work != null)
+		if (doWork != null)
 		{
 			var promise = new Promise<T>();
 			promise.future = this;
@@ -80,11 +80,11 @@ import lime.utils.Log;
 			#if (lime_threads && html5)
 			if (useThreads)
 			{
-				work.makePortable();
+				doWork.makePortable();
 			}
 			#end
 
-			FutureWork.run(dispatchWorkFunction, work, promise, useThreads ? MULTI_THREADED : SINGLE_THREADED, true);
+			FutureWork.run(dispatchWorkFunction, doWork, promise, useThreads ? MULTI_THREADED : SINGLE_THREADED);
 		}
 	}
 
@@ -203,7 +203,7 @@ import lime.utils.Log;
 			{
 				if (FutureWork.activeJobs < 1)
 				{
-					Log.error('Cannot block for a Future without a "work" function.');
+					Log.error('Cannot block for a Future without a "doWork" function.');
 					return this;
 				}
 
@@ -309,24 +309,34 @@ import lime.utils.Log;
 	/**
 		Creates a `Future` instance which will asynchronously compute a value.
 
-		Once `work()` returns a non-null value, the `Future` will finish with that value.
-		If `work()` throws an error, the `Future` will finish with that error instead.
-		@param	work 	A function that computes a value of type `T`.
-		@param  state   An argument to pass to `work()`. As this may be used on another thread, the
-		main thread must not access or modify `state` until the `Future` finishes.
-		@param  mode 	Whether to use real threads as opposed to green threads. Green threads rely
-		on cooperative multitasking, meaning `work()` must return periodically to allow other code
-		enough time to run. In these cases, `work()` should return null to signal that it isn't finished.
+		The provided `doWork` function is the same as as a `ThreadPool` work function.
+		It will run repeatedly until it calls `sendComplete()` or `sendError()`, and
+		should aim to do a small fraction of the work each time. This is important in
+		single-threaded mode to avoid blocking the main thread.
+
+		The three output functions:
+
+		- `sendComplete()` requires a value of type `T` and resolves the `Future` as complete.
+		  Passing the wrong value causes unspecified behavior.
+		- `sendError()` takes any value and resolves the `Future` with that error.
+		- `sendProgress()` requires a `{progress:Int, total:Int}` value. This information will
+		  be sent to any `onProgress` listeners. Any other values will be ignored.
+		@param	doWork 	The function that performs the work.
+		@param  state   An argument to pass to `doWork`. Defaults to `{}`. The same instance will
+		be passed each time `doWork` is called, allowing it to store data between calls. To avoid
+		race conditions, the main thread should not access or modify `state` until all work finishes.
+		@param  mode 	Whether to use real threads (`MULTI_THREADED`) as opposed to green threads (`SINGLE_THREADED`).
+		In single-threaded mode, it's especially important for `doWork` to return often.
 		@return	A new `Future` instance.
-		@see https://en.wikipedia.org/wiki/Cooperative_multitasking
+		@see lime.system.ThreadPool
 	**/
-	public static function withEventualValue<T>(work:WorkFunction<State -> Null<T>>, state:State, mode:ThreadMode = #if html5 SINGLE_THREADED #else MULTI_THREADED #end):Future<T>
+	public static function withEventualValue<T>(doWork:WorkFunction<State -> WorkOutput -> Void>, ?state:State, mode:ThreadMode = #if html5 SINGLE_THREADED #else MULTI_THREADED #end):Future<T>
 	{
 		var future = new Future<T>();
 		var promise = new Promise<T>();
 		promise.future = future;
 
-		FutureWork.run(work, state, promise, mode);
+		FutureWork.run(doWork, state, promise, mode);
 
 		return future;
 	}
@@ -334,14 +344,42 @@ import lime.utils.Log;
 	/**
 		(For backwards compatibility.) Dispatches the given zero-argument function.
 	**/
-	@:noCompletion private static function dispatchWorkFunction<T>(work:WorkFunction<Void -> T>):Null<T>
+	@:noCompletion private static function dispatchWorkFunction<T>(doWork:WorkFunction<Void -> T>, output:WorkOutput):Void
 	{
-		return work.dispatch();
+		output.sendComplete(doWork.dispatch());
 	}
 }
 
 /**
-	The class that handles asynchronous `work` functions passed to `new Future()`.
+	Return values for work functions used with `Future.withEventualValue()`,
+	used to describe the state of the work.
+**/
+enum FutureStatus<T>
+{
+	/**
+		Resolves the `Future` with a completion state. The work function won't be called again.
+	**/
+	Complete(value:T);
+
+	/**
+		Resolves the `Future` with an error state. The work function won't be called again.
+	**/
+	Error(error:Dynamic);
+
+	/**
+		Re-runs the work function without dispatching an event. This is particularly important
+		in single-threaded mode, to avoid blocking the main thread.
+	**/
+	Incomplete;
+
+	/**
+		Dispatches a progress event before re-running the work function.
+	**/
+	Progress(progress:Int, total:Int);
+}
+
+/**
+	The class that handles asynchronous `doWork` functions passed to `Future.withEventualValue()`.
 **/
 #if !lime_debug
 @:fileXml('tags="haxe,release"')
@@ -351,12 +389,13 @@ import lime.utils.Log;
 {
 	@:allow(lime.app.Future)
 	private static var singleThreadPool:ThreadPool;
+	private static var promisesSingle:Map<Int, {complete:Dynamic -> Dynamic, error:Dynamic -> Dynamic, progress:Int -> Int -> Dynamic}> = new Map();
 	#if lime_threads
 	private static var multiThreadPool:ThreadPool;
 	// It isn't safe to pass a promise object to a web worker, but since it's
 	// `@:generic` we can't store it as `Promise<Dynamic>`. Instead, we'll store
-	// the two methods we need.
-	private static var promises:Map<Int, {complete:Dynamic -> Dynamic, error:Dynamic -> Dynamic}> = new Map();
+	// the methods we need.
+	private static var promisesMulti:Map<Int, {complete:Dynamic -> Dynamic, error:Dynamic -> Dynamic, progress:Int -> Int -> Dynamic}> = new Map();
 	#end
 	public static var minThreads(default, set):Int = 0;
 	public static var maxThreads(default, set):Int = 1;
@@ -370,6 +409,7 @@ import lime.utils.Log;
 				multiThreadPool = new ThreadPool(minThreads, maxThreads, MULTI_THREADED);
 				multiThreadPool.onComplete.add(multiThreadPool_onComplete);
 				multiThreadPool.onError.add(multiThreadPool_onError);
+				multiThreadPool.onProgress.add(multiThreadPool_onProgress);
 			}
 			return multiThreadPool;
 		}
@@ -378,76 +418,72 @@ import lime.utils.Log;
 			singleThreadPool = new ThreadPool(minThreads, maxThreads, SINGLE_THREADED);
 			singleThreadPool.onComplete.add(singleThreadPool_onComplete);
 			singleThreadPool.onError.add(singleThreadPool_onError);
+			singleThreadPool.onProgress.add(singleThreadPool_onProgress);
 		}
 		return singleThreadPool;
 	}
 
 	@:allow(lime.app.Future)
-	private static function run<T>(work:WorkFunction<State->Null<T>>, state:State, promise:Promise<T>, mode:ThreadMode = MULTI_THREADED, legacyCode:Bool = false):Void
+	private static function run<T>(doWork:WorkFunction<State->WorkOutput->Void>, state:State, promise:Promise<T>, mode:ThreadMode = MULTI_THREADED):Void
 	{
-		var bundle = {work: work, state: state, promise: promise, legacyCode: legacyCode};
+		var jobID:Int = getPool(mode).run(doWork, state);
 
 		#if lime_threads
 		if (mode == MULTI_THREADED)
 		{
-			#if html5
-			work.makePortable();
-			#end
-
-			bundle.promise = null;
+			promisesMulti[jobID] = {complete: promise.complete, error: promise.error, progress: promise.progress};
 		}
+		else
 		#end
-
-		var jobID:Int = getPool(mode).run(threadPool_doWork, bundle);
-
-		#if lime_threads
-		if (mode == MULTI_THREADED)
 		{
-			promises[jobID] = {complete: promise.complete, error: promise.error};
+			promisesSingle[jobID] = {complete: promise.complete, error: promise.error, progress: promise.progress};
 		}
-		#end
 	}
 
 	// Event Handlers
-	private static function threadPool_doWork(bundle:{work:WorkFunction<State->Dynamic>, state:State, legacyCode:Bool}, output:WorkOutput):Void
-	{
-		try
-		{
-			var result = bundle.work.dispatch(bundle.state);
-			if (result != null || bundle.legacyCode)
-			{
-				output.sendComplete(result);
-			}
-		}
-		catch (e:Dynamic)
-		{
-			output.sendError(e);
-		}
-	}
-
 	private static function singleThreadPool_onComplete(result:Dynamic):Void
 	{
-		singleThreadPool.activeJob.state.promise.complete(result);
+		var promise = promisesSingle[singleThreadPool.activeJob.id];
+		promisesSingle.remove(singleThreadPool.activeJob.id);
+		promise.complete(result);
 	}
 
 	private static function singleThreadPool_onError(error:Dynamic):Void
 	{
-		singleThreadPool.activeJob.state.promise.error(error);
+		var promise = promisesSingle[singleThreadPool.activeJob.id];
+		promisesSingle.remove(singleThreadPool.activeJob.id);
+		promise.error(error);
+	}
+
+	private static function singleThreadPool_onProgress(progress:{progress:Int, total:Int}):Void
+	{
+		if (Type.typeof(progress) == TObject && Type.typeof(progress.progress) == TInt && Type.typeof(progress.total) == TInt)
+		{
+			promisesSingle[singleThreadPool.activeJob.id].progress(progress.progress, progress.total);
+		}
 	}
 
 	#if lime_threads
 	private static function multiThreadPool_onComplete(result:Dynamic):Void
 	{
-		var promise = promises[multiThreadPool.activeJob.id];
-		promises.remove(multiThreadPool.activeJob.id);
+		var promise = promisesMulti[multiThreadPool.activeJob.id];
+		promisesMulti.remove(multiThreadPool.activeJob.id);
 		promise.complete(result);
 	}
 
 	private static function multiThreadPool_onError(error:Dynamic):Void
 	{
-		var promise = promises[multiThreadPool.activeJob.id];
-		promises.remove(multiThreadPool.activeJob.id);
+		var promise = promisesMulti[multiThreadPool.activeJob.id];
+		promisesMulti.remove(multiThreadPool.activeJob.id);
 		promise.error(error);
+	}
+
+	private static function multiThreadPool_onProgress(progress:{progress:Int, total:Int}):Void
+	{
+		if (Type.typeof(progress) == TObject && Type.typeof(progress.progress) == TInt && Type.typeof(progress.total) == TInt)
+		{
+			promisesMulti[multiThreadPool.activeJob.id].progress(progress.progress, progress.total);
+		}
 	}
 	#end
 

--- a/src/lime/app/Future.hx
+++ b/src/lime/app/Future.hx
@@ -84,8 +84,7 @@ import lime.utils.Log;
 			}
 			#end
 
-			FutureWork.forMode(useThreads ? MULTI_THREADED : SINGLE_THREADED)
-				.run(dispatchWorkFunction, doWork, promise);
+			FutureWork.forMode(useThreads ? MULTI_THREADED : SINGLE_THREADED).run(dispatchWorkFunction, doWork, promise);
 		}
 	}
 
@@ -331,7 +330,8 @@ import lime.utils.Log;
 		@return	A new `Future` instance.
 		@see lime.system.ThreadPool
 	**/
-	public static function withEventualValue<T>(doWork:WorkFunction<State -> WorkOutput -> Void>, ?state:State, mode:ThreadMode = #if html5 SINGLE_THREADED #else MULTI_THREADED #end):Future<T>
+	public static function withEventualValue<T>(doWork:WorkFunction<State->WorkOutput->Void>, ?state:State,
+			mode:ThreadMode = #if html5 SINGLE_THREADED #else MULTI_THREADED #end):Future<T>
 	{
 		var future = new Future<T>();
 		var promise = new Promise<T>();
@@ -345,7 +345,7 @@ import lime.utils.Log;
 	/**
 		(For backwards compatibility.) Dispatches the given zero-argument function.
 	**/
-	@:noCompletion private static function dispatchWorkFunction<T>(doWork:WorkFunction<Void -> T>, output:WorkOutput):Void
+	@:noCompletion private static function dispatchWorkFunction<T>(doWork:WorkFunction<Void->T>, output:WorkOutput):Void
 	{
 		output.sendComplete(doWork.dispatch());
 	}
@@ -389,6 +389,7 @@ enum FutureStatus<T>
 @:dox(hide) class FutureWork
 {
 	public static var singleThread(get, null):FutureWork;
+
 	private static inline function get_singleThread():FutureWork
 	{
 		if (singleThread == null)
@@ -400,6 +401,7 @@ enum FutureStatus<T>
 
 	#if lime_threads
 	public static var multiThread(get, null):FutureWork;
+
 	private static inline function get_multiThread():FutureWork
 	{
 		if (multiThread == null)
@@ -411,6 +413,7 @@ enum FutureStatus<T>
 	#end
 
 	public static var totalActiveJobs(get, never):Int;
+
 	private static inline function get_totalActiveJobs():Int
 	{
 		return singleThread.activeJobs #if lime_threads + multiThread.activeJobs #end;
@@ -420,7 +423,8 @@ enum FutureStatus<T>
 	private static function forMode(mode:ThreadMode):FutureWork
 	{
 		#if lime_threads
-		if (mode == MULTI_THREADED) {
+		if (mode == MULTI_THREADED)
+		{
 			return multiThread;
 		}
 		#end
@@ -431,7 +435,7 @@ enum FutureStatus<T>
 
 	// Because `Promise` is `@:generic`, we can't always store it as `Promise<Dynamic>`.
 	// Instead, we'll store the specific methods we need.
-	private var promises:Map<Int, {complete:Dynamic -> Dynamic, error:Dynamic -> Dynamic, progress:Int -> Int -> Dynamic}> = new Map();
+	private var promises:Map<Int, {complete:Dynamic->Dynamic, error:Dynamic->Dynamic, progress:Int->Int->Dynamic}> = new Map();
 
 	public var minThreads(get, set):Int;
 	public var maxThreads(get, set):Int;
@@ -480,6 +484,7 @@ enum FutureStatus<T>
 	{
 		return threadPool.minThreads;
 	}
+
 	private inline function set_minThreads(value:Int):Int
 	{
 		return threadPool.minThreads = value;
@@ -489,6 +494,7 @@ enum FutureStatus<T>
 	{
 		return threadPool.maxThreads;
 	}
+
 	private inline function set_maxThreads(value:Int):Int
 	{
 		return threadPool.maxThreads = value;

--- a/src/lime/graphics/Image.hx
+++ b/src/lime/graphics/Image.hx
@@ -1002,7 +1002,7 @@ class Image
 
 		return promise.future;
 		#else
-		return Future.withEventualValue(fromBytes, bytes, MULTI_THREADED);
+		return new Future(fromBytes.bind(bytes), true);
 		#end
 	}
 

--- a/src/lime/media/AudioBuffer.hx
+++ b/src/lime/media/AudioBuffer.hx
@@ -335,7 +335,7 @@ class AudioBuffer
 
 		return promise.future;
 		#else
-		return Future.withEventualValue(fromFiles, paths, MULTI_THREADED);
+		return new Future(fromFiles.bind(paths), true);
 		#end
 	}
 

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -211,7 +211,7 @@ class ThreadPool extends WorkOutput
 		`SINGLE_THREADED` in HTML5. In HTML5, `MULTI_THREADED` mode uses web
 		workers, which impose additional restrictions.
 	**/
-	public function new(minThreads:Int = 0, maxThreads:Int = 1, mode:ThreadMode = null)
+	public function new(?minThreads:Int = 0, ?maxThreads:Int = 1, ?mode:ThreadMode = null)
 	{
 		super(mode);
 

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -38,7 +38,7 @@ import lime._internal.backend.html5.HTML5Thread as Thread;
 	trigger an `onComplete` event on the main thread.
 
 	@see `lime.system.WorkOutput.WorkFunction` for important information about
-	     `doWork`.
+		 `doWork`.
 	@see https://player03.com/openfl/threads-guide/ for a tutorial.
 **/
 #if !lime_debug
@@ -69,7 +69,7 @@ class ThreadPool extends WorkOutput
 		frame. See `workIterations` for instructions to improve the accuracy of
 		this estimate.
 	**/
-	public static var workLoad:Float = 1/2;
+	public static var workLoad:Float = 1 / 2;
 
 	/**
 		__Access this only from the main thread.__
@@ -152,16 +152,19 @@ class ThreadPool extends WorkOutput
 		Dispatched at most once per job.
 	**/
 	public var onComplete(default, null) = new Event<Dynamic->Void>();
+
 	/**
 		Dispatched on the main thread when `doWork` calls `sendError()`.
 		Dispatched at most once per job.
 	**/
 	public var onError(default, null) = new Event<Dynamic->Void>();
+
 	/**
 		Dispatched on the main thread when `doWork` calls `sendProgress()`. May
 		be dispatched any number of times per job.
 	**/
 	public var onProgress(default, null) = new Event<Dynamic->Void>();
+
 	/**
 		Dispatched on the main thread when a new job begins. Dispatched exactly
 		once per job.
@@ -180,6 +183,7 @@ class ThreadPool extends WorkOutput
 
 	@:deprecated("Instead pass the callback to ThreadPool.run().")
 	@:noCompletion @:dox(hide) public var doWork(get, never):PseudoEvent;
+
 	private var __doWork:WorkFunction<State->WorkOutput->Void>;
 
 	private var __activeJobs:JobList;
@@ -390,6 +394,7 @@ class ThreadPool extends WorkOutput
 	**/
 	private static function __executeThread():Void
 	{
+		// @formatter:off
 		JSAsync.async({
 			var output:WorkOutput = #if html5 new WorkOutput(MULTI_THREADED) #else cast(Thread.readMessage(true), WorkOutput) #end;
 			var event:ThreadEvent = null;
@@ -448,7 +453,7 @@ class ThreadPool extends WorkOutput
 					// Work is done; wait for more.
 					event = interruption;
 				}
-				else if(Reflect.hasField(interruption, "event"))
+				else if (Reflect.hasField(interruption, "event"))
 				{
 					// Work on the new job.
 					event = interruption;
@@ -462,6 +467,7 @@ class ThreadPool extends WorkOutput
 				// Do it all again.
 			}
 		});
+		// @formatter:on
 	}
 	#end
 
@@ -519,8 +525,7 @@ class ThreadPool extends WorkOutput
 			// `workLoad / frameRate` is the total time that pools may use per
 			// frame. `workPriority / __totalWorkPriority` is this pool's
 			// fraction of that total.
-			var maxTimeElapsed:Float = workPriority * workLoad
-				/ (__totalWorkPriority * Application.current.window.frameRate);
+			var maxTimeElapsed:Float = workPriority * workLoad / (__totalWorkPriority * Application.current.window.frameRate);
 
 			var startTime:Float = timestamp();
 			var timeElapsed:Float = 0;
@@ -664,33 +669,56 @@ class ThreadPool extends WorkOutput
 }
 
 @:access(lime.system.ThreadPool) @:forward(canceled)
-private abstract PseudoEvent(ThreadPool) from ThreadPool {
+private abstract PseudoEvent(ThreadPool) from ThreadPool
+{
 	@:noCompletion @:dox(hide) public var __listeners(get, never):Array<Dynamic>;
-	private inline function get___listeners():Array<Dynamic> { return []; };
-	@:noCompletion @:dox(hide) public var __repeat(get, never):Array<Bool>;
-	private inline function get___repeat():Array<Bool> { return []; };
 
-	public function add(callback:Dynamic -> Void):Void {
+	private inline function get___listeners():Array<Dynamic>
+	{
+		return [];
+	};
+
+	@:noCompletion @:dox(hide) public var __repeat(get, never):Array<Bool>;
+
+	private inline function get___repeat():Array<Bool>
+	{
+		return [];
+	};
+
+	public function add(callback:Dynamic->Void):Void
+	{
 		function callCallback(state:State, output:WorkOutput):Void
 		{
 			callback(state);
 		}
 
 		#if (lime_threads && html5)
-		if (this.mode == MULTI_THREADED)
-			throw "Unsupported operation; instead pass the callback to ThreadPool's constructor.";
+		if (this.mode == MULTI_THREADED) throw "Unsupported operation; instead pass the callback to ThreadPool's constructor.";
 		else
-			this.__doWork = { func: callCallback };
+			this.__doWork = {func: callCallback};
 		#else
 		this.__doWork = callCallback;
 		#end
 	}
 
 	public inline function cancel():Void {}
+
 	public inline function dispatch():Void {}
-	public inline function has(callback:Dynamic -> Void):Bool { return this.__doWork != null; }
-	public inline function remove(callback:Dynamic -> Void):Void { this.__doWork = null; }
-	public inline function removeAll():Void { this.__doWork = null; }
+
+	public inline function has(callback:Dynamic->Void):Bool
+	{
+		return this.__doWork != null;
+	}
+
+	public inline function remove(callback:Dynamic->Void):Void
+	{
+		this.__doWork = null;
+	}
+
+	public inline function removeAll():Void
+	{
+		this.__doWork = null;
+	}
 }
 
 class JobList
@@ -834,7 +862,8 @@ class JobList
 
 	// Getters & Setters
 
-	private inline function set___addingWorkPriority(value:Bool):Bool {
+	private inline function set___addingWorkPriority(value:Bool):Bool
+	{
 		if (pool != null && __addingWorkPriority != value && ThreadPool.isMainThread())
 		{
 			if (value)
@@ -869,17 +898,25 @@ class JobList
 	that's in use by multiple jobs, the wrong job may be selected or canceled.
 **/
 @:forward
-abstract JobIdentifier(JobIdentifierImpl) from JobIdentifierImpl {
-	@:from private static inline function fromJob(job:JobData):JobIdentifier {
+abstract JobIdentifier(JobIdentifierImpl) from JobIdentifierImpl
+{
+	@:from private static inline function fromJob(job:JobData):JobIdentifier
+	{
 		return ID(job.id);
 	}
-	@:from private static inline function fromID(id:Int):JobIdentifier {
+
+	@:from private static inline function fromID(id:Int):JobIdentifier
+	{
 		return ID(id);
 	}
-	@:from private static inline function fromFunction(doWork:WorkFunction<State->WorkOutput->Void>):JobIdentifier {
+
+	@:from private static inline function fromFunction(doWork:WorkFunction<State->WorkOutput->Void>):JobIdentifier
+	{
 		return FUNCTION(doWork);
 	}
-	@:from private static inline function fromState(state:State):JobIdentifier {
+
+	@:from private static inline function fromState(state:State):JobIdentifier
+	{
 		return STATE(state);
 	}
 }

--- a/src/lime/system/WorkOutput.hx
+++ b/src/lime/system/WorkOutput.hx
@@ -13,12 +13,10 @@ import neko.vm.Deque;
 import neko.vm.Thread;
 import neko.vm.Tls;
 #end
-
 #if html5
 import lime._internal.backend.html5.HTML5Thread as Thread;
 import lime._internal.backend.html5.HTML5Thread.Transferable;
 #end
-
 #if macro
 import haxe.macro.Expr;
 
@@ -54,6 +52,7 @@ class WorkOutput
 		available on this target, `mode` will always be `SINGLE_THREADED`.
 	**/
 	public var mode(get, never):ThreadMode;
+
 	#if lime_threads
 	/**
 		__Set this only via the constructor.__
@@ -65,6 +64,7 @@ class WorkOutput
 		Messages sent by active jobs, received by the main thread.
 	**/
 	private var __jobOutput:Deque<ThreadEvent> = new Deque();
+
 	/**
 		Thread-local storage. Tracks whether `sendError()` or `sendComplete()`
 		was called by this job.
@@ -77,6 +77,7 @@ class WorkOutput
 		Will be null in all other cases.
 	**/
 	public var activeJob(get, set):Null<JobData>;
+
 	@:noCompletion private var __activeJob:Tls<JobData> = new Tls();
 
 	private inline function new(mode:Null<ThreadMode>)
@@ -171,7 +172,8 @@ class WorkOutput
 		var thread:Thread = Thread.create(executeThread);
 
 		#if html5
-		thread.onMessage.add(function(event:ThreadEvent) {
+		thread.onMessage.add(function(event:ThreadEvent)
+		{
 			__jobOutput.add(event);
 		});
 		#end
@@ -195,6 +197,7 @@ class WorkOutput
 	{
 		return __activeJob.value;
 	}
+
 	private inline function set_activeJob(value:JobData):JobData
 	{
 		return __activeJob.value = value;
@@ -261,8 +264,8 @@ abstract WorkFunction<T:haxe.Constraints.Function>(T) from T to T
 	{
 		switch (self.typeof().follow().toComplexType())
 		{
-			case TPath({ sub: "WorkFunction", params: [TPType(t)] }):
-				return macro ($self:$t)($a{args});
+			case TPath({sub: "WorkFunction", params: [TPType(t)]}):
+				return macro($self : $t)($a{args});
 			default:
 				throw "Underlying function type not found.";
 		}
@@ -275,8 +278,8 @@ abstract WorkFunction<T:haxe.Constraints.Function>(T) from T to T
 	only accepts a single argument, you can pass multiple values as part of an
 	anonymous structure. (Or an array, or a class.)
 
-	    // Does not work: too many arguments.
-	    // threadPool.run(doWork, argument0, argument1, argument2);
+		// Does not work: too many arguments.
+		// threadPool.run(doWork, argument0, argument1, argument2);
 
 		// Works: all arguments are combined into one `State` object.
 		threadPool.run(doWork, { arg0: argument0, arg1: argument1, arg2: argument2 });
@@ -299,6 +302,7 @@ typedef State = Dynamic;
 class JobData
 {
 	private static var nextID:Int = 0;
+
 	/**
 		`JobData` instances will regularly be copied in HTML5, so checking
 		equality won't work. Instead, compare identifiers.
@@ -351,7 +355,8 @@ class JobData
 	var EXIT = "EXIT";
 }
 
-typedef ThreadEvent = {
+typedef ThreadEvent =
+{
 	var event:ThreadEventType;
 	@:optional var message:Dynamic;
 	@:optional var job:JobData;
@@ -379,7 +384,6 @@ class JSAsync
 }
 
 // Define platform-specific types
-
 #if target.threaded
 // Haxe 3 compatibility: "target.threaded" can't go in parentheses.
 #elseif !(cpp || neko)


### PR DESCRIPTION
Previously, `Future.withEventualValue()` tried to match the `Future` constructor, with one subtle difference in behavior. It interpreted null to mean "run the function again," which causes an infinite loop if the programmer returns null without realizing. Joshua found a regression of this sort in Lime itself, one I should have caught but overlooked.

This PR changes the function signature to avoid any possibility of this error. There is no return value anymore, so you can't accidentally return the wrong value. Instead, as with `ThreadPool`, you are given a `WorkOutput` object and must call `sendComplete()` at some point. The work function has the same signature as in `ThreadPool`, so if users understand the one, they'll understand the other.

I have a couple other branches that are closer to how `withEventualValue()` used to work, and I can bring them back if requested. But `withEventualValue()` is new in 8.2.0, so it shouldn't hurt to change its signature.