### PR TITLE
Allow executing arbitrary commands from project.xml.

### DIFF
--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -11,6 +11,7 @@ import lime.tools.HXProject;
 import lime.utils.AssetManifest;
 #end
 import sys.io.File;
+import sys.io.Process;
 import sys.FileSystem;
 #if (haxe_ver >= 4)
 import haxe.xml.Access;
@@ -1864,6 +1865,22 @@ class ProjectXMLParser extends HXProject
 
 				case "config":
 					config.parse(element, substitute);
+
+				case "execute":
+					var process:Process = new Process(element.att.command);
+					var exitCode:Int = process.exitCode(true);
+
+					if (element.has.output)
+					{
+						defines.set(element.att.output, process.stdout.readAll().toString());
+					}
+
+					if (element.has.exitCode)
+					{
+						defines.set(element.att.exitCode, Std.string(exitCode));
+					}
+
+					process.close();
 
 				case "prebuild":
 					parseCommandElement(element, preBuildCallbacks);


### PR DESCRIPTION
The `<execute />` tag immediately runs a single command, and optionally saves its output and/or exit code. Sample usage:

```xml
<section unless="display">
	<execute command="script.bat" if="windows" exitCode="scriptExitCode" />
	<execute command="./script.sh" unless="windows" exitCode="scriptExitCode" />
	<error value="Custom script failed!" if="${scriptExitCode}!=0" />

	<execute command="dir" if="windows" output="directoryContents" />
	<execute command="ls" unless="windows" output="directoryContents" />
	<echo value="Directory contents: ${directoryContents}" />
</section>
```

Checking `unless="display"` is optional but recommended. Without it, the commands will run every time code completion is initialized. Edit: that is, except in the case this is primarily designed to solve (generating assets). Since assets are parsed in display mode, any asset generation must also happen in display mode.

Closes #1959