### PR TITLE
Remove HXCPP_CPP11 from build xml files

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -1,7 +1,6 @@
 <xml>
 
 	<set name="PLATFORM" value="android-21" if="android" />
-	<set name="HXCPP_CPP11" value="1" />
 
 	<include name="${HXCPP}/build-tool/BuildCommon.xml" />
 

--- a/project/BuildHashlink.xml
+++ b/project/BuildHashlink.xml
@@ -1,6 +1,5 @@
 <xml>
 	<set name="PLATFORM" value="android-21" if="android" />
-	<set name="HXCPP_CPP11" value="1" />
 
 	<include name="${HXCPP}/build-tool/BuildCommon.xml" />
 


### PR DESCRIPTION
For updating some dependencies, we may want to use a different c++ standard, but it is not possible to do this because HXCPP_CPP11 takes priority