### PR TITLE
replace deprecated `apple-mobile-web-app-capable` with `mobile-web-app-capable`

### DIFF
--- a/templates/html5/template/index.html
+++ b/templates/html5/template/index.html
@@ -7,7 +7,7 @@
 	<title>::APP_TITLE::</title>
 
 	<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="mobile-web-app-capable" content="yes">
 
 	::if favicons::::foreach (favicons)::
 	<link rel="::__current__.rel::" type="::__current__.type::" href="::__current__.href::">::end::::end::

--- a/templates/webassembly/template/index.html
+++ b/templates/webassembly/template/index.html
@@ -7,7 +7,7 @@
 	<title>::APP_TITLE::</title>
 
 	<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="mobile-web-app-capable" content="yes">
 
 	::if favicons::::foreach (favicons)::
 	<link rel="::__current__.rel::" type="::__current__.type::" href="::__current__.href::">::end::::end::

--- a/templates/winjs/template/source/index.html
+++ b/templates/winjs/template/source/index.html
@@ -5,7 +5,7 @@
     <title>::APP_TITLE:: - ::guid::</title>
     <link href="css/default.css" rel="stylesheet" />
     <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     ::if favicons::::foreach (favicons)::
     <link rel="::__current__.rel::" type="::__current__.type::" href="::__current__.href::">::end::::end::
 


### PR DESCRIPTION
see https://github.com/openfl/openfl/pull/2791

note: im unsure in which context the `winjs` target/template is used, if thats an older target it could potentially *not* be deprecated! 