### PR TITLE
add `-json` flag to allow json types creation 

### DIFF
--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -459,6 +459,11 @@ class AndroidPlatform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		var context = project.templateContext;
 
 		context.CPP_DIR = targetDirectory + "/obj";

--- a/tools/platforms/FlashPlatform.hx
+++ b/tools/platforms/FlashPlatform.hx
@@ -139,6 +139,11 @@ class FlashPlatform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		if (Log.verbose)
 		{
 			project.haxedefs.set("verbose", 1);

--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -353,6 +353,11 @@ class HTML5Platform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		if (Log.verbose)
 		{
 			project.haxedefs.set("verbose", 1);

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -169,6 +169,11 @@ class IOSPlatform extends PlatformTarget
 		{
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
+		
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
 
 		if (project.targetFlags.exists("final"))
 		{

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -556,6 +556,11 @@ class LinuxPlatform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		var context = generateContext();
 		context.OUTPUT_DIR = targetDirectory;
 

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -507,6 +507,11 @@ class MacPlatform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		for (asset in project.assets)
 		{
 			if (asset.embed && asset.sourcePath == "")

--- a/tools/platforms/TVOSPlatform.hx
+++ b/tools/platforms/TVOSPlatform.hx
@@ -168,6 +168,11 @@ class TVOSPlatform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		if (project.targetFlags.exists("final"))
 		{
 			project.haxedefs.set("final", "");

--- a/tools/platforms/TizenPlatform.hx
+++ b/tools/platforms/TizenPlatform.hx
@@ -227,6 +227,11 @@ class TizenPlatform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		var context = project.templateContext;
 		context.CPP_DIR = targetDirectory + "/obj";
 		context.OUTPUT_DIR = targetDirectory;

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -921,6 +921,11 @@ class WindowsPlatform extends PlatformTarget
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
 
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
+		}
+
 		for (asset in project.assets)
 		{
 			if (asset.embed && asset.sourcePath == "")
@@ -1065,6 +1070,11 @@ class WindowsPlatform extends PlatformTarget
 		if (project.targetFlags.exists("xml"))
 		{
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
+		}
+
+		if (project.targetFlags.exists("json"))
+		{
+			project.haxeflags.push("--json " + targetDirectory + "/types.json");
 		}
 
 		if (Log.verbose)


### PR DESCRIPTION
Along with type information in XML format, Haxe also supports type information in JSON format. So this change is simple and follows along wherever `if (project.targetFlags.exists("xml"))` is and we just check for a json flag as well.

