### PR TITLE
Work around ThreadPool error when targeting HashLink in Haxe 4.0-4.1.

### DIFF
--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -425,7 +425,7 @@ class ThreadPool extends WorkOutput
 				{
 					while (!output.__jobComplete.value && (interruption = Thread.readMessage(false)) == null)
 					{
-						output.workIterations.value++;
+						output.workIterations.value = output.workIterations.value + 1;
 						event.job.doWork.dispatch(event.job.state, output);
 					}
 				}
@@ -521,7 +521,7 @@ class ThreadPool extends WorkOutput
 			{
 				do
 				{
-					workIterations.value++;
+					workIterations.value = workIterations.value + 1;
 					activeJob.doWork.dispatch(state, this);
 					timeElapsed = timestamp() - startTime;
 				}


### PR DESCRIPTION
Fixes #1851, at least for Haxe 4.0.5. I couldn't reproduce the issue in Haxe 4.1.5, possibly because I'm using Linux rather than Mac. But since it pointed to the same two lines, I think it's safe to assume it's the same bug.