### PR TITLE
Fix ios/tvos template support for spaces in paths

### DIFF
--- a/templates/ios/template/{{app.file}}/haxe/makefile
+++ b/templates/ios/template/{{app.file}}/haxe/makefile
@@ -55,13 +55,13 @@ $(HAXE_BUILDS): build-haxe-%:
 	@echo "Haxe $(if $(filter $*,$(SIMULATOR_ARCH)),simulator,device) build: $(CONFIG)$(SUFFIX_$*)"
 	haxe Build.hxml $(HXCPP_FLAGS_$*) -cpp build/$(CONFIG)$(SUFFIX_$*) $(DEBUG)
 	cd build/$(CONFIG)$(SUFFIX_$*); ::HAXELIB_PATH:: export HXCPP_NO_COLOR=1; \
-		haxelib run ::CPP_BUILD_LIBRARY:: Build.xml haxe -Ddestination=$(CURDIR)/../lib/$*$(LIB_DEST) \
+		haxelib run ::CPP_BUILD_LIBRARY:: Build.xml haxe -Ddestination="$(CURDIR)/../lib/$*$(LIB_DEST)" \
 		-options Options.txt $(DEBUG)
 	touch ../Classes/Main.mm
 	cd build/$(CONFIG)$(SUFFIX_$*); ::HAXELIB_PATH:: export HXCPP_NO_COLOR=1; \
-		::CPP_CACHE_WORKAROUND:: haxelib run ::CPP_BUILD_LIBRARY:: $(CURDIR)/BuildHxcppMbedtls.xml \
-		-Ddestination=$(CURDIR)/../lib/$*$(LIB_MBEDTLS_DEST) \
-		-options $(CURDIR)/build/$(CONFIG)$(SUFFIX_$*)/Options.txt $(DEBUG)
+		::CPP_CACHE_WORKAROUND:: haxelib run ::CPP_BUILD_LIBRARY:: "$(CURDIR)/BuildHxcppMbedtls.xml" \
+		-Ddestination="$(CURDIR)/../lib/$*$(LIB_MBEDTLS_DEST)" \
+		-options "$(CURDIR)/build/$(CONFIG)$(SUFFIX_$*)/Options.txt" $(DEBUG)
 
 clean:
 	rm -rf build

--- a/templates/tvos/PROJ/haxe/makefile
+++ b/templates/tvos/PROJ/haxe/makefile
@@ -49,13 +49,13 @@ $(HAXE_BUILDS): build-haxe-%:
 	@echo "Haxe $(if $(filter $*,$(SIMULATOR_ARCH)),simulator,device) build: $(CONFIG)$(SUFFIX_$*)"
 	haxe Build.hxml $(HXCPP_FLAGS_$*) -cpp build/$(CONFIG)$(SUFFIX_$*) $(DEBUG)
 	cd build/$(CONFIG)$(SUFFIX_$*); ::HAXELIB_PATH:: export HXCPP_NO_COLOR=1; \
-		haxelib run ::CPP_BUILD_LIBRARY:: Build.xml haxe -Ddestination=$(CURDIR)/../lib/$*$(LIB_DEST) \
+		haxelib run ::CPP_BUILD_LIBRARY:: Build.xml haxe -Ddestination="$(CURDIR)/../lib/$*$(LIB_DEST)" \
 		-options Options.txt $(DEBUG)
 	touch ../Classes/Main.mm
 	cd build/$(CONFIG)$(SUFFIX_$*); ::HAXELIB_PATH:: export HXCPP_NO_COLOR=1; \
-		::CPP_CACHE_WORKAROUND:: haxelib run ::CPP_BUILD_LIBRARY:: $(CURDIR)/BuildHxcppMbedtls.xml \
-		-Ddestination=$(CURDIR)/../lib/$*$(LIB_MBEDTLS_DEST) \
-		-options $(CURDIR)/build/$(CONFIG)$(SUFFIX_$*)/Options.txt $(DEBUG)
+		::CPP_CACHE_WORKAROUND:: haxelib run ::CPP_BUILD_LIBRARY:: "$(CURDIR)/BuildHxcppMbedtls.xml" \
+		-Ddestination="$(CURDIR)/../lib/$*$(LIB_MBEDTLS_DEST)" \
+		-options "$(CURDIR)/build/$(CONFIG)$(SUFFIX_$*)/Options.txt" $(DEBUG)
 
 clean:
 	rm -rf build


### PR DESCRIPTION
This fixes a regression introduced in #1818 that breaks builds where the output path contains a space.

Reported by @beihu235 on discord and based on their patches: https://github.com/NovaFlare-Engine-haxelib/lime-8.3.0/commit/20ea40caa6ecdfd50437c3f785c3b479f86c7c09 and https://github.com/NovaFlare-Engine-haxelib/lime-8.3.0/commit/a8fce61c737b7dc6b8415fc377a3c79a35e74225.