### PR TITLE
Clean up PNG and JPEG encoding properly

### DIFF
--- a/project/src/graphics/format/JPEG.cpp
+++ b/project/src/graphics/format/JPEG.cpp
@@ -487,6 +487,8 @@ namespace lime {
 
 		}
 
+        jpeg_destroy_compress (&cinfo);
+
 		return true;
 
 	}

--- a/project/src/graphics/format/PNG.cpp
+++ b/project/src/graphics/format/PNG.cpp
@@ -237,6 +237,8 @@ namespace lime {
 
 		if (!info_ptr) {
 
+            png_destroy_write_struct (&png_ptr, NULL);
+
 			return false;
 
 		}
@@ -309,6 +311,8 @@ namespace lime {
 			memcpy (bytes->b, &out_buffer[0], size);
 
 		}
+
+        png_destroy_write_struct (&png_ptr, &info_ptr);
 
 		return true;
 


### PR DESCRIPTION
This commit fixes PNG/JPEG encoding memory leak.

Reproduce:
```haxe
var bitmapData:BitmapData = new BitmapData(1, 1, true, 0x00000000);

openfl.Lib.setInterval(() -> {
    for(i in 0...100)
    {
        bitmapData.encode(bitmapData.rect, new PNGEncoderOptions());
    }

    openfl.system.System.gc();
}, 100);
```

Fixes https://github.com/openfl/lime/issues/1860