### PR TITLE
Allow specifying Gradle plugins from project.xml.

### DIFF
--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -4,7 +4,8 @@ import java.awt.GridBagConstraints
 import javax.swing.border.EmptyBorder
 
 apply plugin: 'com.android.application'
-
+::foreach ANDROID_GRADLE_APPLY_PLUGIN::apply plugin: '::__current__::'
+::end::
 System.setProperty('java.awt.headless','false')
 
 //Uncomment to debug deprecation warnings.

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -437,6 +437,7 @@ class AndroidPlatform extends PlatformTarget
 		]);
 		context.ANDROID_GRADLE_VERSION = project.config.getString("android.gradle-version", "8.9");
 		context.ANDROID_GRADLE_PLUGIN = project.config.getString("android.gradle-plugin", "8.7.3");
+		context.ANDROID_GRADLE_APPLY_PLUGIN = project.config.getArrayString("android.gradle-apply-plugin");
 		context.ANDROID_USE_ANDROIDX = project.config.getString("android.useAndroidX", "true");
 		context.ANDROID_ENABLE_JETIFIER = project.config.getString("android.enableJetifier", "false");
 		context.ANDROID_GRADLE_PROPERTIES = project.config.getKeyValueArray("android.gradle-properties");


### PR DESCRIPTION
This allows including [published plugins](http://plugins.gradle.org/) or custom user-created ones. Since plugins can make arbitrary changes to the build script, this allows multiple extensions to add to _app/build.gradle_ without overwriting each other's changes.

https://docs.gradle.org/current/userguide/plugins.html
https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html

Sample usage: `<config:android gradle-apply-plugin="com.google.gms.google-services" />`

From a quick search, there seem to be two ways to include a plugin. `apply plugin` is the more backwards-compatible option, so I went with that. However, `plugin { }` could be more future-proof. Maybe at some point we'll switch.

My main concern for now is, is "gradle-apply-plugin" distinctive enough from "gradle-plugin"? Or would another name be clearer?