### PR TITLE
Add hb_buffer_add_hxstring

### DIFF
--- a/project/src/text/harfbuzz/HarfbuzzBindings.cpp
+++ b/project/src/text/harfbuzz/HarfbuzzBindings.cpp
@@ -242,6 +242,28 @@ namespace lime {
 	}
 
 
+	void lime_hb_buffer_add_hxstring(value buffer, HxString text, int itemOffset, int itemLength) {
+
+		if (hxs_encoding (text) == hx::StringUtf16) {
+
+			hb_buffer_add_utf16 ((hb_buffer_t*)val_data(buffer), (const uint16_t*)text.c_str (), text.length, itemOffset, itemLength);
+
+		} else {
+
+			hb_buffer_add_utf8 ((hb_buffer_t*)val_data(buffer), text.c_str (), text.length, itemOffset, itemLength);
+
+		}
+
+	}
+
+
+	HL_PRIM void HL_NAME(hl_hb_buffer_add_hxstring) (HL_CFFIPointer* buffer, hl_vstring* text, int itemOffset, int itemLength) {
+
+		hb_buffer_add_utf16 ((hb_buffer_t*)buffer->ptr, text ? (const uint16_t*)text->bytes : NULL, text ? text->length : 0, itemOffset, itemLength);
+
+	}
+
+
 	void lime_hb_buffer_add_codepoints (value buffer, double text, int textLength, int itemOffset, int itemLength) {
 
 		hb_buffer_add_codepoints ((hb_buffer_t*)val_data (buffer), (const hb_codepoint_t*)(uintptr_t)text, textLength, itemOffset, itemLength);
@@ -2058,6 +2080,7 @@ namespace lime {
 	DEFINE_PRIME1 (lime_hb_blob_is_immutable);
 	DEFINE_PRIME1v (lime_hb_blob_make_immutable);
 	DEFINE_PRIME3v (lime_hb_buffer_add);
+	DEFINE_PRIME4v (lime_hb_buffer_add_hxstring);
 	DEFINE_PRIME5v (lime_hb_buffer_add_codepoints);
 	DEFINE_PRIME4v (lime_hb_buffer_add_utf8);
 	DEFINE_PRIME5v (lime_hb_buffer_add_utf16);
@@ -2175,6 +2198,7 @@ namespace lime {
 	DEFINE_HL_PRIM (_BOOL, hl_hb_blob_is_immutable, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_VOID, hl_hb_blob_make_immutable, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_VOID, hl_hb_buffer_add, _TCFFIPOINTER _I32 _I32);
+	DEFINE_HL_PRIM (_VOID, hl_hb_buffer_add_hxstring, _TCFFIPOINTER _STRING _I32 _I32);
 	DEFINE_HL_PRIM (_VOID, hl_hb_buffer_add_codepoints, _TCFFIPOINTER _F64 _I32 _I32 _I32);
 	DEFINE_HL_PRIM (_VOID, hl_hb_buffer_add_utf8, _TCFFIPOINTER _STRING _I32 _I32);
 	DEFINE_HL_PRIM (_VOID, hl_hb_buffer_add_utf16, _TCFFIPOINTER _F64 _I32 _I32 _I32);

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -5694,6 +5694,8 @@ class NativeCFFI
 
 	@:cffi private static function lime_hb_buffer_add(buffer:CFFIPointer, codepoint:Int, cluster:Int):Void;
 
+	@:cffi private static function lime_hb_buffer_add_hxstring(buffer:CFFIPointer, text:String, itemOffset:Int, itemLength:Int):Void;
+
 	@:cffi private static function lime_hb_buffer_add_codepoints(buffer:CFFIPointer, text:DataPointer, textLength:Int, itemOffset:Int, itemLength:Int):Void;
 
 	@:cffi private static function lime_hb_buffer_add_utf8(buffer:CFFIPointer, text:String, itemOffset:Int, itemLength:Int):Void;
@@ -5910,6 +5912,8 @@ class NativeCFFI
 		false));
 	private static var lime_hb_buffer_add = new cpp.Callable<cpp.Object->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add", "oiiv",
 		false));
+	private static var lime_hb_buffer_add_hxstring = new cpp.Callable<cpp.Object->String->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
+		"lime_hb_buffer_add_hxstring", "osiiv", false));
 	private static var lime_hb_buffer_add_codepoints = new cpp.Callable<cpp.Object->lime.utils.DataPointer->Int->Int->Int->
 		cpp.Void>(cpp.Prime._loadPrime("lime", "lime_hb_buffer_add_codepoints", "odiiiv", false));
 	private static var lime_hb_buffer_add_utf8 = new cpp.Callable<cpp.Object->String->Int->Int->cpp.Void>(cpp.Prime._loadPrime("lime",
@@ -6090,6 +6094,7 @@ class NativeCFFI
 	private static var lime_hb_blob_is_immutable:Dynamic->Bool = CFFI.load("lime", "lime_hb_blob_is_immutable", 1);
 	private static var lime_hb_blob_make_immutable:Dynamic->Void = CFFI.load("lime", "lime_hb_blob_make_immutable", 1);
 	private static var lime_hb_buffer_add:Dynamic->Int->Int->Void = CFFI.load("lime", "lime_hb_buffer_add", 3);
+	private static var lime_hb_buffer_add_hxstring:Dynamic->String->Int->Int->Void = CFFI.load("lime", "lime_hb_buffer_add_hxstring", 4);
 	private static var lime_hb_buffer_add_codepoints:Dynamic->lime.utils.DataPointer->Int->Int->Int->Void = CFFI.load("lime", "lime_hb_buffer_add_codepoints",
 		5);
 	private static var lime_hb_buffer_add_utf8:Dynamic->String->Int->Int->Void = CFFI.load("lime", "lime_hb_buffer_add_utf8", 4);
@@ -6239,6 +6244,9 @@ class NativeCFFI
 	@:hlNative("lime", "hl_hb_blob_make_immutable") private static function lime_hb_blob_make_immutable(blob:CFFIPointer):Void {}
 
 	@:hlNative("lime", "hl_hb_buffer_add") private static function lime_hb_buffer_add(buffer:CFFIPointer, codepoint:Int, cluster:Int):Void {}
+
+	@:hlNative("lime", "hl_hb_buffer_add_hxstring") private static function lime_hb_buffer_add_hxstring(buffer:CFFIPointer, text:String, itemOffset:Int,
+		itemLength:Int):Void {}
 
 	@:hlNative("lime", "hl_hb_buffer_add_codepoints") private static function lime_hb_buffer_add_codepoints(buffer:CFFIPointer, text:DataPointer,
 		textLength:Int, itemOffset:Int, itemLength:Int):Void {}

--- a/src/lime/text/harfbuzz/HBBuffer.hx
+++ b/src/lime/text/harfbuzz/HBBuffer.hx
@@ -36,6 +36,13 @@ abstract HBBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 		#end
 	}
 
+	public function addString(text:String, itemOffset:Int, itemLength:Int):Void
+	{
+		#if (lime_cffi && lime_harfbuzz && !macro)
+		NativeCFFI.lime_hb_buffer_add_hxstring(this, text, itemOffset, itemLength);
+		#end
+	}
+
 	public function addCodepoints(text:DataPointer, textLength:Int, itemOffset:Int, itemLength:Int):Void
 	{
 		#if (lime_cffi && lime_harfbuzz && !macro)


### PR DESCRIPTION
To properly handle encoding conversions, we need to do it in native code. This new function performs this role.

This is useful for hxcpp which may have either ascii or utf16 encoding, but this can only be checked via the native api and it is not possible on the haxe side.

This is more convenient for users as they don't have to be concerned with what encoding their haxe target is using.