### PR TITLE
Fix Font.getGlyphs returning zeros and looping

### DIFF
--- a/project/src/text/Font.cpp
+++ b/project/src/text/Font.cpp
@@ -1066,8 +1066,6 @@ namespace lime {
 			int count = 0;
 			const char* characters_start = characters;
 
-			// TODO: Determine array size first
-
 			while (*characters != 0) {
 
 				character = readNextChar (characters);

--- a/project/src/text/Font.cpp
+++ b/project/src/text/Font.cpp
@@ -1052,6 +1052,10 @@ namespace lime {
 			while (*characters != 0) {
 
 				character = readNextChar (characters);
+
+				if (character == -1)
+					break;
+
 				index = FT_Get_Char_Index ((FT_Face)face, character);
 				val_array_push (indices, alloc_int (index));
 
@@ -1069,6 +1073,10 @@ namespace lime {
 			while (*characters != 0) {
 
 				character = readNextChar (characters);
+
+				if (character == -1)
+					break;
+
 				count++;
 
 			}
@@ -1080,6 +1088,10 @@ namespace lime {
 			while (*characters != 0) {
 
 				character = readNextChar (characters);
+
+				if (character == -1)
+					break;
+
 				*indicesData++ = FT_Get_Char_Index ((FT_Face)face, character);
 
 			}

--- a/project/src/text/Font.cpp
+++ b/project/src/text/Font.cpp
@@ -1064,6 +1064,7 @@ namespace lime {
 			unsigned long character;
 			int index;
 			int count = 0;
+			const char* characters_start = characters;
 
 			// TODO: Determine array size first
 
@@ -1076,6 +1077,7 @@ namespace lime {
 
 			hl_varray* indices = (hl_varray*)hl_alloc_array (&hlt_i32, count);
 			int* indicesData = hl_aptr (indices, int);
+			characters = characters_start;
 
 			while (*characters != 0) {
 


### PR DESCRIPTION
On hashlink, Font.getGlyphs was incorrectly implemented and always returned an array of zeros.
On all platforms, it would also loop indefinitely if it encountered an invalid character.