### PR TITLE
Fix `RunScript` to use local `haxelib` paths.

### DIFF
--- a/tools/RunScript.hx
+++ b/tools/RunScript.hx
@@ -212,6 +212,7 @@ class RunScript
 				+ "` using Eval (https://haxe.org/blog/eval/)");
 
 			var args = [
+				"--cwd", limeDirectory,
 				"-D", "lime",
 				"-cp", toolsDirectory,
 				"-cp", Path.combine(toolsDirectory, "platforms"),

--- a/tools/RunScript.hx
+++ b/tools/RunScript.hx
@@ -127,19 +127,11 @@ class RunScript
 	{
 		var args = Sys.args();
 
-		var limeDirectory = Haxelib.getPath(new Haxelib("lime"), true);
-		var toolsDirectory = Path.combine(limeDirectory, "tools");
+		var cacheDirectory = Sys.getCwd();
 
-		if (!FileSystem.exists(toolsDirectory))
-		{
-			limeDirectory = Path.combine(limeDirectory, "..");
-			toolsDirectory = Path.combine(limeDirectory, "tools");
-		}
-
-		if (args.length > 2 && args[0] == "rebuild" && args[1] == "tools")
+		if (args.length > 0)
 		{
 			var lastArgument = new Path(args[args.length - 1]).toString();
-			var cacheDirectory = Sys.getCwd();
 
 			if (((StringTools.endsWith(lastArgument, "/") && lastArgument != "/") || StringTools.endsWith(lastArgument, "\\"))
 				&& !StringTools.endsWith(lastArgument, ":\\"))
@@ -153,6 +145,19 @@ class RunScript
 			}
 
 			Haxelib.workingDirectory = Sys.getCwd();
+		}
+
+		var limeDirectory = Haxelib.getPath(new Haxelib("lime"), true);
+		var toolsDirectory = Path.combine(limeDirectory, "tools");
+
+		if (!FileSystem.exists(toolsDirectory))
+		{
+			limeDirectory = Path.combine(limeDirectory, "..");
+			toolsDirectory = Path.combine(limeDirectory, "tools");
+		}
+
+		if (args.length > 2 && args[0] == "rebuild" && args[1] == "tools")
+		{
 			var rebuildBinaries = true;
 
 			for (arg in args)

--- a/tools/RunScript.hx
+++ b/tools/RunScript.hx
@@ -212,11 +212,10 @@ class RunScript
 				+ "` using Eval (https://haxe.org/blog/eval/)");
 
 			var args = [
-				"--cwd", limeDirectory,
 				"-D", "lime",
 				"-cp", toolsDirectory,
 				"-cp", Path.combine(toolsDirectory, "platforms"),
-				"-cp", "src",
+				"-cp", Path.combine(limeDirectory, "src"),
 				"-lib", "format",
 				"-lib", "hxp",
 				"--run", "CommandLineTools"].concat(args);

--- a/tools/RunScript.hx
+++ b/tools/RunScript.hx
@@ -127,8 +127,6 @@ class RunScript
 	{
 		var args = Sys.args();
 
-		var cacheDirectory = Sys.getCwd();
-
 		if (args.length > 0)
 		{
 			var lastArgument = new Path(args[args.length - 1]).toString();
@@ -141,10 +139,8 @@ class RunScript
 
 			if (FileSystem.exists(lastArgument) && FileSystem.isDirectory(lastArgument))
 			{
-				Sys.setCwd(lastArgument);
+				Haxelib.workingDirectory = lastArgument;
 			}
-
-			Haxelib.workingDirectory = Sys.getCwd();
 		}
 
 		var limeDirectory = Haxelib.getPath(new Haxelib("lime"), true);
@@ -158,6 +154,10 @@ class RunScript
 
 		if (args.length > 2 && args[0] == "rebuild" && args[1] == "tools")
 		{
+			var cacheDirectory = Sys.getCwd();
+			// used for Path.tryFullPath when setting overrides
+			Sys.setCwd(Haxelib.workingDirectory);
+
 			var rebuildBinaries = true;
 
 			for (arg in args)


### PR DESCRIPTION
This pr makes it so it uses the working directory when searching for lime's path this mainly ensures that if theres a local lime installed, itll use the tools from that lime and not from the globally installed lime.