### PR TITLE
Setting ios.non-exempt-encryption to false by default

### DIFF
--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -349,7 +349,7 @@ class IOSPlatform extends PlatformTarget
 		}
 
 		context.IOS_LINKER_FLAGS = ["-stdlib=libc++"].concat(project.config.getArrayString("ios.linker-flags"));
-		context.IOS_NON_EXEMPT_ENCRYPTION = project.config.getBool("ios.non-exempt-encryption", true);
+		context.IOS_NON_EXEMPT_ENCRYPTION = project.config.getBool("ios.non-exempt-encryption", false);
 
 		switch (project.window.orientation)
 		{


### PR DESCRIPTION
`ios.non-exempt-encryption` is set to `true` by default, so I had to change `ITSAppUsesNonExemptEncryption` (at {{app.file}}-Info.plist) manually to `false`, because otherwise Apple would not approve my app.

> Set the value for this key to NO in your app’s Information Property List file to indicate that your app—including any third-party libraries you link against—either uses no encryption, or only uses encryption that’s exempt from export compliance requirements, as described in Determine your export compliance requirements. Set the value to YES to indicate that your app uses non-exempt encryption.

From here: https://developer.apple.com/documentation/bundleresources/information-property-list/itsappusesnonexemptencryption

I guess, `false` by default makes more sense.