### PR TITLE
Simplify Timer.stop()

### DIFF
--- a/src/haxe/Timer.hx
+++ b/src/haxe/Timer.hx
@@ -270,19 +270,7 @@ class Timer
 
 	public function stop():Void
 	{
-		if (mRunning)
-		{
-			mRunning = false;
-
-			for (i in 0...sRunningTimers.length)
-			{
-				if (sRunningTimers[i] == this)
-				{
-					sRunningTimers[i] = null;
-					break;
-				}
-			}
-		}
+		mRunning = false;
 	}
 
 	@:noCompletion private function __check(inTime:Float)

--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -96,7 +96,8 @@ class NativeApplication
 			var offset = System.getTimer() - pauseTimer;
 			for (i in 0...Timer.sRunningTimers.length)
 			{
-				if (Timer.sRunningTimers[i] != null) Timer.sRunningTimers[i].mFireAt += offset;
+				var timer = Timer.sRunningTimers[i];
+				if (timer != null && timer.mRunning) timer.mFireAt += offset;
 			}
 			pauseTimer = -1;
 		}
@@ -585,9 +586,9 @@ class NativeApplication
 			{
 				timer = Timer.sRunningTimers[i];
 
-				if (timer != null)
+				if (timer != null && timer.mRunning)
 				{
-					if (timer.mRunning && currentTime >= timer.mFireAt)
+					if (currentTime >= timer.mFireAt)
 					{
 						timer.mFireAt += timer.mTime;
 						timer.run();
@@ -603,7 +604,7 @@ class NativeApplication
 			{
 				Timer.sRunningTimers = Timer.sRunningTimers.filter(function(val)
 				{
-					return val != null;
+					return val != null && val.mRunning;
 				});
 			}
 		}

--- a/src/lime/_internal/backend/native/NativeApplication.hx
+++ b/src/lime/_internal/backend/native/NativeApplication.hx
@@ -94,10 +94,9 @@ class NativeApplication
 		if (pauseTimer > -1)
 		{
 			var offset = System.getTimer() - pauseTimer;
-			for (i in 0...Timer.sRunningTimers.length)
+			for (timer in Timer.sRunningTimers)
 			{
-				var timer = Timer.sRunningTimers[i];
-				if (timer != null && timer.mRunning) timer.mFireAt += offset;
+				if (timer.mRunning) timer.mFireAt += offset;
 			}
 			pauseTimer = -1;
 		}
@@ -579,14 +578,11 @@ class NativeApplication
 		if (Timer.sRunningTimers.length > 0)
 		{
 			var currentTime = System.getTimer();
-			var foundNull = false;
-			var timer;
+			var foundStopped = false;
 
-			for (i in 0...Timer.sRunningTimers.length)
+			for (timer in Timer.sRunningTimers)
 			{
-				timer = Timer.sRunningTimers[i];
-
-				if (timer != null && timer.mRunning)
+				if (timer.mRunning)
 				{
 					if (currentTime >= timer.mFireAt)
 					{
@@ -596,15 +592,15 @@ class NativeApplication
 				}
 				else
 				{
-					foundNull = true;
+					foundStopped = true;
 				}
 			}
 
-			if (foundNull)
+			if (foundStopped)
 			{
 				Timer.sRunningTimers = Timer.sRunningTimers.filter(function(val)
 				{
-					return val != null && val.mRunning;
+					return val.mRunning;
 				});
 			}
 		}


### PR DESCRIPTION
Simplified the `stop()` method in `haxe/Timer.hx` by removing redundant iterations and updated `NativeApplication.hx` to only run on active timers.