### PR TITLE
OpenALBindings: fix crash on HL when passing NULL device

### DIFF
--- a/project/src/media/openal/OpenALBindings.cpp
+++ b/project/src/media/openal/OpenALBindings.cpp
@@ -3388,7 +3388,7 @@ namespace lime {
 
 	HL_PRIM vbyte* HL_NAME(hl_alc_get_string) (HL_CFFIPointer* device, int param) {
 
-		ALCdevice* alcDevice = (ALCdevice*)device->ptr;
+		ALCdevice* alcDevice = device ? (ALCdevice*)device->ptr : 0;
 		const char* result = alcGetString (alcDevice, param);
 		int length = strlen (result);
 		char* _result = (char*)malloc (length + 1);


### PR DESCRIPTION
The following code produces an access violation when targeting Hashlink:

```haxe
import lime.media.openal.ALC;

class Main extends lime.app.Application
{
	public function new()
	{
		super();
		trace(ALC.getString(null, ALC.ALL_DEVICES_SPECIFIER));
	}
}
```

The [OpenAL specification](https://www.openal.org/documentation/openal-1.1-specification.pdf) mentions that passing in `null` to `ALC.getString()` is allowed in certain cases, so we should handle null gracefully instead of blindly trying to read the pointer.
> (...)
Specifying NULL for deviceHandle when asking for ALC_EXTENSIONS will generate
an ALC_INVALID_DEVICE error. The deviceHandle value is ignored when asking for
ALC_DEFAULT_DEVICE_SPECIFIER or
ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER.
(...)
An alcGetString query of ALC_DEVICE_SPECIFIER or
ALC_CAPTURE_DEVICE_SPECIFIER with a NULL device passed in will return a list
of available devices. Each device name will be separated by a single NULL character and
the list will be terminated with two NULL characters.