### PR TITLE
Fix set_title in Window.hx for the legacy branch

### DIFF
--- a/lime/ui/Window.hx
+++ b/lime/ui/Window.hx
@@ -442,7 +442,7 @@ class Window {
 	
 	@:noCompletion private function set_title (value:String):String {
 		
-		return __title = backend.setTitle (__title);
+		return __title = backend.setTitle (value);
 		
 	}
 	


### PR DESCRIPTION
This PR corrects the parameter being passed to backend.setTitle() inside of the set_title function in ui/Window.hx, which allows the window title to be set at runtime. Currently, the existing window title is passed to backend.setTitle() when the set_title function is run in Window.hx, resulting in no change.