### PR TITLE
Don't run `embedBytes()` if `embedByteArray()` is also running.

### DIFF
--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -28,6 +28,16 @@ class AssetsMacro
 
 	macro public static function embedBytes():Array<Field>
 	{
+		for (autoBuild in Context.getLocalClass().get().meta.extract(":autoBuild"))
+		{
+			switch (autoBuild.params[0])
+			{
+				case macro lime._internal.macros.AssetsMacro.embedByteArray():
+					return null;
+				default:
+			}
+		}
+
 		var fields = embedData(":file");
 		if (fields == null) return null;
 

--- a/src/lime/_internal/macros/AssetsMacro.hx
+++ b/src/lime/_internal/macros/AssetsMacro.hx
@@ -28,6 +28,9 @@ class AssetsMacro
 
 	macro public static function embedBytes():Array<Field>
 	{
+		var fields = embedData(":file");
+		if (fields == null) return null;
+
 		for (autoBuild in Context.getLocalClass().get().meta.extract(":autoBuild"))
 		{
 			switch (autoBuild.params[0])
@@ -37,9 +40,6 @@ class AssetsMacro
 				default:
 			}
 		}
-
-		var fields = embedData(":file");
-		if (fields == null) return null;
 
 		var superCall = Context.defined("html5") ? macro super(bytes.b.buffer)
 			: Context.defined("hl") ? macro super(bytes.b, bytes.length)


### PR DESCRIPTION
Both functions insert a constructor, and one class can't have two constructors, much less call `super()` with two different signatures.

I can only assume a bug in Haxe that prevented this from being an issue until now, and that Haxe 5 is fixing the bug.