### PR TITLE
Set RenderContextAttributes.hardware upon context creation

### DIFF
--- a/src/lime/_internal/backend/native/NativeWindow.hx
+++ b/src/lime/_internal/backend/native/NativeWindow.hx
@@ -132,6 +132,7 @@ class NativeWindow
 				var gl = new NativeOpenGLRenderContext();
 
 				useHardware = true;
+				contextAttributes.hardware = true;
 
 				#if lime_opengl
 				context.gl = gl;
@@ -155,6 +156,7 @@ class NativeWindow
 
 			default:
 				useHardware = false;
+				contextAttributes.hardware = false;
 
 				#if lime_cairo
 				context.cairo = cairo;


### PR DESCRIPTION
Trying to request a hardware accelerated window on a system without a proper video driver (that's using the fallback OpenGL 1.1 implementation on Windows) would fail and return a software rendering context, but `RenderContextAttributes.hardware` would never be updated to reflect this and would keep returning `true`