### PR TITLE
Get the correct max length before allocating buffers.

### DIFF
--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -1678,12 +1678,15 @@ namespace lime {
 
 		value result = alloc_empty_object ();
 
-		std::string buffer (GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, 0);
+		GLsizei maxLength = 0;
+		glGetProgramiv (program, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &maxLength);
+
+		std::string buffer (maxLength, 0);
 		GLsizei outLen = 0;
 		GLsizei size = 0;
 		GLenum type = 0;
 
-		glGetActiveAttrib (program, index, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &outLen, &size, &type, &buffer[0]);
+		glGetActiveAttrib (program, index, maxLength, &outLen, &size, &type, &buffer[0]);
 
 		buffer.resize (outLen);
 
@@ -1698,12 +1701,15 @@ namespace lime {
 
 	HL_PRIM vdynamic* HL_NAME(hl_gl_get_active_attrib) (int program, int index) {
 
-		char buffer[GL_ACTIVE_ATTRIBUTE_MAX_LENGTH];
+		GLsizei maxLength = 0;
+		glGetProgramiv (program, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &maxLength);
+
+		char buffer[maxLength];
 		GLsizei outLen = 0;
 		GLsizei size = 0;
 		GLenum type = 0;
 
-		glGetActiveAttrib (program, index, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &outLen, &size, &type, &buffer[0]);
+		glGetActiveAttrib (program, index, maxLength, &outLen, &size, &type, &buffer[0]);
 
 		char* _buffer = (char*)malloc (outLen + 1);
 		memcpy (_buffer, &buffer, outLen);

--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -1704,7 +1704,7 @@ namespace lime {
 		GLsizei maxLength = 0;
 		glGetProgramiv (program, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &maxLength);
 
-		char buffer[maxLength];
+		char* buffer = (char*)malloc (maxLength);
 		GLsizei outLen = 0;
 		GLsizei size = 0;
 		GLenum type = 0;
@@ -1714,6 +1714,8 @@ namespace lime {
 		char* _buffer = (char*)malloc (outLen + 1);
 		memcpy (_buffer, &buffer, outLen);
 		_buffer[outLen] = '\0';
+
+		free (buffer);
 
 		const int id_size = hl_hash_utf8 ("size");
 		const int id_type = hl_hash_utf8 ("type");


### PR DESCRIPTION
[`GL_ACTIVE_ATTRIBUTE_MAX_LENGTH` is not itself the length, but a constant used to look up that length.](https://docs.gl/gl4/glGetActiveAttrib) Presumably it's a larger number than necessary, which is why there weren't any problems.

Closes #1323 unless the OP finds more issues.