### PR TITLE
Fix: attribute "gradle-plugin" of android config is never read

### DIFF
--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -1738,6 +1738,9 @@ class ProjectXMLParser extends HXProject
 
 							case "gradle-version":
 								config.set("android.gradle-version", value);
+							
+							case "gradle-plugin":
+								config.set("android.gradle-plugin", value);
 
 							default:
 								name = formatAttributeName(attribute);


### PR DESCRIPTION
Adding the tag:
```xml
<android gradle-plugin="8.7.0" />
```

to Project.xml has no effect right now, while in `AndroidPlatform.hx` it is considered valid:
https://github.com/openfl/lime/blob/36b14e946935f1560e9cbdaa7b010cdfbf16017e/tools/platforms/AndroidPlatform.hx#L477

This is because the `ProjectXMLParser` is missing the related case - there is one for `gradle-version` but nothing for `gradle-plugin`.