### PR TITLE
Fix old android ndk error not showing

### DIFF
--- a/project/lib/openal-files.xml
+++ b/project/lib/openal-files.xml
@@ -1,5 +1,9 @@
 <xml>
 
+    <section if="android LIME_OPENALSOFT">
+        <error value="NDK version 20 or higher is required." unless="NDKV20+" />
+    </section>
+
     <files id="native-toolkit-openal">
 
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/" />
@@ -155,7 +159,6 @@
 
         <section if="android">
 
-            <error value="NDK version 20 or higher is required." unless="NDKV20+" />
             <compilerflag value="-fsigned-char" />
 
             <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/opensl.cpp" />


### PR DESCRIPTION
The error flag is not valid inside `<files />`, so this wasn't actually doing anything since it was added in f5a24dc40aeb23981fff35997089787826178939.

The error now displays properly.