### PR TITLE
Make JNISafety safe for macro context

### DIFF
--- a/src/lime/system/JNI.hx
+++ b/src/lime/system/JNI.hx
@@ -384,7 +384,7 @@ class JNIMethod
 	```
 **/
 // Haxe 3 can't parse "target.threaded" inside parentheses.
-#if !doc_gen
+#if !(doc_gen || macro)
 #if target.threaded
 @:autoBuild(lime.system.JNI.JNISafetyTools.build())
 #elseif (cpp || neko)


### PR DESCRIPTION
There is a regression in 8.3.0 (specifically 8f0b8f356edf441b9b21dd7e06d81bcba70a4bb3) which has broken builds for android apps that use macros, e.g.:

```haxe
class Main extends lime.app.Application {
	macro static function test() {
		return macro "hello";
	}
	
	public function new () {
		super ();
		test();
	}
}
```

```
$ lime build android
/.../lime/src/lime/_internal/backend/native/NativeApplication.hx:1052: character 9 : You cannot use @:build inside a macro : make sure that your type is not used in macro
/.../lime/src/lime/_internal/backend/native/NativeApplication.hx:95: characters 31-87 : lime._internal.backend.native._NativeApplication.OrientationChangeListener does not have a constructor
/.../lime/src/lime/app/Application.hx:61: characters 30-55 : Unknown<0> cannot be constructed
```

This is because `src/lime/_internal/backend/native/NativeApplication.hx` now has `OrientationChangeListener`, which extends `JNISafety` which is marked with `@:autoBuild`.

We can avoid the error by skipping the `@:autoBuild` meta in the macro context.