### PR TITLE
Update openal soft to 1.21.1

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -1,6 +1,7 @@
 <xml>
 
-	<set name="HXCPP_NO_CPP11" value="1" />
+	<set name="HXCPP_NO_CPP11" value="1" unless="mac" />
+	<set name="HXCPP_CPP14" value="1" if="mac" />
 
 	<include name="${HXCPP}/build-tool/BuildCommon.xml" />
 

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -1,6 +1,6 @@
 <xml>
 
-	<set name="HXCPP_CPP11" value="1" />
+	<set name="HXCPP_NO_CPP11" value="1" />
 
 	<include name="${HXCPP}/build-tool/BuildCommon.xml" />
 
@@ -55,6 +55,7 @@
 
 	<files id="lime">
 
+		<compilerflag value="-std=c++11" />
 		<compilerflag value="-Iinclude" />
 
 		<file name="src/ExternalInterface.cpp" />

--- a/project/lib/custom/openal/build/version.h
+++ b/project/lib/custom/openal/build/version.h
@@ -1,8 +1,9 @@
 /* Define to the library version */
-#define ALSOFT_VERSION "1.20.1"
+#define ALSOFT_VERSION "1.21.1"
+#define ALSOFT_VERSION_NUM 1,21,1,0
 
 /* Define the branch being built */
-#define ALSOFT_GIT_BRANCH "master"
+#define ALSOFT_GIT_BRANCH "HEAD"
 
 /* Define the hash of the head commit */
-#define ALSOFT_GIT_COMMIT_HASH "f5e0eef3"
+#define ALSOFT_GIT_COMMIT_HASH "ae4eacf14"

--- a/project/lib/openal-files.xml
+++ b/project/lib/openal-files.xml
@@ -2,6 +2,8 @@
 
     <files id="native-toolkit-openal">
 
+        <compilerflag value="-std=c++14" unless="isMsvc" />
+
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/" />
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/custom/openal/alc/" />
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/alc/" />
@@ -9,6 +11,8 @@
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/common/" />
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/custom/openal/include/" />
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/include/" />
+        <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/core/" />
+
         <compilerflag value="-DAL_LIBTYPE_STATIC" if="native_toolkit_openal_static" />
 
         <compilerflag value="-DAL_ALEXT_PROTOTYPES" />
@@ -19,6 +23,20 @@
         <file name="${NATIVE_TOOLKIT_PATH}/openal/al/auxeffectslot.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/al/buffer.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effect.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/autowah.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/chorus.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/compressor.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/convolution.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/dedicated.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/distortion.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/echo.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/equalizer.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/fshifter.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/modulator.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/null.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/pshifter.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/reverb.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/al/effects/vmorpher.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/al/error.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/al/event.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/al/extension.cpp" />
@@ -29,17 +47,18 @@
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/alc.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/alconfig.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/alu.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/ambdec.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/base.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/loopback.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/null.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/wave.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/bformatdec.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/bs2b.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/buffer_storage.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/converter.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effectslot.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/autowah.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/chorus.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/compressor.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/convolution.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/dedicated.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/distortion.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/echo.cpp" />
@@ -50,30 +69,38 @@
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/pshifter.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/reverb.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/effects/vmorpher.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/filters/biquad.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/filters/nfc.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/filters/splitter.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/helpers.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/hrtf.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/mastering.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/mixer/mixer_c.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/mixer/mixer_neon.cpp" if="rpi || HXCPP_ARM64" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/mixer/mixer_sse.cpp" unless="rpi || android || HXCPP_ARM64" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/mixer/mixer_sse2.cpp" unless="rpi || android || HXCPP_ARM64" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/mixer/mixer_sse3.cpp" unless="rpi || android || HXCPP_ARM64" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/panning.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/ringbuffer.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/uhjfilter.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/voice.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/alcomplex.cpp" />
-        <file name="${NATIVE_TOOLKIT_PATH}/openal/common/alexcpt.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/alfstream.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/almalloc.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/alstring.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/dynload.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/polyphase_resampler.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/common/ringbuffer.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/strutils.cpp" />
         <file name="${NATIVE_TOOLKIT_PATH}/openal/common/threads.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/ambdec.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/bs2b.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/bsinc_tables.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/cpu_caps.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/devformat.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/except.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/filters/biquad.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/filters/nfc.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/filters/splitter.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/fmt_traits.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/fpu_ctrl.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/logging.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/mastering.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/mixer/mixer_c.cpp" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/mixer/mixer_neon.cpp" if="rpi || HXCPP_ARM64" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/mixer/mixer_sse.cpp" unless="rpi || android || HXCPP_ARM64" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/mixer/mixer_sse2.cpp" unless="rpi || android || HXCPP_ARM64" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/mixer/mixer_sse3.cpp" unless="rpi || android || HXCPP_ARM64" />
+        <file name="${NATIVE_TOOLKIT_PATH}/openal/core/uhjfilter.cpp" />
 
         <section if="NATIVE_TOOLKIT_HAVE_SDL">
 


### PR DESCRIPTION
This openal soft version resolves an issue on android so that lime can be built without having to force a newer minimum sdk version, see #1923.

Openal soft 1.21.1 requires c++14. On most platforms this isn't an issue and we can just set `HXCPP_NO_CPP11` and add `-std=c++14` (see https://github.com/HaxeFoundation/hxcpp/issues/1200). However, on MacOS this leads to a problem because `HXCPP_NO_CPP11` prevents hxcpp from using `-stdlib=libc++`. We can resolve this by using `HXCPP_CPP14`, however, that is only available since hxcpp 4.3.2 so older versions of hxcpp won't be able to build successfully.