### PR TITLE
Implement ALC.getStringList()

### DIFF
--- a/project/src/media/openal/OpenALBindings.cpp
+++ b/project/src/media/openal/OpenALBindings.cpp
@@ -3456,6 +3456,7 @@ namespace lime {
 			listData++;
 
 			result += length;
+			free(_result);
 
 		}
 

--- a/project/src/media/openal/OpenALBindings.cpp
+++ b/project/src/media/openal/OpenALBindings.cpp
@@ -3398,6 +3398,72 @@ namespace lime {
 	}
 
 
+	value lime_alc_get_string_list (value device, int param) {
+
+		ALCdevice* alcDevice = (ALCdevice*)val_data (device);
+		const char* result = alcGetString (alcDevice, param);
+
+		if (!result || *result == '\0') {
+
+			return alloc_null ();
+
+		}
+
+		value list = alloc_array (0);
+
+		while (*result != '\0') {
+
+			val_array_push (list, alloc_string (result));
+			result += strlen (result) + 1;
+
+		}
+
+		return list;
+
+	}
+
+
+	HL_PRIM varray* HL_NAME(hl_alc_get_string_list) (HL_CFFIPointer* device, int param) {
+
+		ALCdevice* alcDevice = device ? (ALCdevice*)device->ptr : 0;
+		const char* result = alcGetString(alcDevice, param);
+
+		if (!result || *result == '\0') {
+
+			return 0;
+
+		}
+
+		int count = 0;
+		const char* temp = result;
+		while (*temp != '\0') {
+
+			count++;
+			temp += strlen (temp) + 1;
+
+		}
+
+		varray* list = hl_alloc_array (&hlt_bytes, count);
+		vbyte** listData = hl_aptr (list, vbyte*);
+
+		while (*result != '\0') {
+
+			int length = strlen (result) + 1;
+			char* _result = (char*)malloc (length);
+			strcpy (_result, result);
+
+			*listData = (vbyte*)_result;
+			listData++;
+
+			result += length;
+
+		}
+
+		return list;
+
+	}
+
+
 	bool lime_alc_make_context_current (value context) {
 
 		ALCcontext* alcContext = (ALCcontext*)val_data (context);
@@ -3622,6 +3688,7 @@ namespace lime {
 	DEFINE_PRIME1 (lime_alc_get_error);
 	DEFINE_PRIME3 (lime_alc_get_integerv);
 	DEFINE_PRIME2 (lime_alc_get_string);
+	DEFINE_PRIME2 (lime_alc_get_string_list);
 	DEFINE_PRIME1 (lime_alc_make_context_current);
 	DEFINE_PRIME1 (lime_alc_open_device);
 	DEFINE_PRIME1v (lime_alc_pause_device);
@@ -3746,6 +3813,7 @@ namespace lime {
 	DEFINE_HL_PRIM (_I32, hl_alc_get_error, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_ARR, hl_alc_get_integerv, _TCFFIPOINTER _I32 _I32);
 	DEFINE_HL_PRIM (_BYTES, hl_alc_get_string, _TCFFIPOINTER _I32);
+	DEFINE_HL_PRIM (_ARR, hl_alc_get_string_list, _TCFFIPOINTER _I32);
 	DEFINE_HL_PRIM (_BOOL, hl_alc_make_context_current, _TCFFIPOINTER);
 	DEFINE_HL_PRIM (_TCFFIPOINTER, hl_alc_open_device, _STRING);
 	DEFINE_HL_PRIM (_VOID, hl_alc_pause_device, _TCFFIPOINTER);

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -1683,6 +1683,8 @@ class NativeCFFI
 
 	@:cffi private static function lime_alc_get_string(device:CFFIPointer, param:Int):Dynamic;
 
+	@:cffi private static function lime_alc_get_string_list(device:CFFIPointer, param:Int):Array<Dynamic>;
+
 	@:cffi private static function lime_alc_make_context_current(context:CFFIPointer):Bool;
 
 	@:cffi private static function lime_alc_open_device(devicename:String):CFFIPointer;
@@ -1853,6 +1855,7 @@ class NativeCFFI
 	private static var lime_alc_get_integerv = new cpp.Callable<cpp.Object->Int->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_get_integerv",
 		"oiio", false));
 	private static var lime_alc_get_string = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_get_string", "oio", false));
+	private static var lime_alc_get_string_list = new cpp.Callable<cpp.Object->Int->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_get_string_list", "oio", false));
 	private static var lime_alc_make_context_current = new cpp.Callable<cpp.Object->Bool>(cpp.Prime._loadPrime("lime", "lime_alc_make_context_current", "ob",
 		false));
 	private static var lime_alc_open_device = new cpp.Callable<String->cpp.Object>(cpp.Prime._loadPrime("lime", "lime_alc_open_device", "so", false));
@@ -1976,6 +1979,7 @@ class NativeCFFI
 	private static var lime_alc_get_error = CFFI.load("lime", "lime_alc_get_error", 1);
 	private static var lime_alc_get_integerv = CFFI.load("lime", "lime_alc_get_integerv", 3);
 	private static var lime_alc_get_string = CFFI.load("lime", "lime_alc_get_string", 2);
+	private static var lime_alc_get_string_list = CFFI.load("lime", "lime_alc_get_string_list", 2);
 	private static var lime_alc_make_context_current = CFFI.load("lime", "lime_alc_make_context_current", 1);
 	private static var lime_alc_open_device = CFFI.load("lime", "lime_alc_open_device", 1);
 	private static var lime_alc_pause_device = CFFI.load("lime", "lime_alc_pause_device", 1);
@@ -2316,6 +2320,11 @@ class NativeCFFI
 	}
 
 	@:hlNative("lime", "hl_alc_get_string") private static function lime_alc_get_string(device:CFFIPointer, param:Int):hl.Bytes
+	{
+		return null;
+	}
+
+	@:hlNative("lime", "hl_alc_get_string_list") private static function lime_alc_get_string_list(device:CFFIPointer, param:Int):hl.NativeArray<hl.Bytes>
 	{
 		return null;
 	}

--- a/src/lime/media/OpenALAudioContext.hx
+++ b/src/lime/media/OpenALAudioContext.hx
@@ -413,6 +413,11 @@ class OpenALAudioContext
 		}
 	}
 
+	public function getStringList(device:ALDevice, param:Int):Array<String>
+	{
+		return ALC.getStringList(device, param);
+	}
+
 	public function isBuffer(buffer:ALBuffer):Bool
 	{
 		return AL.isBuffer(buffer);

--- a/src/lime/media/openal/ALC.hx
+++ b/src/lime/media/openal/ALC.hx
@@ -152,6 +152,31 @@ class ALC
 		#end
 	}
 
+	public static function getStringList(device:ALDevice, param:Int):Array<String>
+	{
+		#if (lime_cffi && lime_openal && !macro)
+		if (param == DEVICE_SPECIFIER ||
+			param == ALL_DEVICES_SPECIFIER)
+		{
+			var result = NativeCFFI.lime_alc_get_string_list(device, param);
+			#if hl
+			if (result == null) return [];
+			var _result = [];
+			for (i in 0...result.length)
+				_result[i] = CFFI.stringValue(result[i]);
+			return _result;
+			#else
+			return result;
+			#end
+
+		}
+
+		return [getString(device, param)];
+		#else
+		return null;
+		#end
+	}
+
 	public static function makeContextCurrent(context:ALContext):Bool
 	{
 		#if (lime_cffi && lime_openal && !macro)


### PR DESCRIPTION
Fixes #1986

There are certain OpenAL parameters, meant to be passed into `ALC.getString()`, that return a list of strings. For example, `ALC_ALL_DEVICES_SPECIFIER` to get the names of available playback audio devices or `ALC_CAPTURE_DEVICE_SPECIFIER`to get the names of available capture devices.

`ALC.getString()` assumes that the result will always be a standard C string with a single NULL character at the end, but this is not the case when passing the params mentioned above:

> An alcGetString query of ALC_DEVICE_SPECIFIER or
ALC_CAPTURE_DEVICE_SPECIFIER with a NULL device passed in will return a list
of available devices. Each device name will be separated by a single NULL character and
the list will be terminated with two NULL characters.
(https://www.openal.org/documentation/openal-1.1-specification.pdf)

This PR introduces the `ALC.getStringList(device, param)` method which handles these lists properly and returns them as an `Array<String>`. If list handling is unnecessary for the param provided, the result will simply be `[ALC.getString(device, param)]`