### PR TITLE
Fix crash on null returns from sdl path functions

### DIFF
--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -108,13 +108,19 @@ namespace lime {
 			case APPLICATION: {
 
 				char* path = SDL_GetBasePath ();
-				#ifdef HX_WINDOWS
-				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-				result = new std::wstring (converter.from_bytes(path));
-				#else
-				result = new std::wstring (path, path + strlen (path));
-				#endif
-				SDL_free (path);
+
+				if (path != nullptr) {
+
+					#ifdef HX_WINDOWS
+					std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+					result = new std::wstring (converter.from_bytes(path));
+					#else
+					result = new std::wstring (path, path + strlen (path));
+					#endif
+					SDL_free (path);
+
+				}
+
 				break;
 
 			}
@@ -122,13 +128,17 @@ namespace lime {
 			case APPLICATION_STORAGE: {
 
 				char* path = SDL_GetPrefPath (company, title);
-				#ifdef HX_WINDOWS
-				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-				result = new std::wstring (converter.from_bytes(path));
-				#else
-				result = new std::wstring (path, path + strlen (path));
-				#endif
-				SDL_free (path);
+
+				if (path != nullptr) {
+					#ifdef HX_WINDOWS
+					std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+					result = new std::wstring (converter.from_bytes(path));
+					#else
+					result = new std::wstring (path, path + strlen (path));
+					#endif
+					SDL_free (path);
+				}
+
 				break;
 
 			}


### PR DESCRIPTION
On android SDL_GetBasePath is not implemented and returns NULL, which means that calling strlen causes a crash:

https://github.com/libsdl-org/SDL/blob/1f21aae242ba7e1e040d93d1932e64d3e4246438/src/filesystem/android/SDL_sysfilesystem.c#L35-L40

According to sdl docs, SDL_GetPrefPath can also return NULL, so we also need to check for that:
https://wiki.libsdl.org/SDL2/SDL_GetPrefPath#return-value https://wiki.libsdl.org/SDL2/SDL_GetBasePath#return-value

Fixes #1358.