### PR TITLE
Bumped Android SDK to 34, Google Play won't accept lower.

### DIFF
--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -465,7 +465,7 @@ class AndroidPlatform extends PlatformTarget
 		context.OUTPUT_DIR = targetDirectory;
 		context.ANDROID_INSTALL_LOCATION = project.config.getString("android.install-location", "auto");
 		context.ANDROID_MINIMUM_SDK_VERSION = project.config.getInt("android.minimum-sdk-version", 21);
-		context.ANDROID_TARGET_SDK_VERSION = project.config.getInt("android.target-sdk-version", 30);
+		context.ANDROID_TARGET_SDK_VERSION = project.config.getInt("android.target-sdk-version", 34);
 		context.ANDROID_EXTENSIONS = project.config.getArrayString("android.extension");
 		context.ANDROID_PERMISSIONS = project.config.getArrayString("android.permission", [
 			"android.permission.WAKE_LOCK",


### PR DESCRIPTION
There is the following warning when bulding the project, but I had no problems so far.
> WARNING:We recommend using a newer Android Gradle plugin to use compileSdk = 34
> 
> This Android Gradle plugin (7.3.1) was tested up to compileSdk = 33
> 
> This warning can be suppressed by adding
>     android.suppressUnsupportedCompileSdk=34
> to this project's gradle.properties
> 
> The build will continue, but you are strongly encouraged to update your project to
> use a newer Android Gradle Plugin that has been tested with compileSdk = 34

If gradle can be upgraded, would be great.