### PR TITLE
Add seperate defines for OpenAL Soft and MojoAL

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -19,7 +19,7 @@
 	<define name="lime-howlerjs" if="html5" />
 	<define name="lime-html5" if="html5" />
 	<define name="lime-native" if="native" />
-	<define name="lime-openalsoft" if="windows || linux || mac || android" unless="static_link || lime-mojoal" />
+	<define name="lime-openalsoft" if="windows || linux || mac || android" unless="static_link || lime-mojoal || winrt" />
 	<define name="lime-mojoal" if="lime-switch || static_link || winrt" unless="lime-openalsoft" />
 	<define name="lime-openal" if="ios || tvos || emscripten || lime-openalsoft || lime-mojoal" />
 	<define name="lime-opengl" if="desktop" unless="html5" />

--- a/include.xml
+++ b/include.xml
@@ -19,7 +19,9 @@
 	<define name="lime-howlerjs" if="html5" />
 	<define name="lime-html5" if="html5" />
 	<define name="lime-native" if="native" />
-	<define name="lime-openal" unless="lime-console || flash || html5" />
+	<define name="lime-openalsoft" if="windows || linux || mac || android" unless="static_link || lime-mojoal" />
+	<define name="lime-mojoal" if="lime-switch || static_link || winrt" unless="lime-openalsoft" />
+	<define name="lime-openal" if="ios || tvos || emscripten || lime-openalsoft || lime-mojoal" />
 	<define name="lime-opengl" if="desktop" unless="html5" />
 	<define name="lime-opengles" if="emscripten || mobile" />
 	<define name="lime-vorbis" if="native" />

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -21,12 +21,9 @@
 	<set name="LIME_MBEDTLS" value="1" unless="emscripten || winrt" />
 	<!-- <set name="LIME_NEKO" value="1" if="linux" /> -->
 	<set name="LIME_OGG" value="1" />
-	<set name="LIME_OPENALSOFT" value="1" if="windows || linux || mac || android" unless="static_link" />
-	<set name="LIME_OPENAL" value="1" if="iphone || webassembly || tvos" />
-	<set name="LIME_MOJOAL" value="1" if="switch || static_link || winrt || mojoal" unless="LIME_OPENAL" />
-	<unset name="LIME_OPENALSOFT" if="LIME_MOJOAL" />
-	<set name="LIME_OPENAL" value="1" if="LIME_OPENALSOFT" />
-	<set name="LIME_OPENAL" value="1" if="LIME_MOJOAL" />
+	<set name="LIME_OPENALSOFT" value="1" if="lime-openalsoft" />
+	<set name="LIME_OPENAL" value="1" if="lime-openal" />
+	<set name="LIME_MOJOAL" value="1" if="lime-mojoal" />
 	<set name="LIME_OPENGL" value="1" />
 	<set name="LIME_PIXMAN" value="1" />
 	<set name="LIME_PNG" value="1" />


### PR DESCRIPTION
Lime uses different OpenAL backends based on the target platform and build configuration. Currently there's only one define (`lime_openal`) that only lets us determine if any OpenAL backend is being used, but not what which one specifically.