### PR TITLE
Prefer currently booted iOS Simulator

### DIFF
--- a/src/lime/tools/XCodeHelper.hx
+++ b/src/lime/tools/XCodeHelper.hx
@@ -43,15 +43,35 @@ class XCodeHelper
 
 	private static function extractSimulatorID(line:String):String
 	{
-		var id = line.substring(line.indexOf("(") + 1, line.indexOf(")"));
-
-		if (id.indexOf("inch") > -1 || id.indexOf("generation") > -1)
+		// Simulator ID's are always:
+		// XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+		var searchPos = 0;
+	
+		while (true)
 		{
-			var startIndex = line.indexOf(")") + 2;
-			id = line.substring(line.indexOf("(", startIndex) + 1, line.indexOf(")", startIndex));
+			var openParen = line.indexOf("(", searchPos);
+			var closeParen = line.indexOf(")", openParen);
+			
+			if (openParen == -1 || closeParen == -1)
+			{
+				// Couldn't find a valid ID
+				break;
+			}
+	
+			var potentialID = line.substring(openParen + 1, closeParen);
+	
+			// Simulator IDs are always UUID strings exactly 36 chars long
+			if (potentialID.length == 36 && potentialID.indexOf("-") > -1)
+			{
+				return potentialID;
+			}
+			
+			// Skip past the current set of parentheses and keep looking
+			searchPos = closeParen + 1;
 		}
-
-		return id;
+	
+		// No valid ID found
+		return "";
 	}
 
 	private static function getBootedSimulator():SimulatorInfo
@@ -62,7 +82,7 @@ class XCodeHelper
 		{
 			if (line.indexOf("(Booted)") > -1)
 			{
-				return { id: extractSimulatorID(line), name: extractSimulatorFullName(line) };
+				return { id: extractSimulatorID(StringTools.trim(line)), name: extractSimulatorFullName(StringTools.trim(line)) };
 			}
 		}
 		return null;
@@ -187,35 +207,30 @@ class XCodeHelper
 
 	public static function getSimulatorID(project:HXProject):String
 	{
-		// try and get the simulator which is currently open and running
-		// if there are none running then fall back to getting the selected simulator
-		var simulator = getBootedSimulatorID();
-		if (simulator != null) 
-		{
-			// we found a running simulator, so use that
-			return simulator.id;
-		}
-
-		simulator = getSelectedSimulator(project);
-		if (simulator != null)
-		{
-			return simulator.id;
-		}
-		return null;
+		var simulator = getPreferredSimulator(project);
+		return (simulator != null) ? simulator.id : null;
 	}
 
 	public static function getSimulatorName(project:HXProject):String
 	{
-		var simulator = getBootedSimulatorID();
+		var simulator = getPreferredSimulator(project);
+		return (simulator != null) ? simulator.name : null;
+	}
+
+	private static function getPreferredSimulator(project:HXProject):SimulatorInfo
+	{
+		// try and get the simulator which is currently open and running
+		// if there are none running then fall back to getting the selected simulator
+		var simulator = getBootedSimulator();
 		if (simulator != null) 
 		{
-			return simulator.name;
+			return simulator;
 		}
 
 		simulator = getSelectedSimulator(project);
 		if (simulator != null)
 		{
-			return simulator.name;
+			return simulator;
 		}
 		return null;
 	}

--- a/src/lime/tools/XCodeHelper.hx
+++ b/src/lime/tools/XCodeHelper.hx
@@ -54,6 +54,21 @@ class XCodeHelper
 		return id;
 	}
 
+	public static function getBootedSimulatorID():String 
+	{
+		// attempts to find a simulator which is currently booted and running
+		var result = System.runProcess("", "xcrun", ["simctl", "list", "devices", "booted"]);
+		var lines = result.split("\n");
+		for (line in lines) {
+			// Match a line like: "    iPhone 15 Pro (E5B048F6-BE70-498E-B5F6-B84B8594DDBF) (Booted)"
+			var match = ~/.*\(([A-F0-9\-]{36})\)\s+\(Booted\)/;
+			if (match.match(line)) {
+				return match.matched(1);
+			}
+		}
+		return null;
+	}
+	
 	public static function getSelectedSimulator(project:HXProject):SimulatorInfo
 	{
 		var output = getSimulators();
@@ -173,6 +188,15 @@ class XCodeHelper
 
 	public static function getSimulatorID(project:HXProject):String
 	{
+		// try and get the simulator which is currently open and running
+		// if there are none running then fall back to getting the selected simulator
+		var booted = getBootedSimulatorID();
+		if (booted != null) 
+		{
+			// we found a running simulator, so use that
+			return booted;
+		}
+
 		var simulator = getSelectedSimulator(project);
 		if (simulator == null)
 		{

--- a/src/lime/tools/XCodeHelper.hx
+++ b/src/lime/tools/XCodeHelper.hx
@@ -54,21 +54,20 @@ class XCodeHelper
 		return id;
 	}
 
-	public static function getBootedSimulatorID():String 
+	private static function getBootedSimulator():SimulatorInfo
 	{
-		// attempts to find a simulator which is currently booted and running
 		var result = System.runProcess("", "xcrun", ["simctl", "list", "devices", "booted"]);
 		var lines = result.split("\n");
-		for (line in lines) {
-			// Match a line like: "    iPhone 15 Pro (E5B048F6-BE70-498E-B5F6-B84B8594DDBF) (Booted)"
-			var match = ~/.*\(([A-F0-9\-]{36})\)\s+\(Booted\)/;
-			if (match.match(line)) {
-				return match.matched(1);
+		for (line in lines)
+		{
+			if (line.indexOf("(Booted)") > -1)
+			{
+				return { id: extractSimulatorID(line), name: extractSimulatorFullName(line) };
 			}
 		}
 		return null;
 	}
-	
+
 	public static function getSelectedSimulator(project:HXProject):SimulatorInfo
 	{
 		var output = getSimulators();
@@ -190,29 +189,35 @@ class XCodeHelper
 	{
 		// try and get the simulator which is currently open and running
 		// if there are none running then fall back to getting the selected simulator
-		var booted = getBootedSimulatorID();
-		if (booted != null) 
+		var simulator = getBootedSimulatorID();
+		if (simulator != null) 
 		{
 			// we found a running simulator, so use that
-			return booted;
+			return simulator.id;
 		}
 
-		var simulator = getSelectedSimulator(project);
-		if (simulator == null)
+		simulator = getSelectedSimulator(project);
+		if (simulator != null)
 		{
-			return null;
+			return simulator.id;
 		}
-		return simulator.id;
+		return null;
 	}
 
 	public static function getSimulatorName(project:HXProject):String
 	{
-		var simulator = getSelectedSimulator(project);
-		if (simulator == null)
+		var simulator = getBootedSimulatorID();
+		if (simulator != null) 
 		{
-			return null;
+			return simulator.name;
 		}
-		return simulator.name;
+
+		simulator = getSelectedSimulator(project);
+		if (simulator != null)
+		{
+			return simulator.name;
+		}
+		return null;
 	}
 
 	private static function getSimulators():String


### PR DESCRIPTION
This PR updates XCodeHelper.getSimulatorID to first check if a simulator is already running and use that device's UDID, if there are no simulators running it will fall back to original behaviour.

This improves usability when switching simulators manually via the Simulator app, as users may wish to switch simulators multiple times during testing. For example if I open an "iPad 11 inch" simulator specifically and then build I'd expect it to be installed and run on that simulator.

This change is non-breaking and falls back to the existing logic if no simulator is currently running.