### PR TITLE
HTML5Window: update context.attributes.hardware when creating context

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -354,6 +354,7 @@ class HTML5Window
 				context.canvas2D = cast canvas.getContext("2d");
 				context.type = CANVAS;
 				context.version = "";
+				context.attributes.hardware = false;
 			}
 			else
 			{
@@ -375,6 +376,7 @@ class HTML5Window
 
 				context.type = WEBGL;
 				context.version = isWebGL2 ? "2" : "1";
+				context.attributes.hardware = true;
 			}
 		}
 


### PR DESCRIPTION
Follow up to #1902

If the project requests a hardware accelerated context, but the browser does not give it for whatever reason (WebGL disabled?), `context.attributes.hardware` would not update to reflect this. With this, `context.attributes.hardware` will properly update according to whether we have an WebGL context or not