### PR TITLE
Fix ImageDataUtil.copyPixels crash on Hashlink

### DIFF
--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -2052,16 +2052,18 @@ namespace lime {
 
 		} else {
 
-			Vector2* _alphaPoint = alphaPoint;
-			
-			if (!_alphaPoint) {
+			if (!alphaPoint) {
 
-				Vector2 tempAlphaPoint = Vector2(0, 0);
-				_alphaPoint = &tempAlphaPoint;
+				Vector2 _alphaPoint = Vector2 (0, 0);
+
+				ImageDataUtil::CopyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, &_alphaPoint, mergeAlpha);
+
+			} else {
+
+				ImageDataUtil::CopyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
 
 			}
 
-			ImageDataUtil::CopyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, _alphaPoint, mergeAlpha);
 		}
 
 	}

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -2052,8 +2052,13 @@ namespace lime {
 
 		} else {
 
-			Vector2 tempPoint = Vector2(0, 0);
-			Vector2* _alphaPoint = alphaPoint ? alphaPoint : &tempPoint;
+			Vector2* _alphaPoint = alphaPoint;
+			if (!_alphaPoint) {
+
+				Vector2 tempAlphaPoint = Vector2(0, 0);
+				_alphaPoint = &tempAlphaPoint;
+
+			}
 
 			ImageDataUtil::CopyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, _alphaPoint, mergeAlpha);
 		}

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -2053,6 +2053,7 @@ namespace lime {
 		} else {
 
 			Vector2* _alphaPoint = alphaPoint;
+			
 			if (!_alphaPoint) {
 
 				Vector2 tempAlphaPoint = Vector2(0, 0);

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -2052,16 +2052,10 @@ namespace lime {
 
 		} else {
 
-			Vector2* _alphaPoint = alphaPoint ? alphaPoint : new Vector2(0, 0);
+			Vector2 tempPoint = Vector2(0, 0);
+			Vector2* _alphaPoint = alphaPoint ? alphaPoint : &tempPoint;
 
 			ImageDataUtil::CopyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, _alphaPoint, mergeAlpha);
-
-			if (!alphaPoint) {
-
-				delete _alphaPoint;
-
-			}
-
 		}
 
 	}

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -2052,7 +2052,15 @@ namespace lime {
 
 		} else {
 
-			ImageDataUtil::CopyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
+			Vector2* _alphaPoint = alphaPoint ? alphaPoint : new Vector2(0, 0);
+
+			ImageDataUtil::CopyPixels (image, sourceImage, sourceRect, destPoint, alphaImage, _alphaPoint, mergeAlpha);
+
+			if (!alphaPoint) {
+
+				delete _alphaPoint;
+
+			}
 
 		}
 

--- a/src/lime/_internal/graphics/ImageDataUtil.hx
+++ b/src/lime/_internal/graphics/ImageDataUtil.hx
@@ -311,13 +311,6 @@ class ImageDataUtil
 		else
 		{
 			#if (lime_cffi && !disable_cffi && !macro)
-			#if hl
-			if (alphaPoint == null)
-			{
-				alphaPoint = new Vector2();
-			}
-			#end
-
 			if (CFFI.enabled) NativeCFFI.lime_image_data_util_copy_pixels(image, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
 			else
 			#end

--- a/src/lime/_internal/graphics/ImageDataUtil.hx
+++ b/src/lime/_internal/graphics/ImageDataUtil.hx
@@ -311,6 +311,13 @@ class ImageDataUtil
 		else
 		{
 			#if (lime_cffi && !disable_cffi && !macro)
+			#if hl
+			if (alphaPoint == null)
+			{
+				alphaPoint = new Vector2();
+			}
+			#end
+
 			if (CFFI.enabled) NativeCFFI.lime_image_data_util_copy_pixels(image, sourceImage, sourceRect, destPoint, alphaImage, alphaPoint, mergeAlpha);
 			else
 			#end


### PR DESCRIPTION
On C++ when a passed Vector2 instance is null, it'll just make it (0, 0) on the C++ side: https://github.com/openfl/lime/blob/0b08e7fa61371a962c114bc52d28ccb42913a68f/project/src/math/Vector2.cpp#L31-L41

Unlike C++, on Hashlink there's no failsafe for if the Vector2 instance is null, it'll just pass it further to `ImageDataUtil::copyPixels` causing an access violation. This PR checks if we're passing in a null Vector2 on the Haxe side, and makes a new object if we are. I assume this is better than making it on the C++ side but please correct me if I'm wrong

Fixes: https://github.com/openfl/openfl/issues/2754