### PR TITLE
Implement Window.setVSyncMode()

### DIFF
--- a/project/include/ui/Window.h
+++ b/project/include/ui/Window.h
@@ -16,6 +16,13 @@
 
 namespace lime {
 
+	enum WindowVSyncMode {
+
+		WINDOW_VSYNC_ADAPTIVE = -1,
+		WINDOW_VSYNC_OFF = 0,
+		WINDOW_VSYNC_ON = 1,
+
+	};
 
 	class Window {
 
@@ -25,6 +32,7 @@ namespace lime {
 			virtual ~Window () {};
 
 			virtual void Alert (const char* message, const char* title) = 0;
+			virtual bool SetVSyncMode (WindowVSyncMode mode) = 0;
 			virtual void Close () = 0;
 			virtual void ContextFlip () = 0;
 			virtual void* ContextLock (bool useCFFIValue) = 0;
@@ -97,7 +105,6 @@ namespace lime {
 		WINDOW_FLAG_COLOR_DEPTH_32_BIT = 0x00010000
 
 	};
-
 }
 
 

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -3158,6 +3158,22 @@ namespace lime {
 	}
 
 
+	bool lime_window_set_vsync_mode (value window, int mode) {
+
+		Window* targetWindow = (Window*)val_data (window);
+		return targetWindow->SetVSyncMode (mode);
+
+	}
+
+
+	HL_PRIM bool HL_NAME(hl_window_set_vsync_mode) (HL_CFFIPointer* window, int mode) {
+
+		Window* targetWindow = (Window*)window->ptr;
+		return targetWindow->SetVSyncMode (mode);
+
+	}
+
+
 	void lime_window_close (value window) {
 
 		Window* targetWindow = (Window*)val_data (window);
@@ -4040,6 +4056,7 @@ namespace lime {
 	DEFINE_PRIME2v (lime_text_event_manager_register);
 	DEFINE_PRIME2v (lime_touch_event_manager_register);
 	DEFINE_PRIME3v (lime_window_alert);
+	DEFINE_PRIME2 (lime_window_set_vsync_mode);
 	DEFINE_PRIME1v (lime_window_close);
 	DEFINE_PRIME1v (lime_window_context_flip);
 	DEFINE_PRIME1 (lime_window_context_lock);

--- a/project/src/backend/sdl/SDLWindow.cpp
+++ b/project/src/backend/sdl/SDLWindow.cpp
@@ -221,11 +221,11 @@ namespace lime {
 
 				if (flags & WINDOW_FLAG_VSYNC) {
 
-					SDL_GL_SetSwapInterval (1);
+					SetVSyncMode (WINDOW_VSYNC_ON);
 
 				} else {
 
-					SDL_GL_SetSwapInterval (0);
+					SetVSyncMode (WINDOW_VSYNC_OFF);
 
 				}
 
@@ -344,6 +344,13 @@ namespace lime {
 			SDL_ShowSimpleMessageBox (SDL_MESSAGEBOX_INFORMATION, title, message, sdlWindow);
 
 		}
+
+	}
+
+
+	bool SDLWindow::SetVSyncMode (WindowVSyncMode mode) {
+
+		return SDL_GL_SetSwapInterval (mode);
 
 	}
 

--- a/project/src/backend/sdl/SDLWindow.h
+++ b/project/src/backend/sdl/SDLWindow.h
@@ -19,6 +19,7 @@ namespace lime {
 			~SDLWindow ();
 
 			virtual void Alert (const char* message, const char* title);
+			virtual bool SetVSyncMode (WindowVSyncMode mode);
 			virtual void Close ();
 			virtual void ContextFlip ();
 			virtual void* ContextLock (bool useCFFIValue);

--- a/src/lime/_internal/backend/air/AIRWindow.hx
+++ b/src/lime/_internal/backend/air/AIRWindow.hx
@@ -178,6 +178,11 @@ class AIRWindow extends FlashWindow
 		}
 	}
 
+	public function setVSyncMode(mode:WindowVSyncMode):Bool
+	{
+		return false;
+	}
+
 	private function handleNativeWindowEvent(event:Event):Void
 	{
 		switch (event.type)

--- a/src/lime/_internal/backend/flash/FlashWindow.hx
+++ b/src/lime/_internal/backend/flash/FlashWindow.hx
@@ -290,6 +290,11 @@ class FlashWindow
 
 	public function focus():Void {}
 
+	public function setVSyncMode(mode:WindowVSyncMode):Bool
+	{
+		return false;
+	}
+
 	public function getCursor():MouseCursor
 	{
 		return cursor;

--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -381,6 +381,11 @@ class HTML5Window
 
 	public function focus():Void {}
 
+	public function setVSyncMode(mode:WindowVSyncMode):Bool
+	{
+		return false;
+	}
+
 	private function focusTextInput():Void
 	{
 		// Avoid changing focus multiple times per frame.

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -275,6 +275,8 @@ class NativeCFFI
 
 	@:cffi private static function lime_window_alert(handle:Dynamic, message:String, title:String):Void;
 
+	@:cffi private static function lime_window_set_vsync_mode(handle:Dynamic, mode:Int):Bool;
+
 	@:cffi private static function lime_window_close(handle:Dynamic):Void;
 
 	@:cffi private static function lime_window_context_flip(handle:Dynamic):Void;
@@ -548,6 +550,8 @@ class NativeCFFI
 		"lime_touch_event_manager_register", "oov", false));
 	private static var lime_window_alert = new cpp.Callable<cpp.Object->String->String->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_alert", "ossv",
 		false));
+	private static var lime_window_set_vsync_mode = new cpp.Callable<cpp.Object->Int->Bool>(cpp.Prime._loadPrime("lime", "lime_window_set_vsync_mode", "oib",
+		false));
 	private static var lime_window_close = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_close", "ov", false));
 	private static var lime_window_context_flip = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_window_context_flip", "ov",
 		false));
@@ -733,6 +737,7 @@ class NativeCFFI
 	private static var lime_text_event_manager_register = CFFI.load("lime", "lime_text_event_manager_register", 2);
 	private static var lime_touch_event_manager_register = CFFI.load("lime", "lime_touch_event_manager_register", 2);
 	private static var lime_window_alert = CFFI.load("lime", "lime_window_alert", 3);
+	private static var lime_window_set_vsync_mode = CFFI.load("lime", "lime_window_set_vsync_mode", 2);
 	private static var lime_window_close = CFFI.load("lime", "lime_window_close", 1);
 	private static var lime_window_context_flip = CFFI.load("lime", "lime_window_context_flip", 1);
 	private static var lime_window_context_lock = CFFI.load("lime", "lime_window_context_lock", 1);
@@ -1235,6 +1240,8 @@ class NativeCFFI
 		eventObject:TouchEventInfo):Void {}
 
 	@:hlNative("lime", "hl_window_alert") private static function lime_window_alert(handle:CFFIPointer, message:String, title:String):Void {}
+
+	@:hlNative("lime", "hl_window_set_vsync_mode") private static function lime_window_set_vsync_mode(handle:CFFIPointer, mode:Int):Bool {}
 
 	@:hlNative("lime", "hl_window_close") private static function lime_window_close(handle:CFFIPointer):Void {}
 

--- a/src/lime/_internal/backend/native/NativeWindow.hx
+++ b/src/lime/_internal/backend/native/NativeWindow.hx
@@ -1,5 +1,6 @@
 package lime._internal.backend.native;
 
+import lime.ui.WindowVSyncMode;
 import haxe.io.Bytes;
 import lime._internal.backend.native.NativeCFFI;
 import lime.app.Application;
@@ -242,6 +243,18 @@ class NativeWindow
 			NativeCFFI.lime_window_focus(handle);
 			#end
 		}
+	}
+
+	public function setVSyncMode(mode:WindowVSyncMode):Bool
+	{
+		if (handle != null)
+		{
+			#if (!macro && lime_cffi)
+			return NativeCFFI.lime_window_set_vsync_mode(handle, mode);
+			#end
+		}
+
+		return false;
 	}
 
 	public function getCursor():MouseCursor

--- a/src/lime/ui/Window.hx
+++ b/src/lime/ui/Window.hx
@@ -395,6 +395,15 @@ class Window
 		__backend.focus();
 	}
 
+	/**
+	 * Sets the swap interval for the current window.
+	 * @return `false` if the swap interval could not be set
+	**/
+	public function setVSyncMode(mode:WindowVSyncMode):Bool
+	{
+		return __backend.setVSyncMode(mode);
+	}
+
 	public function move(x:Int, y:Int):Void
 	{
 		__backend.move(x, y);

--- a/src/lime/ui/WindowVSyncMode.hx
+++ b/src/lime/ui/WindowVSyncMode.hx
@@ -1,0 +1,23 @@
+package lime.ui;
+
+/**
+	An enum containing swap intervals for the current window.
+**/
+#if (haxe_ver >= 4.0) enum #else @:enum #end abstract WindowVSyncMode(Int) from Int to Int from UInt to UInt
+{
+	/**
+		Disable VSync, and push immediate updates.
+	**/
+	public var OFF = 0;
+
+	/**
+		Enable VSync, and synchronize with the monitor's refresh rate
+	**/
+	public var ON = 1;
+
+	/**
+		Enable adaptive VSync, and synchronize with the monitor's refresh rate
+		unless there is a frame rate drop
+	**/
+	public var ADAPTIVE = -1;
+}


### PR DESCRIPTION
Resolves #1908 by adding a function to set the VSync mode after the window has been initialized.

Includes the ability to set the mode to Adaptive VSync, which disables VSync if the frame rate drops below the monitor's refresh rate.

The function returns `false` if the VSync mode failed to be applied properly (i.e. attempting to use Adaptive VSync on a device which does not support it).