### PR TITLE
Remove `@:generic` from `Promise`.

### DIFF
--- a/src/lime/app/Future.hx
+++ b/src/lime/app/Future.hx
@@ -40,7 +40,7 @@ import lime.utils.Log;
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
-@:allow(lime.app.Promise) /*@:generic*/ class Future<T>
+@:allow(lime.app.Promise) class Future<T>
 {
 	/**
 		If the `Future` has finished with an error state, the `error` value

--- a/src/lime/app/Promise.hx
+++ b/src/lime/app/Promise.hx
@@ -44,9 +44,6 @@ package lime.app;
 @:noDebug
 #end
 @:allow(lime.app.Future)
-#if (!hl && !js && !macro)
-@:generic
-#end
 class Promise<T>
 {
 	/**


### PR DESCRIPTION
This was first added in 3dad6d81d09d9f4742c3ad99c4ef91cbcdaccfdb, without explanation. I think it's time to remove it.

Considerations:

- In theory, `@:generic` may make the code faster. However, this isn't performance-critical code, and any improvements are likely to be vanishingly small.
- `@:generic` increases the size of the output.
- `@:generic` prevents casting to `Promise<Dynamic>`, which forced a slightly more verbose implementation of `FutureWork`. Technically this enforces type safety, but usually we don't worry about that sort of thing. If a user's going to use `Dynamic`, they accept responsibility for the risks.
- If we remove the tag, we'll be able to add static utility functions.