### PR TITLE
Disable HRTF by default when using OpenAL Soft

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -26,6 +26,10 @@ class NativeAudioSource
 	#end
 	private static var STREAM_TIMER_FREQUENCY = 100;
 
+	#if lime_openalsoft
+	private static var hasDirectChannelsExt:Null<Bool>;
+	#end
+
 	private var buffers:Array<ALBuffer>;
 	private var bufferTimeBlocks:Array<Float>;
 	private var completed:Bool;
@@ -135,6 +139,18 @@ class NativeAudioSource
 				AL.sourcei(handle, AL.BUFFER, parent.buffer.__srcBuffer);
 			}
 		}
+
+		#if lime_openalsoft
+		if (hasDirectChannelsExt == null)
+		{
+			hasDirectChannelsExt = AL.isExtensionPresent("AL_SOFT_direct_channels") && AL.isExtensionPresent("AL_SOFT_direct_channels_remix");
+		}
+
+		if (hasDirectChannelsExt)
+		{
+			AL.sourcei(handle, AL.DIRECT_CHANNELS_SOFT, AL.REMIX_UNMATCHED_SOFT);
+		}
+		#end
 
 		samples = Std.int((dataLength * 8.0) / (parent.buffer.channels * parent.buffer.bitsPerSample));
 	}

--- a/src/lime/media/openal/AL.hx
+++ b/src/lime/media/openal/AL.hx
@@ -233,6 +233,13 @@ class AL
 	public static inline var FILTER_LOWPASS:Int = 0x0001;
 	public static inline var FILTER_HIGHPASS:Int = 0x0002;
 	public static inline var FILTER_BANDPASS:Int = 0x0003;
+	#if lime_openalsoft
+	/* AL_SOFT_direct_channels extension */
+	public static inline var DIRECT_CHANNELS_SOFT:Int = 0x1033;
+	/* AL_SOFT_direct_channels_remix extension */
+	public static inline var DROP_UNMATCHED_SOFT:Int = 0x0001;
+	public static inline var REMIX_UNMATCHED_SOFT:Int = 0x0002;
+	#end
 
 	public static function removeDirectFilter(source:ALSource)
 	{


### PR DESCRIPTION
OpenAL Soft will automatically enable HRTF if it detects that headphones are being used.

> Specifically, ALSoft tries to figure out if you are using a headphone and then turns on the HRTF. Not all backends support headphone detection and they can still be wrong.
https://github.com/kcat/openal-soft/wiki/User%27s-Guide#hrtf

However, this may not be ideal as HRTF can cause audio to sound "muddy" and lower quality. Considering that [in a recent change](https://github.com/openfl/lime/pull/1788) HRTF was disabled by default on HTML5, I think it would make sense to also disable it on native targets. The `AL_SOFT_direct_channels` and `AL_SOFT_direct_channels_remix` extensions are used to disable HRTF per source rather than globally (see: https://github.com/kcat/openal-soft/issues/357#issuecomment-579178239).

I'm unsure if this change is required (or possible) with Apple's OpenAL implementation. As for MojoAL, it seems to not support HRTF at all.

Since OpenAL Soft's headphone detection seems to be hit or miss, it's easier to test this PR by manually forcing HRTF to be on using OpenAL's config. In the directory with the executable, create a file called `alsoft.ini` on Windows, or `alsoft.conf` elsewhere. In it add:
```
[general]
hrtf=true
```
Without this patch, any played audio will sound less clean compared to the original audio file, while with the patch it should sound identical to the original file.