### PR TITLE
IOS embed a dynamic framework xcode project changes

### DIFF
--- a/templates/ios/template/{{app.file}}.xcodeproj/project.pbxproj
+++ b/templates/ios/template/{{app.file}}.xcodeproj/project.pbxproj
@@ -41,6 +41,10 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+::ADDL_PBX_COPY_FILES_BUILD_PHASE::
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		1D6058910D05DD3D006BFB54 /* ::APP_TITLE::.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "::APP_TITLE::.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E2E17A5131E8B5D0048F3C7 /* ::APP_FILE::/assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "::APP_FILE::/assets"; sourceTree = "<group>"; };
@@ -179,7 +183,7 @@
 			buildPhases = (
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
-				1D60588F0D05DD3D006BFB54 /* Frameworks */,
+				1D60588F0D05DD3D006BFB54 /* Frameworks */,::ADDL_PBX_BUILD_PHASE_LIST::
 			);
 			buildRules = (
 			);
@@ -370,6 +374,7 @@
 				GCC_PREFIX_HEADER = "::APP_FILE::/::APP_FILE::-Prefix.pch";
 				INFOPLIST_FILE = "::APP_FILE::/::APP_FILE::-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = ::DEPLOYMENT::;
+				::ADDL_PBX_RUNPATH_SEARCH_PATHS::
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = (
 					"$(inherited)",
 					"\"$(SRCROOT)/::APP_FILE::/lib/arm64-debug\"",
@@ -428,6 +433,7 @@
 				GCC_PREFIX_HEADER = "::APP_FILE::/::APP_FILE::-Prefix.pch";
 				INFOPLIST_FILE = "::APP_FILE::/::APP_FILE::-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = ::DEPLOYMENT::;
+				::ADDL_PBX_RUNPATH_SEARCH_PATHS::
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = (
 					"$(inherited)",
 					"\"$(SRCROOT)/::APP_FILE::/lib/arm64\"",

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -354,6 +354,9 @@ class IOSPlatform extends PlatformTarget
 		context.ADDL_PBX_FILE_REFERENCE = "";
 		context.ADDL_PBX_FRAMEWORKS_BUILD_PHASE = "";
 		context.ADDL_PBX_FRAMEWORK_GROUP = "";
+		context.ADDL_PBX_COPY_FILES_BUILD_PHASE = "";
+		context.ADDL_PBX_BUILD_PHASE_LIST = "";
+		context.ADDL_PBX_RUNPATH_SEARCH_PATHS = "";
 
 		context.frameworkSearchPaths = [];
 
@@ -401,6 +404,22 @@ class IOSPlatform extends PlatformTarget
 					+ "\"; name = \"" + name + "\"; path = \"" + path + "\"; sourceTree = SDKROOT; };\n";
 				context.ADDL_PBX_FRAMEWORKS_BUILD_PHASE += "				" + frameworkID + " /* " + name + " in Frameworks */,\n";
 				context.ADDL_PBX_FRAMEWORK_GROUP += "				" + fileID + " /* " + name + " */,\n";
+
+				if (dependency.embed)
+				{
+					var copyID = StringTools.getUniqueID();
+					var copyFileID = "37E717FD2D8D9CDF" + copyID;
+					var copyPhaseID = "37E717FC2D8D9CCB" + copyID;
+					context.ADDL_PBX_BUILD_FILE += "		" + copyFileID + " /* " + name + " in CopyFiles */ = {isa = PBXBuildFile; fileRef = " + fileID + " /* "
+					+ name + " */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };\n";
+
+					context.ADDL_PBX_COPY_FILES_BUILD_PHASE += "		" + copyPhaseID + " /* CopyFiles */ = {\n			isa = PBXCopyFilesBuildPhase;\n			buildActionMask = 2147483647;\n			dstPath = \"\";\n			dstSubfolderSpec = 10;\n			files = (\n				" 
+					+ copyFileID + " /* " + name + " in CopyFiles */,\n			);\n			runOnlyForDeploymentPostprocessing = 0;\n			};\n";
+
+					context.ADDL_PBX_BUILD_PHASE_LIST += "\n				" + copyPhaseID + " /* CopyFiles */,";
+
+					context.ADDL_PBX_RUNPATH_SEARCH_PATHS = "LD_RUNPATH_SEARCH_PATHS = (\n\"$(LD_RUNPATH_SEARCH_PATHS_$(IS_MACCATALYST))\",\n\"@executable_path/Frameworks\",\n);";
+				}
 			}
 		}
 


### PR DESCRIPTION
This pull request updates the generated Xcode project when using embed=true with an iOS framework dependency. 
Specifically, it:
Adds a "Copy Files" build phase
Updates the Runpath Search Paths

These changes ensure that dynamic framework dependencies are correctly embedded and included in the final app bundle.
Note: You’ll need to rebuild Lime tools after applying these changes.

Why this is needed:
Dynamic frameworks aren’t automatically embedded in the same way static frameworks are. This becomes particularly important when working with Swift code, which must be included in a dynamic framework.

Use case:
To include Swift code in an extension, it was added to a custom dynamic framework. That framework was then included in the extension using embed=true. Without these changes, the framework wouldn't be properly compiled into the app.