### PR TITLE
[tools] Fix --no-output behaviour in android build

### DIFF
--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -208,7 +208,7 @@ class AndroidPlatform extends PlatformTarget
 
 			System.runCommand("", "haxe", haxeParams);
 
-			if (noOutput) return;
+			if (noOutput) continue;
 
 			CPPHelper.compile(project, targetDirectory + "/obj", cppParams);
 


### PR DESCRIPTION
Returning here means other architecture builds won't run. If we continue instead, all architecture builds will finish first before the function exits.