### PR TITLE
[HTML5] Added "outline:none" property to canvas/div style in HTML5Window.hx

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -140,6 +140,7 @@ class HTML5Window
 			var style = canvas.style;
 			style.setProperty("-webkit-transform", "translateZ(0)", null);
 			style.setProperty("transform", "translateZ(0)", null);
+			style.setProperty("outline", "none", null);
 		}
 		else if (div != null)
 		{
@@ -154,6 +155,7 @@ class HTML5Window
 			style.setProperty("-moz-user-select", "none", null);
 			style.setProperty("-ms-user-select", "none", null);
 			style.setProperty("-o-user-select", "none", null);
+			style.setProperty("outline", "none", null);
 		}
 
 		if (parent.__width == 0 && parent.__height == 0)


### PR DESCRIPTION
Had to add this to address the following issue: in some cases (mine was Mac + Chrome) a visible outline appears around the render area when a key on the keyboard is pressed. 

Looks like this:

<img width="1079" height="576" alt="Screenshot 2025-10-10 at 15 49 09" src="https://github.com/user-attachments/assets/5fcd1809-5d94-42fb-9336-6c82be58235e" />
