### PR TITLE
Fix perspective camera

### DIFF
--- a/src/lime/math/Matrix4.hx
+++ b/src/lime/math/Matrix4.hx
@@ -416,7 +416,7 @@ abstract Matrix4(Float32Array) from Float32Array to Float32Array
 		this[12] = 0;
 		this[13] = 0;
 		this[14] = -2 * zFar * zNear / (zFar - zNear);
-		this[15] = 1;
+		this[15] = 0;
 	}
 
 	/**


### PR DESCRIPTION
In a perspective projection matrix, the homogeneous coordinate w must depend on z (depth) to enable correct perspective division.  
This ensures objects farther from the camera appear smaller and depth is properly mapped.

I found a useful resource explaining this in detail, which you can check here:
https://www.scratchapixel.com/lessons/3d-basic-rendering/perspective-and-orthographic-projection-matrix/opengl-perspective-projection-matrix.html
The issue with `w` is explained in the beggining of the article.

In the attached GIF, I demonstrate the issue with a 3D scene - although it looks like the camera is rotating around the origin, the real problem lies in the incorrect perspective projection formula.

![chrome_G1WVXoEk3k](https://github.com/user-attachments/assets/94d5d4a9-e31f-4c9d-9ee7-1897f28bac63)
