### PR TITLE
Add allowNativeHeapPointerTagging attribute to application

### DIFF
--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 	::foreach ANDROID_PERMISSIONS::<uses-permission android:name="::__current__::" />
 	::end::
 
-	<application ::foreach ANDROID_APPLICATION::::if ((value != null) && (value != ""))::::key::="::value::" ::end::::end::>
+	<application ::foreach ANDROID_APPLICATION::::if ((value != null) && (value != ""))::::key::="::value::" ::end::::end:: ::if (ANDROID_TARGET_SDK_VERSION >= 30):: android:allowNativeHeapPointerTagging="false" ::end::>
 
 		::if (WIN_ORIENTATION=="portrait")::
 		<meta-data android:name="SDL_ENV.SDL_IOS_ORIENTATIONS" android:value="Portrait PortraitUpsideDown" />


### PR DESCRIPTION
When the compiled version is greater than 29, memory access conflicts may occur, causing the application to crash.
```
E/libEGL: validate_display:547 error 3008 (EGL_BAD_DISPLAY)
```