### PR TITLE
Fix duplicate code in `PlatformTarget` subclasses, fix assets being included twice.

### DIFF
--- a/src/lime/tools/PlatformTarget.hx
+++ b/src/lime/tools/PlatformTarget.hx
@@ -155,7 +155,13 @@ class PlatformTarget
 
 	@ignore public function build():Void {}
 
-	@ignore public function clean():Void {}
+	public function clean():Void
+	{
+		if (FileSystem.exists(targetDirectory))
+		{
+			System.removeDirectory(targetDirectory);
+		}
+	}
 
 	@ignore public function deploy():Void {}
 

--- a/src/lime/tools/PlatformTarget.hx
+++ b/src/lime/tools/PlatformTarget.hx
@@ -173,7 +173,25 @@ class PlatformTarget
 
 	@ignore public function update():Void {}
 
-	@ignore public function watch():Void {}
+	public function watch():Void
+	{
+		var hxml = getDisplayHXML();
+		if (hxml == null)
+		{
+			return;
+		}
+
+		var dirs = hxml.getClassPaths(true);
+
+		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
+		dirs = dirs.filter(function(dir)
+		{
+			return (!Path.startsWith(dir, outputPath));
+		});
+
+		var command = ProjectHelper.getCurrentCommand();
+		System.watch(command, dirs);
+	}
 
 	// Common functionality used by subclasses
 
@@ -216,6 +234,8 @@ class PlatformTarget
 			}
 		}
 	}
+
+	private function getDisplayHXML():HXML { return null; }
 
 	// Functions to track and delete stale files
 

--- a/src/lime/tools/PlatformTarget.hx
+++ b/src/lime/tools/PlatformTarget.hx
@@ -151,6 +151,8 @@ class PlatformTarget
 		}
 	}
 
+	// Command implementations
+
 	@ignore public function build():Void {}
 
 	@ignore public function clean():Void {}
@@ -172,6 +174,48 @@ class PlatformTarget
 	@ignore public function update():Void {}
 
 	@ignore public function watch():Void {}
+
+	// Common functionality used by subclasses
+
+	private function copyProjectAssets(outputDirectory:String, assetDirectory:String = null)
+	{
+		if (assetDirectory == null)
+		{
+			assetDirectory = outputDirectory;
+		}
+		else if (!StringTools.startsWith(assetDirectory, targetDirectory))
+		{
+			assetDirectory = Path.combine(outputDirectory, assetDirectory);
+		}
+
+		var embedDirectory = Path.combine(targetDirectory, "obj/tmp");
+
+		for (asset in project.assets)
+		{
+			if (asset.type == AssetType.TEMPLATE)
+			{
+				var path = Path.combine(outputDirectory, asset.targetPath);
+				System.mkdir(Path.directory(path));
+				AssetHelper.copyAsset(asset, path, project.templateContext);
+			}
+			else if (asset.embed == true)
+			{
+				if (asset.sourcePath == "")
+				{
+					var path = Path.combine(embedDirectory, asset.targetPath);
+					System.mkdir(Path.directory(path));
+					AssetHelper.copyAsset(asset, path);
+					asset.sourcePath = path;
+				}
+			}
+			else
+			{
+				var path = Path.combine(assetDirectory, asset.targetPath);
+				System.mkdir(Path.directory(path));
+				AssetHelper.copyAssetIfNewer(asset, path);
+			}
+		}
+	}
 
 	// Functions to track and delete stale files
 

--- a/tools/platforms/AIRPlatform.hx
+++ b/tools/platforms/AIRPlatform.hx
@@ -392,4 +392,6 @@ class AIRPlatform extends FlashPlatform
 	}
 
 	@ignore public override function rebuild():Void {}
+
+	@ignore public override function watch():Void {}
 }

--- a/tools/platforms/AIRPlatform.hx
+++ b/tools/platforms/AIRPlatform.hx
@@ -168,14 +168,6 @@ class AIRPlatform extends FlashPlatform
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		if (targetFlags.exists("gdrive") || targetFlags.exists("zip"))

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -406,17 +406,6 @@ class AndroidPlatform extends PlatformTarget
 
 		// project = project.clone ();
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		// initialize (project);
 
 		var destination = targetDirectory + "/bin";
@@ -426,36 +415,6 @@ class AndroidPlatform extends PlatformTarget
 		System.mkdir(sourceSet + "/res/drawable-mdpi/");
 		System.mkdir(sourceSet + "/res/drawable-hdpi/");
 		System.mkdir(sourceSet + "/res/drawable-xhdpi/");
-
-		for (asset in project.assets)
-		{
-			if (asset.type != AssetType.TEMPLATE)
-			{
-				var targetPath = "";
-
-				switch (asset.type)
-				{
-					default:
-						// case SOUND, MUSIC:
-
-						// var extension = Path.extension (asset.sourcePath);
-						// asset.flatName += ((extension != "") ? "." + extension : "");
-
-						// asset.resourceName = asset.flatName;
-						targetPath = Path.combine(sourceSet + "/assets/", asset.resourceName);
-
-						// asset.resourceName = asset.id;
-						// targetPath = sourceSet + "/res/raw/" + asset.flatName + "." + Path.extension (asset.targetPath);
-
-						// default:
-
-						// asset.resourceName = asset.flatName;
-						// targetPath = sourceSet + "/assets/" + asset.resourceName;
-				}
-
-				AssetHelper.copyAssetIfNewer(asset, targetPath);
-			}
-		}
 
 		if (project.targetFlags.exists("xml"))
 		{
@@ -663,13 +622,13 @@ class AndroidPlatform extends PlatformTarget
 
 		for (asset in project.assets)
 		{
-			if (asset.type == AssetType.TEMPLATE)
+			if (asset.type != AssetType.TEMPLATE)
 			{
-				var targetPath = Path.combine(destination, asset.targetPath);
-				System.mkdir(Path.directory(targetPath));
-				AssetHelper.copyAsset(asset, targetPath, context);
+				asset.targetPath = asset.resourceName;
 			}
 		}
+
+		copyProjectAssets(destination, sourceSet + "/assets/");
 	}
 
 	public override function watch():Void

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -259,14 +259,6 @@ class AndroidPlatform extends PlatformTarget
 		AndroidHelper.build(project, destination);
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		DeploymentHelper.deploy(project, targetFlags, targetDirectory, "Android");

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -300,7 +300,7 @@ class AndroidPlatform extends PlatformTarget
 		}
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/haxe/" + buildType + ".hxml";
 
@@ -629,20 +629,5 @@ class AndroidPlatform extends PlatformTarget
 		}
 
 		copyProjectAssets(destination, sourceSet + "/assets/");
-	}
-
-	public override function watch():Void
-	{
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
 	}
 }

--- a/tools/platforms/FlashPlatform.hx
+++ b/tools/platforms/FlashPlatform.hx
@@ -175,7 +175,7 @@ class FlashPlatform extends PlatformTarget
 		return context;
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/haxe/" + buildType + ".hxml";
 
@@ -333,20 +333,6 @@ class FlashPlatform extends PlatformTarget
 		}
 
 	}*/
-	public override function watch():Void
-	{
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
-	}
 
 	@ignore public override function install():Void {}
 

--- a/tools/platforms/FlashPlatform.hx
+++ b/tools/platforms/FlashPlatform.hx
@@ -103,16 +103,6 @@ class FlashPlatform extends PlatformTarget
 		System.runCommand("", "haxe", [targetDirectory + "/haxe/" + buildType + ".hxml"]);
 	}
 
-	public override function clean():Void
-	{
-		var targetPath = targetDirectory + "";
-
-		if (FileSystem.exists(targetPath))
-		{
-			System.removeDirectory(targetPath);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		DeploymentHelper.deploy(project, targetFlags, targetDirectory, "Flash");

--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -177,14 +177,6 @@ class HTML5Platform extends PlatformTarget
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		var name = "HTML5";

--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -209,7 +209,7 @@ class HTML5Platform extends PlatformTarget
 		}
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/haxe/" + buildType + ".hxml";
 
@@ -583,17 +583,7 @@ class HTML5Platform extends PlatformTarget
 	{
 		// TODO: Use a custom live reload HTTP server for test/run instead
 
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
+		super.watch();
 	}
 
 	@ignore public override function install():Void {}

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -446,7 +446,7 @@ class IOSPlatform extends PlatformTarget
 		return context;
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/" + project.app.file + "/haxe/Build.hxml";
 
@@ -873,20 +873,6 @@ class IOSPlatform extends PlatformTarget
 		context.HAS_LAUNCH_IMAGE = has_launch_image;
 
 	}*/
-	public override function watch():Void
-	{
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
-	}
 
 	@ignore public override function install():Void {}
 

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -132,14 +132,6 @@ class IOSPlatform extends PlatformTarget
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		IOSHelper.deploy(project, targetDirectory);

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -169,7 +169,7 @@ class IOSPlatform extends PlatformTarget
 		{
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
 		}
-		
+
 		if (project.targetFlags.exists("json"))
 		{
 			project.haxeflags.push("--json " + targetDirectory + "/types.json");
@@ -524,17 +524,6 @@ class IOSPlatform extends PlatformTarget
 
 		// project = project.clone ();
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/" + project.app.file + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		// var manifest = new Asset ();
 		// manifest.id = "__manifest__";
 		// manifest.data = AssetHelper.createManifest (project).serialize ();
@@ -857,30 +846,7 @@ class IOSPlatform extends PlatformTarget
 			}
 		}
 
-		System.mkdir(projectDirectory + "/assets");
-
-		for (asset in project.assets)
-		{
-			if (asset.type != AssetType.TEMPLATE)
-			{
-				var targetPath = Path.combine(projectDirectory + "/assets/", asset.resourceName);
-
-				// var sourceAssetPath:String = projectDirectory + "haxe/" + asset.sourcePath;
-
-				System.mkdir(Path.directory(targetPath));
-				AssetHelper.copyAssetIfNewer(asset, targetPath);
-
-				// System.mkdir (Path.directory (sourceAssetPath));
-				// System.linkFile (flatAssetPath, sourceAssetPath, true, true);
-			}
-			else
-			{
-				var targetPath = Path.combine(projectDirectory, asset.targetPath);
-
-				System.mkdir(Path.directory(targetPath));
-				AssetHelper.copyAsset(asset, targetPath, context);
-			}
-		}
+		copyProjectAssets(projectDirectory, "assets");
 
 		if (project.targetFlags.exists("xcode") && System.hostPlatform == MAC && command == "update")
 		{

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -428,7 +428,7 @@ class LinuxPlatform extends PlatformTarget
 		return context;
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/haxe/" + buildType + ".hxml";
 
@@ -596,21 +596,6 @@ class LinuxPlatform extends PlatformTarget
 
 		// context.HAS_ICON = IconHelper.createIcon (project.icons, 256, 256, Path.combine (applicationDirectory, "icon.png"));
 		copyProjectAssets(applicationDirectory);
-	}
-
-	public override function watch():Void
-	{
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
 	}
 
 	@ignore public override function install():Void {}

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -382,14 +382,6 @@ class LinuxPlatform extends PlatformTarget
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		DeploymentHelper.deploy(project, targetFlags, targetDirectory, "Linux " + (is64 ? "64" : "32") + "-bit");

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -553,17 +553,6 @@ class LinuxPlatform extends PlatformTarget
 		// project = project.clone ();
 		// initialize (project);
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		if (project.targetFlags.exists("xml"))
 		{
 			project.haxeflags.push("-xml " + targetDirectory + "/types.xml");
@@ -606,24 +595,7 @@ class LinuxPlatform extends PlatformTarget
 		}
 
 		// context.HAS_ICON = IconHelper.createIcon (project.icons, 256, 256, Path.combine (applicationDirectory, "icon.png"));
-		for (asset in project.assets)
-		{
-			var path = Path.combine(applicationDirectory, asset.targetPath);
-
-			if (asset.embed != true)
-			{
-				if (asset.type != AssetType.TEMPLATE)
-				{
-					System.mkdir(Path.directory(path));
-					AssetHelper.copyAssetIfNewer(asset, path);
-				}
-				else
-				{
-					System.mkdir(Path.directory(path));
-					AssetHelper.copyAsset(asset, path, context);
-				}
-			}
-		}
+		copyProjectAssets(applicationDirectory);
 	}
 
 	public override function watch():Void

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -397,7 +397,7 @@ class MacPlatform extends PlatformTarget
 		return context;
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/haxe/" + buildType + ".hxml";
 
@@ -574,21 +574,6 @@ class MacPlatform extends PlatformTarget
 		context.HAS_ICON = IconHelper.createMacIcon(icons, Path.combine(contentDirectory, "icon.icns"));
 
 		copyProjectAssets(targetDirectory, contentDirectory);
-	}
-
-	public override function watch():Void
-	{
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
 	}
 
 	@ignore public override function install():Void {}

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -525,17 +525,6 @@ class MacPlatform extends PlatformTarget
 			project.haxeflags.push("--json " + targetDirectory + "/types.json");
 		}
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		var context = generateContext();
 		context.OUTPUT_DIR = targetDirectory;
 
@@ -584,22 +573,7 @@ class MacPlatform extends PlatformTarget
 
 		context.HAS_ICON = IconHelper.createMacIcon(icons, Path.combine(contentDirectory, "icon.icns"));
 
-		for (asset in project.assets)
-		{
-			if (asset.embed != true)
-			{
-				if (asset.type != AssetType.TEMPLATE)
-				{
-					System.mkdir(Path.directory(Path.combine(contentDirectory, asset.targetPath)));
-					AssetHelper.copyAssetIfNewer(asset, Path.combine(contentDirectory, asset.targetPath));
-				}
-				else
-				{
-					System.mkdir(Path.directory(Path.combine(targetDirectory, asset.targetPath)));
-					AssetHelper.copyAsset(asset, Path.combine(targetDirectory, asset.targetPath), context);
-				}
-			}
-		}
+		copyProjectAssets(targetDirectory, contentDirectory);
 	}
 
 	public override function watch():Void

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -360,14 +360,6 @@ class MacPlatform extends PlatformTarget
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		DeploymentHelper.deploy(project, targetFlags, targetDirectory, "Mac");

--- a/tools/platforms/TVOSPlatform.hx
+++ b/tools/platforms/TVOSPlatform.hx
@@ -130,14 +130,6 @@ class TVOSPlatform extends PlatformTarget
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		TVOSHelper.deploy(project, targetDirectory);

--- a/tools/platforms/TVOSPlatform.hx
+++ b/tools/platforms/TVOSPlatform.hx
@@ -434,17 +434,6 @@ class TVOSPlatform extends PlatformTarget
 
 		// project = project.clone ();
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/" + project.app.file + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		// var manifest = new Asset ();
 		// manifest.id = "__manifest__";
 		// manifest.data = AssetHelper.createManifest (project).serialize ();
@@ -628,30 +617,7 @@ class TVOSPlatform extends PlatformTarget
 			}
 		}
 
-		System.mkdir(projectDirectory + "/assets");
-
-		for (asset in project.assets)
-		{
-			if (asset.type != AssetType.TEMPLATE)
-			{
-				var targetPath = Path.combine(projectDirectory + "/assets/", asset.resourceName);
-
-				// var sourceAssetPath:String = projectDirectory + "haxe/" + asset.sourcePath;
-
-				System.mkdir(Path.directory(targetPath));
-				AssetHelper.copyAssetIfNewer(asset, targetPath);
-
-				// System.mkdir (Path.directory (sourceAssetPath));
-				// System.linkFile (flatAssetPath, sourceAssetPath, true, true);
-			}
-			else
-			{
-				var targetPath = Path.combine(projectDirectory, asset.targetPath);
-
-				System.mkdir(Path.directory(targetPath));
-				AssetHelper.copyAsset(asset, targetPath, context);
-			}
-		}
+		copyProjectAssets(projectDirectory, "assets");
 
 		if (project.targetFlags.exists("xcode") && System.hostPlatform == MAC && command == "update")
 		{

--- a/tools/platforms/TVOSPlatform.hx
+++ b/tools/platforms/TVOSPlatform.hx
@@ -357,7 +357,7 @@ class TVOSPlatform extends PlatformTarget
 		return context;
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/" + project.app.file + "/haxe/Build.hxml";
 
@@ -644,20 +644,6 @@ class TVOSPlatform extends PlatformTarget
 		context.HAS_LAUNCH_IMAGE = has_launch_image;
 
 	}*/
-	public override function watch():Void
-	{
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
-	}
 
 	@ignore public override function install():Void {}
 

--- a/tools/platforms/TizenPlatform.hx
+++ b/tools/platforms/TizenPlatform.hx
@@ -237,14 +237,6 @@ class TizenPlatform extends PlatformTarget
 		ProjectHelper.recursiveSmartCopyTemplate(project, "haxe", targetDirectory + "/haxe", context);
 		ProjectHelper.recursiveSmartCopyTemplate(project, "tizen/hxml", targetDirectory + "/haxe", context);
 
-		for (asset in project.assets)
-		{
-			if (asset.targetPath == "/appinfo.json" || asset.targetPath == "appinfo.json")
-			{
-				asset.type = AssetType.TEMPLATE;
-			}
-		}
-
 		// going to root directory now, but should it be a forced "assets" folder later?
 		copyProjectAssets(destination + "res/", "");
 		// copyProjectAssets(destination + "res/", "assets");

--- a/tools/platforms/TizenPlatform.hx
+++ b/tools/platforms/TizenPlatform.hx
@@ -261,4 +261,6 @@ class TizenPlatform extends PlatformTarget
 	@ignore public override function install():Void {}
 
 	@ignore public override function uninstall():Void {}
+
+	@ignore public override function watch():Void {}
 }

--- a/tools/platforms/TizenPlatform.hx
+++ b/tools/platforms/TizenPlatform.hx
@@ -245,6 +245,14 @@ class TizenPlatform extends PlatformTarget
 		ProjectHelper.recursiveSmartCopyTemplate(project, "haxe", targetDirectory + "/haxe", context);
 		ProjectHelper.recursiveSmartCopyTemplate(project, "tizen/hxml", targetDirectory + "/haxe", context);
 
+		for (asset in project.assets)
+		{
+			if (asset.targetPath == "/appinfo.json" || asset.targetPath == "appinfo.json")
+			{
+				asset.type = AssetType.TEMPLATE;
+			}
+		}
+
 		// going to root directory now, but should it be a forced "assets" folder later?
 		copyProjectAssets(destination + "res/", "");
 		// copyProjectAssets(destination + "res/", "assets");

--- a/tools/platforms/TizenPlatform.hx
+++ b/tools/platforms/TizenPlatform.hx
@@ -142,14 +142,6 @@ class TizenPlatform extends PlatformTarget
 		TizenHelper.createPackage(project, targetDirectory + "/bin/CommandLineBuild", "");
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		DeploymentHelper.deploy(project, targetFlags, targetDirectory, "Tizen");

--- a/tools/platforms/TizenPlatform.hx
+++ b/tools/platforms/TizenPlatform.hx
@@ -203,17 +203,6 @@ class TizenPlatform extends PlatformTarget
 
 		// project = project.clone ();
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		var destination = targetDirectory + "/bin/";
 		System.mkdir(destination);
 
@@ -256,30 +245,9 @@ class TizenPlatform extends PlatformTarget
 		ProjectHelper.recursiveSmartCopyTemplate(project, "haxe", targetDirectory + "/haxe", context);
 		ProjectHelper.recursiveSmartCopyTemplate(project, "tizen/hxml", targetDirectory + "/haxe", context);
 
-		for (asset in project.assets)
-		{
-			var path = Path.combine(destination + "res/", asset.targetPath);
-
-			System.mkdir(Path.directory(path));
-
-			if (asset.type != AssetType.TEMPLATE)
-			{
-				if (asset.targetPath == "/appinfo.json")
-				{
-					AssetHelper.copyAsset(asset, path, context);
-				}
-				else
-				{
-					// going to root directory now, but should it be a forced "assets" folder later?
-
-					AssetHelper.copyAssetIfNewer(asset, path);
-				}
-			}
-			else
-			{
-				AssetHelper.copyAsset(asset, path, context);
-			}
-		}
+		// going to root directory now, but should it be a forced "assets" folder later?
+		copyProjectAssets(destination + "res/", "");
+		// copyProjectAssets(destination + "res/", "assets");
 	}
 
 	@ignore public override function install():Void {}

--- a/tools/platforms/WebAssemblyPlatform.hx
+++ b/tools/platforms/WebAssemblyPlatform.hx
@@ -477,5 +477,6 @@ class WebAssemblyPlatform extends PlatformTarget
 
 	@ignore public override function uninstall():Void {}
 
+	// TODO: remove this line to enable watching?
 	@ignore public override function watch():Void {}
 }

--- a/tools/platforms/WebAssemblyPlatform.hx
+++ b/tools/platforms/WebAssemblyPlatform.hx
@@ -330,14 +330,6 @@ class WebAssemblyPlatform extends PlatformTarget
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		DeploymentHelper.deploy(project, targetFlags, targetDirectory, "WebAssembly");

--- a/tools/platforms/WebAssemblyPlatform.hx
+++ b/tools/platforms/WebAssemblyPlatform.hx
@@ -396,17 +396,6 @@ class WebAssemblyPlatform extends PlatformTarget
 
 		// project = project.clone ();
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		// for (asset in project.assets)
 		// {
 		// 	asset.resourceName = "assets/" + asset.resourceName;
@@ -481,37 +470,13 @@ class WebAssemblyPlatform extends PlatformTarget
 			}
 		}
 
-		for (asset in project.assets)
-		{
-			var path = Path.combine(targetDirectory + "/obj/assets", asset.targetPath);
-
-			if (asset.type != AssetType.TEMPLATE)
-			{
-				// if (asset.type != AssetType.FONT) {
-
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAssetIfNewer(asset, path);
-
-				// }
-			}
-		}
-
 		ProjectHelper.recursiveSmartCopyTemplate(project, "webassembly/template", destination, context);
 		ProjectHelper.recursiveSmartCopyTemplate(project, "haxe", targetDirectory + "/haxe", context);
 		ProjectHelper.recursiveSmartCopyTemplate(project, "webassembly/hxml", targetDirectory + "/haxe", context);
 		// ProjectHelper.recursiveSmartCopyTemplate(project, "webassembly/cpp", targetDirectory + "/obj", context);
 		ProjectHelper.recursiveSmartCopyTemplate(project, "cpp/static", targetDirectory + "/obj", context);
 
-		for (asset in project.assets)
-		{
-			var path = Path.combine(destination, asset.targetPath);
-
-			if (asset.type == AssetType.TEMPLATE)
-			{
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path, context);
-			}
-		}
+		copyProjectAssets(destination, targetDirectory + "/obj/assets");
 	}
 
 	@ignore public override function install():Void {}

--- a/tools/platforms/WebAssemblyPlatform.hx
+++ b/tools/platforms/WebAssemblyPlatform.hx
@@ -355,7 +355,7 @@ class WebAssemblyPlatform extends PlatformTarget
 		}
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/haxe/" + buildType + ".hxml";
 
@@ -484,4 +484,6 @@ class WebAssemblyPlatform extends PlatformTarget
 	@ignore public override function trace():Void {}
 
 	@ignore public override function uninstall():Void {}
+
+	@ignore public override function watch():Void {}
 }

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -962,17 +962,6 @@ class WindowsPlatform extends PlatformTarget
 			project.haxeflags.push("--json " + targetDirectory + "/types.json");
 		}
 
-		for (asset in project.assets)
-		{
-			if (asset.embed && asset.sourcePath == "")
-			{
-				var path = Path.combine(targetDirectory + "/obj/tmp", asset.targetPath);
-				System.mkdir(Path.directory(path));
-				AssetHelper.copyAsset(asset, path);
-				asset.sourcePath = path;
-			}
-		}
-
 		var context = generateContext();
 		context.OUTPUT_DIR = targetDirectory;
 
@@ -1040,24 +1029,7 @@ class WindowsPlatform extends PlatformTarget
 
 		}*/
 
-		for (asset in project.assets)
-		{
-			if (asset.embed != true)
-			{
-				var path = Path.combine(applicationDirectory, asset.targetPath);
-
-				if (asset.type != AssetType.TEMPLATE)
-				{
-					System.mkdir(Path.directory(path));
-					AssetHelper.copyAssetIfNewer(asset, path);
-				}
-				else
-				{
-					System.mkdir(Path.directory(path));
-					AssetHelper.copyAsset(asset, path, context);
-				}
-			}
-		}
+		copyProjectAssets(applicationDirectory);
 	}
 
 	private function updateUWP():Void

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -726,7 +726,7 @@ class WindowsPlatform extends PlatformTarget
 		return context;
 	}
 
-	private function getDisplayHXML():HXML
+	private override function getDisplayHXML():HXML
 	{
 		var path = targetDirectory + "/haxe/" + buildType + ".hxml";
 
@@ -1233,21 +1233,6 @@ class WindowsPlatform extends PlatformTarget
 				AssetHelper.copyAsset(asset, path, context);
 			}
 		}
-	}
-
-	public override function watch():Void
-	{
-		var hxml = getDisplayHXML();
-		var dirs = hxml.getClassPaths(true);
-
-		var outputPath = Path.combine(Sys.getCwd(), project.app.path);
-		dirs = dirs.filter(function(dir)
-		{
-			return (!Path.startsWith(dir, outputPath));
-		});
-
-		var command = ProjectHelper.getCurrentCommand();
-		System.watch(command, dirs);
 	}
 
 	//	@ignore public override function install ():Void {}

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -634,14 +634,6 @@ class WindowsPlatform extends PlatformTarget
 		}
 	}
 
-	public override function clean():Void
-	{
-		if (FileSystem.exists(targetDirectory))
-		{
-			System.removeDirectory(targetDirectory);
-		}
-	}
-
 	public override function deploy():Void
 	{
 		DeploymentHelper.deploy(project, targetFlags, targetDirectory, "Windows" + (is64 ? "64" : ""));


### PR DESCRIPTION
Having eight separate implementations made it harder to maintain.

When an asset embedding bug got fixed on desktop targets, it got overlooked on others. This lead to assets being included twice on those other targets: once embedded, and once normally. (#1898) Now, that behavior is controlled from one place, and the bug is fixed for eight targets at once.

This also standardizes the case of `asset.embed == true && asset.type == TEMPLATE`. Previously, some targets would prioritze `embed` over `type`, embedding the template into the app without even processing it as a template. Now, it will always prioritize `type`, processing templates as templates and never trying to embed them.

I left out `AIRPlatform`, `FlashPlatform`, and `HTML5Platform` since they have more complex asset embedding behavior. I haven't checked if the bug is present on any of those.