### PR TITLE
Fix AL.getContextsDevice() always returning null on Hashlink

### DIFF
--- a/src/lime/media/openal/ALC.hx
+++ b/src/lime/media/openal/ALC.hx
@@ -76,12 +76,13 @@ class ALC
 
 	public static function getContextsDevice(context:ALContext):ALDevice
 	{
-		#if (lime_cffi && lime_openal && !macro) #if !hl var handle:Dynamic = NativeCFFI.lime_alc_get_contexts_device(context);
+		#if (lime_cffi && lime_openal && !macro)
+		var handle:Dynamic = NativeCFFI.lime_alc_get_contexts_device(context);
 
 		if (handle != null)
 		{
 			return new ALDevice(handle);
-		} #else #end
+		}
 		#end
 
 		return null;


### PR DESCRIPTION
Despite having [proper bindings](https://github.com/openfl/lime/blob/develop/project/src/media/openal/OpenALBindings.cpp#L3258), the `AL.getContextsDevice()` has a conditional check which ignores hashlink: https://github.com/openfl/lime/blob/develop/src/lime/media/openal/ALC.hx#L79

This PR just gets rid of the conditional