### PR TITLE
Fix unicode system path conversions on linux

### DIFF
--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -111,9 +111,9 @@ namespace lime {
 
 				if (path != nullptr) {
 
-						wstring_convert converter;
-						result = new std::wstring (converter.from_bytes(path));
-						SDL_free (path);
+					wstring_convert converter;
+					result = new std::wstring (converter.from_bytes(path));
+					SDL_free (path);
 
 				}
 
@@ -127,11 +127,11 @@ namespace lime {
 
 				if (path != nullptr) {
 
-        		wstring_convert converter;
-						result = new std::wstring (converter.from_bytes(path));
-						SDL_free (path);
+        			wstring_convert converter;
+					result = new std::wstring (converter.from_bytes(path));
+					SDL_free (path);
 
-        }
+				}
 
 				break;
 
@@ -160,9 +160,9 @@ namespace lime {
 
 				if (home != NULL) {
 
-						std::string path = std::string (home) + std::string ("/Desktop");
-						wstring_convert converter;
-						result = new std::wstring (converter.from_bytes(path));
+					std::string path = std::string (home) + std::string ("/Desktop");
+					wstring_convert converter;
+					result = new std::wstring (converter.from_bytes(path));
 
 				}
 

--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -38,10 +38,10 @@
 #include <SDL.h>
 #include <string>
 
-#ifdef HX_WINDOWS
 #include <locale>
 #include <codecvt>
-#endif
+
+using wstring_convert = std::wstring_convert<std::codecvt_utf8<wchar_t>>;
 
 
 namespace lime {
@@ -108,12 +108,8 @@ namespace lime {
 			case APPLICATION: {
 
 				char* path = SDL_GetBasePath ();
-				#ifdef HX_WINDOWS
-				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				wstring_convert converter;
 				result = new std::wstring (converter.from_bytes(path));
-				#else
-				result = new std::wstring (path, path + strlen (path));
-				#endif
 				SDL_free (path);
 				break;
 
@@ -122,12 +118,8 @@ namespace lime {
 			case APPLICATION_STORAGE: {
 
 				char* path = SDL_GetPrefPath (company, title);
-				#ifdef HX_WINDOWS
-				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+				wstring_convert converter;
 				result = new std::wstring (converter.from_bytes(path));
-				#else
-				result = new std::wstring (path, path + strlen (path));
-				#endif
 				SDL_free (path);
 				break;
 
@@ -161,7 +153,8 @@ namespace lime {
 				}
 
 				std::string path = std::string (home) + std::string ("/Desktop");
-				result = new std::wstring (path.begin (), path.end ());
+				wstring_convert converter;
+				result = new std::wstring (converter.from_bytes(path));
 
 				#endif
 				break;
@@ -196,7 +189,8 @@ namespace lime {
 				if (home != NULL) {
 
 					std::string path = std::string (home) + std::string ("/Documents");
-					result = new std::wstring (path.begin (), path.end ());
+					wstring_convert converter;
+					result = new std::wstring (converter.from_bytes(path));
 
 				}
 
@@ -270,7 +264,8 @@ namespace lime {
 				if (home != NULL) {
 
 					std::string path = std::string (home);
-					result = new std::wstring (path.begin (), path.end ());
+					wstring_convert converter;
+					result = new std::wstring (converter.from_bytes(path));
 
 				}
 


### PR DESCRIPTION
For non windows platforms, we previously just passed `char*` into `wstring`, which didn't perform the necessary conversion into utf32 which is expected when hxcpp converts a wchar string to a hxstring on platforms where wchar has 4 bytes.

Ideally, we would skip the wstring conversion altogether, since it is an unnecessary conversion which has caused lots of issues like this in the past, however, for now this fixes #1937. I also tested on Windows and it seems to be working correctly still (`DESKTOP`, `APPLICATION` and `APPLICATION_STORAGE` at least). It would be useful if others could test on other systems like Mac. This is what I used to test on linux for example:
```haxe
// Source/Main.hx
class Main extends lime.app.Application {
	public override function onPreloadComplete() {
		trace(lime.system.System.applicationDirectory);
		trace(lime.system.System.applicationStorageDirectory);

		Sys.putEnv("HOME", "/TÉST");
		trace(lime.system.System.documentsDirectory);
		trace(lime.system.System.userDirectory);
		trace(lime.system.System.desktopDirectory);
	}
}
```

```xml
<!-- project.xml -->
<?xml version="1.0" encoding="utf-8"?>
<project>

	<meta title="HelloWorld" package="com.sample.helloworld" version="1.0.0" company="Cømpany Name" />
	<app main="Main" path="Éxport" file="HelloWorld" />

	<source path="Source" />

	<haxelib name="lime" />

	<assets path="Assets" rename="assets" />

</project>
```