### PR TITLE
Replace Map with IMap on AssetCache

### DIFF
--- a/src/lime/utils/AssetCache.hx
+++ b/src/lime/utils/AssetCache.hx
@@ -1,6 +1,7 @@
 package lime.utils;
 
 import haxe.macro.Compiler;
+import haxe.Constraints.IMap;
 import lime.media.AudioBuffer;
 import lime.graphics.Image;
 #if !(macro || commonjs)
@@ -13,10 +14,10 @@ import lime._internal.macros.AssetsMacro;
 #end
 class AssetCache
 {
-	public var audio:Map<String, AudioBuffer>;
+	public var audio:IMap<String, AudioBuffer>;
 	public var enabled:Bool = true;
-	public var image:Map<String, Image>;
-	public var font:Map<String, Dynamic /*Font*/>;
+	public var image:IMap<String, Image>;
+	public var font:IMap<String, Dynamic /*Font*/>;
 	public var version:Int;
 
 	public function new()


### PR DESCRIPTION
This allows `audio`, `font`, and `image` to be replaced with any object which implements `IMap`, which includes custom map implementations with different underlying behavior. This is required to replace the map with a different class, as I don't believe you can extend the standard `Map` class since it is an abstract and the underlying implementation is provided by the standard library.

In my use case, I am replacing Map with a CallbackMap class I made, which re-implements the standard Map but allows me to register callbacks when values are added or removed.