### PR TITLE
Implement `Image.willReadFrequently`.

### DIFF
--- a/src/lime/_internal/graphics/ImageCanvasUtil.hx
+++ b/src/lime/_internal/graphics/ImageCanvasUtil.hx
@@ -192,7 +192,7 @@ class ImageCanvasUtil
 				buffer.__srcCanvas.setAttribute("moz-opaque", "true");
 			}
 
-			buffer.__srcContext = buffer.__srcCanvas.getContext("2d", {alpha: image.transparent});
+			buffer.__srcContext = buffer.__srcCanvas.getContext("2d", {alpha: image.transparent, willReadFrequently: image.willReadFrequently});
 		}
 		#end
 	}

--- a/src/lime/graphics/Image.hx
+++ b/src/lime/graphics/Image.hx
@@ -176,6 +176,18 @@ class Image
 	**/
 	public var width:Int;
 
+	#if (js && html5)
+	/**
+		Whether this image should be rendered on the CPU. This is slower, but speeds up operations
+		like `copyPixels()` that read from the image. Always set this value immediately after
+		constructing the image, before calling `ImageCanvasUtil.convertToCanvas()`.
+
+		To use this with `openfl.display.BitmapData`, create an instance with `fillColor` set to 0,
+		then immediately set `bitmapData.image.willReadFrequently = true`.
+	**/
+	@:noCompletion public var willReadFrequently:Bool = false;
+	#end
+
 	/**
 		A convenience property, unused internally, which may be helpful for different renderer
 		implementations


### PR DESCRIPTION
This improves performance when doing pixel operations, at the expense of rendering speed. But you don't have to render it; you could designate one bitmap as a source, never adding it to the display list. Instead, you'd copy its pixels to other bitmaps that would be rendered.

Currently only implemented for HTML5, but the same logic should apply on other platforms, so I'm keeping this as a draft for now. Unless those other platforms already store a copy of the data for easy reading?

Another reason this is a draft is it's not a pretty implementation. It would be nicer to either take this as a constructor argument, or allow changing it later, but both of those have problems. If it's a constructor argument, then we also have to modify `openfl.display.BitmapData`. If you can modify it, then we need to delete the existing canvas and make a new one, and maybe also synchronize some other state (not sure).

Closes #1690