### PR TITLE
Perform null check for XMLHttpRequest.upload

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
+++ b/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
@@ -64,7 +64,8 @@ class HTML5HTTPRequest
 
 		if (parent.method == POST)
 		{
-			request.upload.addEventListener("progress", progress, false);
+			if(request.upload != null)
+				request.upload.addEventListener("progress", progress, false);
 		}
 		else
 		{


### PR DESCRIPTION
Some browsers may not support uploading, and accessing upload will return null.