### PR TITLE
Implement bindings for alcIsExtensionPresent

### DIFF
--- a/project/src/media/openal/OpenALBindings.cpp
+++ b/project/src/media/openal/OpenALBindings.cpp
@@ -2301,10 +2301,32 @@ namespace lime {
 	}
 
 
+	bool lime_alc_is_extension_present (HxString extname) {
+
+		#ifdef LIME_OPENALSOFT
+		return alcIsExtensionPresent (extname.__s);
+		#else
+		return false;
+		#endif
+
+	}
+
+
 	HL_PRIM bool HL_NAME(hl_al_is_extension_present) (hl_vstring* extname) {
 
 		#ifdef LIME_OPENALSOFT
 		return alIsExtensionPresent (extname ? hl_to_utf8 (extname->bytes) : NULL);
+		#else
+		return false;
+		#endif
+
+	}
+
+
+	HL_PRIM bool HL_NAME(hl_alc_is_extension_present) (hl_vstring* extname) {
+
+		#ifdef LIME_OPENALSOFT
+		return alcIsExtensionPresent (extname ? hl_to_utf8 (extname->bytes) : NULL);
 		#else
 		return false;
 		#endif
@@ -3580,6 +3602,7 @@ namespace lime {
 	DEFINE_PRIME1 (lime_al_is_effect);
 	DEFINE_PRIME1 (lime_al_is_enabled);
 	DEFINE_PRIME1 (lime_al_is_extension_present);
+	DEFINE_PRIME1 (lime_alc_is_extension_present);
 	DEFINE_PRIME1 (lime_al_is_filter);
 	DEFINE_PRIME1 (lime_al_is_source);
 	DEFINE_PRIME4v (lime_al_listener3f);
@@ -3704,6 +3727,7 @@ namespace lime {
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_effect, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_enabled, _I32);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_extension_present, _STRING);
+	DEFINE_HL_PRIM (_BOOL, hl_alc_is_extension_present, _STRING);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_filter, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_source, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_VOID, hl_al_listener3f, _I32 _F32 _F32 _F32);

--- a/project/src/media/openal/OpenALBindings.cpp
+++ b/project/src/media/openal/OpenALBindings.cpp
@@ -2301,17 +2301,6 @@ namespace lime {
 	}
 
 
-	bool lime_alc_is_extension_present (HxString extname) {
-
-		#ifdef LIME_OPENALSOFT
-		return alcIsExtensionPresent (extname.__s);
-		#else
-		return false;
-		#endif
-
-	}
-
-
 	HL_PRIM bool HL_NAME(hl_al_is_extension_present) (hl_vstring* extname) {
 
 		#ifdef LIME_OPENALSOFT
@@ -2323,10 +2312,23 @@ namespace lime {
 	}
 
 
-	HL_PRIM bool HL_NAME(hl_alc_is_extension_present) (hl_vstring* extname) {
+	bool lime_alc_is_extension_present (value device, HxString extname) {
 
 		#ifdef LIME_OPENALSOFT
-		return alcIsExtensionPresent (extname ? hl_to_utf8 (extname->bytes) : NULL);
+		ALCdevice* alcDevice = (ALCdevice*)val_data (device);
+		return alcIsExtensionPresent (alcDevice, extname.__s);
+		#else
+		return false;
+		#endif
+
+	}
+
+
+	HL_PRIM bool HL_NAME(hl_alc_is_extension_present) (HL_CFFIPointer* device, hl_vstring* extname) {
+
+		#ifdef LIME_OPENALSOFT
+		ALCdevice* alcDevice = (ALCdevice*)device->ptr;
+		return alcIsExtensionPresent (alcDevice, extname ? hl_to_utf8 (extname->bytes) : NULL);
 		#else
 		return false;
 		#endif
@@ -3602,7 +3604,7 @@ namespace lime {
 	DEFINE_PRIME1 (lime_al_is_effect);
 	DEFINE_PRIME1 (lime_al_is_enabled);
 	DEFINE_PRIME1 (lime_al_is_extension_present);
-	DEFINE_PRIME1 (lime_alc_is_extension_present);
+	DEFINE_PRIME2 (lime_alc_is_extension_present);
 	DEFINE_PRIME1 (lime_al_is_filter);
 	DEFINE_PRIME1 (lime_al_is_source);
 	DEFINE_PRIME4v (lime_al_listener3f);
@@ -3727,7 +3729,7 @@ namespace lime {
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_effect, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_enabled, _I32);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_extension_present, _STRING);
-	DEFINE_HL_PRIM (_BOOL, hl_alc_is_extension_present, _STRING);
+	DEFINE_HL_PRIM (_BOOL, hl_alc_is_extension_present, _TCFFIPOINTER _STRING);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_filter, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_BOOL, hl_al_is_source, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_VOID, hl_al_listener3f, _I32 _F32 _F32 _F32);

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -1574,6 +1574,8 @@ class NativeCFFI
 
 	@:cffi private static function lime_al_is_extension_present(extname:String):Bool;
 
+	@:cffi private static function lime_alc_is_extension_present(extname:String):Bool;
+
 	@:cffi private static function lime_al_is_source(source:CFFIPointer):Bool;
 
 	@:cffi private static function lime_al_listener3f(param:Int, value1:Float32, value2:Float32, value3:Float32):Void;
@@ -1760,6 +1762,8 @@ class NativeCFFI
 	private static var lime_al_is_enabled = new cpp.Callable<Int->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_enabled", "ib", false));
 	private static var lime_al_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_extension_present", "sb",
 		false));
+	private static var lime_alc_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_alc_is_extension_present", "sb",
+		false));
 	private static var lime_al_is_source = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_source", "ob", false));
 	private static var lime_al_listener3f = new cpp.Callable<Int->cpp.Float32->cpp.Float32->cpp.Float32->cpp.Void>(cpp.Prime._loadPrime("lime",
 		"lime_al_listener3f", "ifffv", false));
@@ -1899,6 +1903,7 @@ class NativeCFFI
 	private static var lime_al_is_buffer = CFFI.load("lime", "lime_al_is_buffer", 1);
 	private static var lime_al_is_enabled = CFFI.load("lime", "lime_al_is_enabled", 1);
 	private static var lime_al_is_extension_present = CFFI.load("lime", "lime_al_is_extension_present", 1);
+	private static var lime_alc_is_extension_present = CFFI.load("lime", "lime_alc_is_extension_present", 1);
 	private static var lime_al_is_source = CFFI.load("lime", "lime_al_is_source", 1);
 	private static var lime_al_listener3f = CFFI.load("lime", "lime_al_listener3f", 4);
 	private static var lime_al_listener3i = CFFI.load("lime", "lime_al_listener3i", 4);
@@ -2176,6 +2181,11 @@ class NativeCFFI
 	}
 
 	@:hlNative("lime", "hl_al_is_extension_present") private static function lime_al_is_extension_present(extname:String):Bool
+	{
+		return false;
+	}
+
+	@:hlNative("lime", "hl_alc_is_extension_present") private static function lime_alc_is_extension_present(extname:String):Bool
 	{
 		return false;
 	}

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -1574,7 +1574,7 @@ class NativeCFFI
 
 	@:cffi private static function lime_al_is_extension_present(extname:String):Bool;
 
-	@:cffi private static function lime_alc_is_extension_present(extname:String):Bool;
+	@:cffi private static function lime_alc_is_extension_present(device:CFFIPointer, extname:String):Bool;
 
 	@:cffi private static function lime_al_is_source(source:CFFIPointer):Bool;
 
@@ -1762,7 +1762,7 @@ class NativeCFFI
 	private static var lime_al_is_enabled = new cpp.Callable<Int->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_enabled", "ib", false));
 	private static var lime_al_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_extension_present", "sb",
 		false));
-	private static var lime_alc_is_extension_present = new cpp.Callable<String->Bool>(cpp.Prime._loadPrime("lime", "lime_alc_is_extension_present", "sb",
+	private static var lime_alc_is_extension_present = new cpp.Callable<cpp.Object->String->Bool>(cpp.Prime._loadPrime("lime", "lime_alc_is_extension_present", "osb",
 		false));
 	private static var lime_al_is_source = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_al_is_source", "ob", false));
 	private static var lime_al_listener3f = new cpp.Callable<Int->cpp.Float32->cpp.Float32->cpp.Float32->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -1903,7 +1903,7 @@ class NativeCFFI
 	private static var lime_al_is_buffer = CFFI.load("lime", "lime_al_is_buffer", 1);
 	private static var lime_al_is_enabled = CFFI.load("lime", "lime_al_is_enabled", 1);
 	private static var lime_al_is_extension_present = CFFI.load("lime", "lime_al_is_extension_present", 1);
-	private static var lime_alc_is_extension_present = CFFI.load("lime", "lime_alc_is_extension_present", 1);
+	private static var lime_alc_is_extension_present = CFFI.load("lime", "lime_alc_is_extension_present", 2);
 	private static var lime_al_is_source = CFFI.load("lime", "lime_al_is_source", 1);
 	private static var lime_al_listener3f = CFFI.load("lime", "lime_al_listener3f", 4);
 	private static var lime_al_listener3i = CFFI.load("lime", "lime_al_listener3i", 4);
@@ -2185,7 +2185,7 @@ class NativeCFFI
 		return false;
 	}
 
-	@:hlNative("lime", "hl_alc_is_extension_present") private static function lime_alc_is_extension_present(extname:String):Bool
+	@:hlNative("lime", "hl_alc_is_extension_present") private static function lime_alc_is_extension_present(device:CFFIPointer, extname:String):Bool
 	{
 		return false;
 	}

--- a/src/lime/media/OpenALAudioContext.hx
+++ b/src/lime/media/OpenALAudioContext.hx
@@ -423,9 +423,16 @@ class OpenALAudioContext
 		return AL.isEnabled(capability);
 	}
 
-	public function isExtensionPresent(extname:String):Bool
+	public function isExtensionPresent(extname:String, device:ALDevice = null):Bool
 	{
-		return AL.isExtensionPresent(extname);
+		if (device == null)
+		{
+			return AL.isExtensionPresent(extname);
+		}
+		else
+		{
+			return ALC.isExtensionPresent(device, extname);
+		}
 	}
 
 	public function isSource(source:ALSource):Bool

--- a/src/lime/media/openal/ALC.hx
+++ b/src/lime/media/openal/ALC.hx
@@ -202,10 +202,10 @@ class ALC
 		#end
 	}
 
-	public static function isExtensionPresent(extname:String):Bool
+	public static function isExtensionPresent(device:ALDevice, extname:String):Bool
 	{
 		#if (lime_cffi && lime_openal && !macro)
-		return NativeCFFI.lime_alc_is_extension_present(extname);
+		return NativeCFFI.lime_alc_is_extension_present(device, extname);
 		#else
 		return false;
 		#end

--- a/src/lime/media/openal/ALC.hx
+++ b/src/lime/media/openal/ALC.hx
@@ -201,5 +201,14 @@ class ALC
 		NativeCFFI.lime_alc_suspend_context(context);
 		#end
 	}
+
+	public static function isExtensionPresent(extname:String):Bool
+	{
+		#if (lime_cffi && lime_openal && !macro)
+		return NativeCFFI.lime_alc_is_extension_present(extname);
+		#else
+		return false;
+		#end
+	}
 }
 #end


### PR DESCRIPTION
This PR implements CFFI bindings for the OpenAL Soft `alcIsExtensionPresent` function (which is different from the already existing `alIsExtensionPresent` function)

I've only tested it on Windows (C++, Neko & Hashlink)