### PR TITLE
[BUGFIX] Run Macro Flags when using a local haxelib repository (Move flags to `include.xml`)

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,2 +1,0 @@
---macro lime._internal.macros.DefineMacro.run()
---macro haxe.macro.Compiler.addMetadata("@:autoBuild(lime._internal.macros.AssetsMacro.embedBytes())", "haxe.io.Bytes")

--- a/include.xml
+++ b/include.xml
@@ -224,4 +224,7 @@
 
 	</section>
 
+	<haxeflag name="--macro" value="lime._internal.macros.DefineMacro.run()" />
+	<haxeflag name="--macro" value="haxe.macro.Compiler.addMetadata('@:autoBuild(lime._internal.macros.AssetsMacro.embedBytes())', 'haxe.io.Bytes')" />
+
 </extension>


### PR DESCRIPTION
## Related Issues
Fixes #2004

## Description
When compiling a `lime` project while using a local `haxelib` repository, the `extraParams.hxml` in `lime` is skipped.
This causes `AssetsMacro.embedBytes()` to never run on `haxe.io.Bytes`, causing #2004.

To fix this, I have moved those flags over to `include.xml`.


This is my first PR to here, so let me know if I should do something different in the future!