### PR TITLE
Enhance frame rate calculations with double and SDL performance counter

### DIFF
--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -129,7 +129,7 @@ namespace lime {
 
 				if (!inBackground) {
 
-					currentUpdate = SDL_GetTicks ();
+					currentUpdate = ((double) SDL_GetPerformanceCounter () / (double) SDL_GetPerformanceFrequency ()) * 1000.0;
 					applicationEvent.type = UPDATE;
 					applicationEvent.deltaTime = currentUpdate - lastUpdate;
 					lastUpdate = currentUpdate;
@@ -877,7 +877,7 @@ namespace lime {
 
 			}
 
-			currentUpdate = SDL_GetTicks ();
+			currentUpdate = ((double) SDL_GetPerformanceCounter () / (double) SDL_GetPerformanceFrequency ()) * 1000.0;
 
 		#if defined (IPHONE) || defined (EMSCRIPTEN)
 

--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -329,7 +329,7 @@ namespace lime {
 	void SDLApplication::Init () {
 
 		active = true;
-		lastUpdate = SDL_GetTicks ();
+		lastUpdate = ((double) SDL_GetPerformanceCounter () / (double) SDL_GetPerformanceFrequency ()) * 1000.0;
 		nextUpdate = lastUpdate;
 
 	}

--- a/project/src/backend/sdl/SDLApplication.h
+++ b/project/src/backend/sdl/SDLApplication.h
@@ -60,15 +60,15 @@ namespace lime {
 			bool active;
 			ApplicationEvent applicationEvent;
 			ClipboardEvent clipboardEvent;
-			Uint32 currentUpdate;
+			double currentUpdate;
 			double framePeriod;
 			DropEvent dropEvent;
 			GamepadEvent gamepadEvent;
 			JoystickEvent joystickEvent;
 			KeyEvent keyEvent;
-			Uint32 lastUpdate;
+			double lastUpdate;
 			MouseEvent mouseEvent;
-			Uint32 nextUpdate;
+			double nextUpdate;
 			RenderEvent renderEvent;
 			SensorEvent sensorEvent;
 			TextEvent textEvent;


### PR DESCRIPTION
* Updated frame rate calculations to improve timing accuracy.

* Replaced Uint32 with double for precise timing values.

* Switched from SDL_GetTicks() to SDL_GetPerformanceCounter() and SDL_GetPerformanceFrequency() for high-resolution timing.