### PR TITLE
Fix broken default windows cross compile build

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -765,7 +765,7 @@ class HXProject extends Script
 				defines.set("targetType", "cpp");
 				defines.set("cpp", "1");
 			}
-			else if (target == Platform.WINDOWS && targetFlags.exists("mingw"))
+			else if (target == Platform.WINDOWS && (targetFlags.exists("cpp") || targetFlags.exists("mingw")))
 			{
 				defines.set("targetType", "cpp");
 				defines.set("cpp", "1");

--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -773,6 +773,8 @@ class HXProject extends Script
 			}
 			else
 			{
+				targetFlags.set("neko", "1");
+
 				defines.set("targetType", "neko");
 				defines.set("neko", "1");
 			}

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -580,7 +580,7 @@ class WindowsPlatform extends PlatformTarget
 
 					System.copyFile(targetDirectory + "/obj/ApplicationMain" + (project.debug ? "-debug" : "") + ".exe", executablePath);
 
-					if (project.targetFlags.exists("mingw"))
+					if (project.defines.exists("mingw"))
 					{
 						var libraries = ["libwinpthread-1.dll", "libstdc++-6.dll"];
 						if (is64)


### PR DESCRIPTION
The default is meant to be neko, however, since no "neko" target flag is set, this gets ignored and we end up with a broken cpp build that is missing the `mingw` flag.

Since the default has changed back to neko with this patch, I've also modified the logic so that `-cpp` is respected and won't lead to a neko build.