### PR TITLE
Remove MAC_USE_CURRENT_SDK from lime setup

### DIFF
--- a/tools/utils/PlatformSetup.hx
+++ b/tools/utils/PlatformSetup.hx
@@ -816,11 +816,6 @@ class PlatformSetup
 			setupHaxelib(new Haxelib("lime"));
 		}
 
-		if (System.hostPlatform == MAC)
-		{
-			ConfigHelper.writeConfigValue("MAC_USE_CURRENT_SDK", "1");
-		}
-
 		if (targetFlags.exists("noalias"))
 		{
 			return;
@@ -1077,11 +1072,6 @@ class PlatformSetup
 		if (!targetFlags.exists("alias") && !targetFlags.exists("cli"))
 		{
 			setupHaxelib(new Haxelib("openfl"));
-		}
-
-		if (System.hostPlatform == MAC)
-		{
-			ConfigHelper.writeConfigValue("MAC_USE_CURRENT_SDK", "1");
 		}
 
 		if (targetFlags.exists("noalias"))


### PR DESCRIPTION
`MAC_USE_CURRENT_SDK` is an incredibly old relic from a very old version of hxcpp (haxe 2 days). It was removed in:
https://github.com/HaxeFoundation/hxcpp/commit/9a7f7f931fbdc4a4d4812c333ead14519b7c05e0

This is now instead controlled by the flag `MACOSX_DEPLOYMENT_TARGET`.

The setup command now only does two things
- Sets up haxelibs
- Adds cli alias