### PR TITLE
set correct paths for ndll for linxuarm and linuxarm64 (raspberrypi)

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -235,9 +235,6 @@
 
 			<section if="rpi">
 
-				<compilerflag value="-I/opt/vc/include" />
-				<compilerflag value="-I/opt/vc/include/interface/vcos/pthreads" />
-				<compilerflag value="-I/opt/vc/include/interface/vmcs_host/linux" />
 				<compilerflag value="-I/usr/include/libdrm" />
 				<compilerflag value="-I/usr/include/dbus-1.0" />
 				<compilerflag value="-I/usr/lib/arm-linux-gnueabihf/dbus-1.0/include" unless="HXCPP_ARM64" />
@@ -510,9 +507,6 @@
 				<lib name="-lm" />
 				<lib name="-lEGL" />
 				<lib name="-lGLESv2" />
-				<!-- For legacy Pi driver support -->
-				<lib name="-lbcm_host" />
-				<lib name="-L/opt/vc/lib" />
 
 			</section>
 

--- a/src/lime/tools/HTML5Helper.hx
+++ b/src/lime/tools/HTML5Helper.hx
@@ -107,6 +107,14 @@ class HTML5Helper
 				{
 					suffix += "32";
 				}
+				else if( System.hostArchitecture == ARMV7)
+				{
+					suffix += "Arm";
+				}
+				else if( System.hostArchitecture == ARM64)
+				{
+					suffix += "Arm64";
+				}
 				else
 				{
 					suffix += "64";

--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -496,16 +496,14 @@ class CommandLineTools
 
 			case LINUX:
 				var arguments = Sys.args();
-				var raspberryPi = false;
 
-				for (argument in arguments)
+				if (System.hostArchitecture == ARMV7 )
 				{
-					if (argument == "-rpi") raspberryPi = true;
+					untyped $loader.path = $array(path + "LinuxArm/", $loader.path);
 				}
-
-				if (raspberryPi || System.hostArchitecture == ARMV6 || System.hostArchitecture == ARMV7)
+				else if (System.hostArchitecture == ARM64)
 				{
-					untyped $loader.path = $array(path + "RPi/", $loader.path);
+					untyped $loader.path = $array(path + "LinuxArm64/", $loader.path);
 				}
 				else if (System.hostArchitecture == X64)
 				{

--- a/tools/RunScript.hx
+++ b/tools/RunScript.hx
@@ -35,7 +35,7 @@ class RunScript
 
 		if (!rebuildBinaries) return;
 
-		var platforms = ["Windows", "Mac", "Mac64", "MacArm64", "Linux", "Linux64"];
+		var platforms = ["Windows", "Mac", "Mac64", "MacArm64", "Linux", "Linux64", "LinuxArm", "LinuxArm64"];
 
 		for (platform in platforms)
 		{
@@ -70,14 +70,14 @@ class RunScript
 							System.runCommand(limeDirectory, "neko", args.concat(["mac", toolsDirectory]));
 						}
 
-					case "Linux":
-						if (System.hostPlatform == LINUX && System.hostArchitecture != X64)
+					case "Linux", "LinuxArm":
+						if (System.hostPlatform == LINUX && System.hostArchitecture != X64 && System.hostArchitecture != ARM64)
 						{
 							System.runCommand(limeDirectory, "neko", args.concat(["linux", "-32", toolsDirectory]));
 						}
 
-					case "Linux64":
-						if (System.hostPlatform == LINUX && System.hostArchitecture == X64)
+					case "Linux64", "LinuxArm64":
+						if (System.hostPlatform == LINUX && (System.hostArchitecture == X64 || System.hostArchitecture == ARM64))
 						{
 							System.runCommand(limeDirectory, "neko", args.concat(["linux", "-64", toolsDirectory]));
 						}

--- a/tools/SVGExport.hx
+++ b/tools/SVGExport.hx
@@ -78,16 +78,14 @@ class SVGExport
 
 			case LINUX:
 				var arguments = Sys.args();
-				var raspberryPi = false;
 
-				for (argument in arguments)
+				if ( System.hostArchitecture == ARMV7 )
 				{
-					if (argument == "-rpi") raspberryPi = true;
+					untyped $loader.path = $array(path + "LinuxArm/", $loader.path);
 				}
-
-				if (raspberryPi)
+				else if (System.hostArchitecture == ARM64)
 				{
-					untyped $loader.path = $array(path + "RPi/", $loader.path);
+					untyped $loader.path = $array(path + "LinuxArm64/", $loader.path);
 				}
 				else if (System.hostArchitecture == X64)
 				{

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -95,6 +95,8 @@ class LinuxPlatform extends PlatformTarget
 				defaults.architectures = [ARMV6];
 			case ARMV7:
 				defaults.architectures = [ARMV7];
+			case ARM64:
+				defaults.architectures = [ARM64];
 			case X86:
 				defaults.architectures = [X86];
 			case X64:
@@ -120,22 +122,14 @@ class LinuxPlatform extends PlatformTarget
 
 		for (architecture in project.architectures)
 		{
-			if (!targetFlags.exists("32") && !targetFlags.exists("x86_32") && architecture == Architecture.X64)
+			if (!targetFlags.exists("32") && !targetFlags.exists("x86_32") && (architecture == Architecture.X64 || architecture == Architecture.ARM64))
 			{
 				is64 = true;
 			}
 			else if (architecture == Architecture.ARMV7)
 			{
-				// TODO: can we assume this is actually a Pi? probably not. -JT
-				isRaspberryPi = true;
 				is64 = false;
 			}
-		}
-
-		if (project.targetFlags.exists("rpi"))
-		{
-			isRaspberryPi = true;
-			is64 = targetFlags.exists("64");
 		}
 
 		if (project.targetFlags.exists("neko"))
@@ -183,16 +177,9 @@ class LinuxPlatform extends PlatformTarget
 				{
 					ProjectHelper.copyLibrary(project, ndll, "Linux" + (is64 ? "64" : ""), "", ".hdll", applicationDirectory, project.debug, targetSuffix);
 				}
-				else if (isRaspberryPi)
-				{
-					ProjectHelper.copyLibrary(project, ndll, "RPi" + (is64 ? "64" : ""), "",
-						(ndll.haxelib != null
-							&& (ndll.haxelib.name == "hxcpp" || ndll.haxelib.name == "hxlibc")) ? ".dso" : ".ndll", applicationDirectory,
-						project.debug, targetSuffix);
-				}
 				else
 				{
-					ProjectHelper.copyLibrary(project, ndll, "Linux" + (is64 ? "64" : ""), "",
+					ProjectHelper.copyLibrary(project, ndll, "Linux" + (( System.hostArchitecture == ARMV7 || System.hostArchitecture == ARM64)?"Arm":"") + (is64 ? "64" : ""), "",
 						(ndll.haxelib != null
 							&& (ndll.haxelib.name == "hxcpp" || ndll.haxelib.name == "hxlibc")) ? ".dll" : ".ndll", applicationDirectory,
 						project.debug, targetSuffix);
@@ -206,16 +193,9 @@ class LinuxPlatform extends PlatformTarget
 
 			if (noOutput) return;
 
-			if (isRaspberryPi)
-			{
-				NekoHelper.createExecutable(project.templatePaths, "rpi", targetDirectory + "/obj/ApplicationMain.n", executablePath);
-				NekoHelper.copyLibraries(project.templatePaths, "rpi", applicationDirectory);
-			}
-			else
-			{
-				NekoHelper.createExecutable(project.templatePaths, "linux" + (is64 ? "64" : ""), targetDirectory + "/obj/ApplicationMain.n", executablePath);
-				NekoHelper.copyLibraries(project.templatePaths, "linux" + (is64 ? "64" : ""), applicationDirectory);
-			}
+			NekoHelper.createExecutable(project.templatePaths, "linux" + (( System.hostArchitecture == ARMV7 || System.hostArchitecture == ARM64)?"Arm":"") + (is64 ? "64" : ""), targetDirectory + "/obj/ApplicationMain.n", executablePath);
+			NekoHelper.copyLibraries(project.templatePaths, "linux" + (is64 ? "64" : ""), applicationDirectory);
+
 		}
 		else if (targetType == "hl")
 		{
@@ -281,7 +261,7 @@ class LinuxPlatform extends PlatformTarget
 
 			if (is64)
 			{
-				if (isRaspberryPi)
+				if (System.hostArchitecture == ARM64)
 				{
 					haxeArgs.push("-D");
 					haxeArgs.push("HXCPP_ARM64");
@@ -412,7 +392,7 @@ class LinuxPlatform extends PlatformTarget
 	{
 		// var project = project.clone ();
 
-		if (isRaspberryPi)
+		if(targetFlags.exists('rpi'))
 		{
 			project.haxedefs.set("rpi", 1);
 		}
@@ -469,36 +449,33 @@ class LinuxPlatform extends PlatformTarget
 	{
 		var commands = [];
 
-		if (targetFlags.exists("rpi"))
+		if (System.hostArchitecture == ARM64 )
 		{
-			if (is64)
-			{
-				commands.push([
-					"-Dlinux",
-					"-Drpi",
-					"-Dtoolchain=linux",
-					"-DBINDIR=RPi64",
-					"-DHXCPP_ARM64",
-					"-DCXX=aarch64-linux-gnu-g++",
-					"-DHXCPP_STRIP=aarch64-linux-gnu-strip",
-					"-DHXCPP_AR=aarch64-linux-gnu-ar",
-					"-DHXCPP_RANLIB=aarch64-linux-gnu-ranlib"
-				]);
-			}
-			else
-			{
-				commands.push([
-					"-Dlinux",
-					"-Drpi",
-					"-Dtoolchain=linux",
-					"-DBINDIR=RPi",
-					"-DHXCPP_M32",
-					"-DCXX=arm-linux-gnueabihf-g++",
-					"-DHXCPP_STRIP=arm-linux-gnueabihf-strip",
-					"-DHXCPP_AR=arm-linux-gnueabihf-ar",
-					"-DHXCPP_RANLIB=arm-linux-gnueabihf-ranlib"
-				]);
-			}
+			commands.push([
+				"-Dlinux",
+				"-Drpi",
+				"-Dtoolchain=linux",
+				"-DBINDIR=LinuxArm64",
+				"-DHXCPP_ARM64",
+				"-DCXX=aarch64-linux-gnu-g++",
+				"-DHXCPP_STRIP=aarch64-linux-gnu-strip",
+				"-DHXCPP_AR=aarch64-linux-gnu-ar",
+				"-DHXCPP_RANLIB=aarch64-linux-gnu-ranlib"
+			]);
+		}
+		else if (System.hostArchitecture == ARMV7)
+		{
+			commands.push([
+				"-Dlinux",
+				"-Drpi",
+				"-Dtoolchain=linux",
+				"-DBINDIR=LinuxArm",
+				"-DHXCPP_M32",
+				"-DCXX=arm-linux-gnueabihf-g++",
+				"-DHXCPP_STRIP=arm-linux-gnueabihf-strip",
+				"-DHXCPP_AR=arm-linux-gnueabihf-ar",
+				"-DHXCPP_RANLIB=arm-linux-gnueabihf-ranlib"
+			]);
 		}
 		else if (targetFlags.exists("hl") && System.hostArchitecture == X64)
 		{
@@ -584,14 +561,7 @@ class LinuxPlatform extends PlatformTarget
 
 				if (ndll.path == null || ndll.path == "")
 				{
-					if (isRaspberryPi)
-					{
-						context.ndlls[i].path = NDLL.getLibraryPath(ndll, "RPi" + (is64 ? "64" : ""), "lib", ".a", project.debug);
-					}
-					else
-					{
-						context.ndlls[i].path = NDLL.getLibraryPath(ndll, "Linux" + (is64 ? "64" : ""), "lib", ".a", project.debug);
-					}
+					context.ndlls[i].path = NDLL.getLibraryPath(ndll, "Linux" + (( System.hostArchitecture == ARMV7 || System.hostArchitecture == ARM64) ? "Arm" : "") + (is64 ? "64" : ""), "lib", ".a", project.debug);
 				}
 			}
 		}


### PR DESCRIPTION
_set correct paths for ndll for linxuarm and linuxarm64 (raspberrypi)
and remove conflicting legacy includepaths in build.xml_

These are the changes I made which allow compilation on a raspberry pi 4 or 5 running 32 or 64bit Bullseye or Bookworm (raspberrypios).  A lot of the `isRaspberryPi` statements have been replaced by checking for Arm64 or Armv7 so that in the future other linux arm boards could be used as well.  Ndlls are built in ndll/LinuxArm and  ndll/LinuxArm64 instead of the previous ndll/RPi  path

Old -I flags have been removed from Build.xml because they point to libraries from older OS versions and do  no longer exist on bullseye and bookworm.  They prevented sdl from compiling on these os versions.
Performance on older versions of the raspberrypi was poor. So I think support  should be for pi4 and up only.
 
SDL still has pi specific code. 
That's why a -Drpi flag can still be found when calling hxcpp. Otherwise a build would fail.

_One important note is that for 64bit the latest (git)build of hxcpp is needed ! There is a bug in haxelibversion that caused threads to throw a bus error. This is solved in master._