### PR TITLE
Apply -std=c++11 to openal-soft build on android

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -55,8 +55,7 @@
 	<set name="NATIVE_TOOLKIT_SDL_ANGLE" value="1" if="LIME_SDL_ANGLE" />
 
 	<files id="lime">
-		
-		<compilerflag value="-std=c++11" />
+
 		<compilerflag value="-Iinclude" />
 
 		<file name="src/ExternalInterface.cpp" />

--- a/project/lib/openal-files.xml
+++ b/project/lib/openal-files.xml
@@ -2,6 +2,8 @@
 
     <files id="native-toolkit-openal">
 
+        <compilerflag value="-std=c++11" if="android" />
+
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/" />
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/custom/openal/alc/" />
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal/alc/" />


### PR DESCRIPTION
openal-soft assumes that aligned_alloc is available with c++17. Newer android ndks set c++17 by default, however they do not expose aligned_alloc without setting min sdk version to 28.

We can avoid this issue by forcing openal to be compiled with c++11.

Also note, we have HXCPP_CPP11 defined, however, hxcpp ignores this for the android toolchain.  This means we must set it explicitly

See:
https://github.com/kcat/openal-soft/blob/f5e0eef34db3a3ab94b61a2f99f84f078ba947e7/common/almalloc.cpp#L15

This partially addresses #1923.