### PR TITLE
Include extraParams.hxml when library path is overridden.

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -1241,7 +1241,7 @@ class HXProject extends Script
 			{
 				var path = Haxelib.pathOverrides.get(name);
 				var jsonPath = Path.combine(path, "haxelib.json");
-				var added = false;
+				var extraParamsPath = Path.combine(path, "extraParams.hxml");
 
 				try
 				{
@@ -1262,6 +1262,18 @@ class HXProject extends Script
 				var param = "-cp " + path;
 				compilerFlags.remove(param);
 				compilerFlags.push(param);
+
+				try
+				{
+					if (FileSystem.exists(extraParamsPath))
+					{
+						var extraParams = Lambda.filter(File.getContent(extraParamsPath).split("\n"),
+							function(param:String) return param.length > 0 && param.charCodeAt(0) != "#".code);
+
+						compilerFlags = ArrayTools.concatUnique(compilerFlags, extraParams);
+					}
+				}
+				catch (e:Dynamic) {}
 			}
 			else
 			{


### PR DESCRIPTION
When including a haxelib with an overridden path (such as Lime itself, when using a local Haxelib repo), Lime fails to copy _extraParams.hxml_, potentially breaking compilation. This checks for the file and copies all non-comment lines if found.

Closes #2004, supersedes #2009.