### PR TITLE
Support IME input method to support more complex input methods such as Chinese, Japanese, and Korean.

### DIFF
--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -268,6 +268,7 @@ namespace lime {
 
 			case SDL_TEXTINPUT:
 			case SDL_TEXTEDITING:
+			case SDL_TEXTEDITING_EXT:
 
 				ProcessTextEvent (event);
 				break;

--- a/project/src/backend/sdl/SDLWindow.cpp
+++ b/project/src/backend/sdl/SDLWindow.cpp
@@ -75,6 +75,8 @@ namespace lime {
 		SDL_SetHint (SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 		SDL_SetHint (SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
 		SDL_SetHint (SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
+		SDL_SetHint (SDL_HINT_IME_SHOW_UI, "1");
+        SDL_SetHint (SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
 		#endif
 
 		if (flags & WINDOW_FLAG_HARDWARE) {


### PR DESCRIPTION
SDL_SetHint (SDL_HINT_IME_SHOW_UI, "1");
SDL_SetHint (SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
These two newly added activation definitions do not seem to have a significant impact on users who do not use IME and need to be checked.

Currently, it has only passed testing on Android.