### PR TITLE
Fix static build linking on windows

### DIFF
--- a/templates/cpp/static/BuildMain.xml
+++ b/templates/cpp/static/BuildMain.xml
@@ -35,6 +35,7 @@
 			<lib name="rpcrt4.lib" />
 			<lib name="dwrite.lib" />
 			<lib name="setupapi.lib" />
+			<lib name="crypt32.lib" />
 
 		</section>
 

--- a/templates/cpp/static/Main.cpp
+++ b/templates/cpp/static/Main.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-#if defined(HX_WINDOWS) && !defined(HXCPP_DEBUG)
+#if defined(HX_WINDOWS) && !defined(HXCPP_DEBUGGER)
 #include <windows.h>
 #endif
 
@@ -14,7 +14,7 @@ extern "C" int lime_openal_register_prims ();
 extern "C" int ::nameSafe::_register_prims ();::end::::end::
 
 
-#if defined(HX_WINDOWS) && !defined(HXCPP_DEBUG)
+#if defined(HX_WINDOWS) && !defined(HXCPP_DEBUGGER)
 int __stdcall WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
 #else
 extern "C" int main(int argc, char *argv[]) {


### PR DESCRIPTION
There was a .lib file missing that's required for linking mbedtls, see: https://github.com/openfl/openfl/issues/2603

This also fixes a change from #1529. The original PR mentions that debug causes the console subsystem, however, actually it's specifically [the hxcpp-debugger that causes it](https://github.com/HaxeFoundation/hxcpp/blob/aa01cc61e3f58a2002140dbeaa3cba1b34a7a5d5/toolchain/msvc-toolchain.xml#L29). This meant that if running a debug build without the debugger, the following linker error would occur:

```
LIBCMT.lib(exe_winmain.obj) : error LNK2019: unresolved external symbol WinMain referenced in function "int __cdecl __scrt_common_main_seh(void)" (?__scrt_common_main_seh@@YAHXZ)
Main-debug.exe : fatal error LNK1120: 1 unresolved externals
```