### PR TITLE
[tools] Fix format of android PLATFORM define

### DIFF
--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -163,8 +163,8 @@ class AndroidPlatform extends PlatformTarget
 		{
 			var minSDKVer = project.config.getInt("android.minimum-sdk-version", 21);
 			//PLATFORM define needed for older ndk and gcc toolchain
-			var haxeParams = [hxml, "-D", "android", "-D", 'PLATFORM_NUMBER=$minSDKVer', "-D", 'PLATFORM=$minSDKVer'];
-			var cppParams = ["-Dandroid", '-DPLATFORM_NUMBER=$minSDKVer', '-DPLATFORM=$minSDKVer'];
+			var haxeParams = [hxml, "-D", "android", "-D", 'PLATFORM_NUMBER=$minSDKVer', "-D", 'PLATFORM=android-$minSDKVer'];
+			var cppParams = ["-Dandroid", '-DPLATFORM_NUMBER=$minSDKVer', '-DPLATFORM=android-$minSDKVer'];
 			var path = sourceSet + "/jniLibs/armeabi";
 			var suffix = ".so";
 
@@ -377,7 +377,7 @@ class AndroidPlatform extends PlatformTarget
 		var minSDKVer = 21;
 		var platformNumberDefine = '-DPLATFORM_NUMBER=$minSDKVer';
 		// Required for older ndk and gcc toolchain
-		var platformDefine = '-DPLATFORM=$minSDKVer';
+		var platformDefine = '-DPLATFORM=android-$minSDKVer';
 
 		if (armv5) commands.push(["-Dandroid", platformDefine]);
 		if (armv7) commands.push(["-Dandroid", "-DHXCPP_ARMV7", platformDefine, platformNumberDefine]);


### PR DESCRIPTION
This define was temporarily removed in:
46aab0c80ee2395cf099f0fe1905505f1f98d69d
before being added back in:
9f2f518857145d85776c83765303a9d995d7887d

However, it was added back with the incorrect format, which gives the hxcpp error:
`Badly formed android PLATFORM "21" - should be like android-123`

A user reported this error on the forums: https://community.openfl.org/t/badly-formed-android-platform-error/14416