### PR TITLE
Fix NULL handling in `GetDirectory(DESKTOP)`

### DIFF
--- a/project/src/backend/sdl/SDLSystem.cpp
+++ b/project/src/backend/sdl/SDLSystem.cpp
@@ -154,14 +154,12 @@ namespace lime {
 
 				char const* home = getenv ("HOME");
 
-				if (home == NULL) {
+				if (home != NULL) {
 
-					return 0;
+					std::string path = std::string (home) + std::string ("/Desktop");
+					result = new std::wstring (path.begin (), path.end ());
 
 				}
-
-				std::string path = std::string (home) + std::string ("/Desktop");
-				result = new std::wstring (path.begin (), path.end ());
 
 				#endif
 				break;


### PR DESCRIPTION
If HOME is NULL, we cannot return here immediately, since we haven't called `System::GCExitBlocking()`. This currently causes:
```
Critical Error: Allocating from a GC-free thread
```

This is already handled correctly for `USER` and `DOCUMENTS`, however `DESKTOP` was missed out in f6e38208d368b503031898538d1d3f13b3d43d11

Here is a program that can be used to demonstrate the crash:

```haxe
class Main extends lime.app.Application {
	public function new() {
		super();
		Sys.putEnv("HOME", null);
		trace(lime.system.System.desktopDirectory);
	}
}
```