### PR TITLE
Fix utf8 conversions in hb_buffer_add_utf8

### DIFF
--- a/project/src/text/harfbuzz/HarfbuzzBindings.cpp
+++ b/project/src/text/harfbuzz/HarfbuzzBindings.cpp
@@ -258,7 +258,13 @@ namespace lime {
 
 	void lime_hb_buffer_add_utf8 (value buffer, HxString text, int itemOffset, int itemLength) {
 
-		hb_buffer_add_utf8 ((hb_buffer_t*)val_data (buffer), text.c_str (), text.length, itemOffset, itemLength);
+		int textLength = text.length;
+		if (hxs_encoding (text) == hx::StringUtf16) {
+			// hxs_utf8 doesn't give us the length, so treat it as null terminated
+			textLength = -1;
+		}
+
+		hb_buffer_add_utf8 ((hb_buffer_t*)val_data (buffer), hxs_utf8 (text, nullptr), textLength, itemOffset, itemLength);
 
 	}
 

--- a/project/src/text/harfbuzz/HarfbuzzBindings.cpp
+++ b/project/src/text/harfbuzz/HarfbuzzBindings.cpp
@@ -271,7 +271,7 @@ namespace lime {
 
 	HL_PRIM void HL_NAME(hl_hb_buffer_add_utf8) (HL_CFFIPointer* buffer, hl_vstring* text, int itemOffset, int itemLength) {
 
-		hb_buffer_add_utf8 ((hb_buffer_t*)buffer->ptr, text ? hl_to_utf8 (text->bytes) : NULL, text ? text->length : 0, itemOffset, itemLength);
+		hb_buffer_add_utf8 ((hb_buffer_t*)buffer->ptr, text ? hl_to_utf8 (text->bytes) : NULL, -1, itemOffset, itemLength);
 
 	}
 


### PR DESCRIPTION
A HxString is not guaranteed to be utf8 on hxcpp, so we need to use hxs_utf8 to convert it otherwise it incorrectly displays any utf16 encoded string.

Unfortunately, hxs_utf8 doesn't give us the length of the utf8 string. The best thing we can do is to tell harfbuzz it is null terminated. This isn't perfect because technically hxcpp strings are allowed to contain NULL, but it's better than all utf16 strings being broken.

We have the same issue on hashlink, but there using `-1` is less of a problem as NULL is not a valid string character.

This was the original reason for issues like: https://github.com/openfl/openfl/issues/2264