### PR TITLE
[ci] Revert to stable setup-haxe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev g++-multilib gcc-multilib libasound2-dev libx11-dev libxext-dev libxi-dev libxrandr-dev libxinerama-dev libpulse-dev libmbedtls-dev libpng-dev libturbojpeg-dev libuv1-dev libvorbis-dev
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -101,7 +101,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -195,7 +195,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -311,7 +311,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -384,7 +384,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -448,7 +448,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -567,7 +567,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -597,7 +597,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -642,7 +642,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ matrix.haxe-version }}
 
@@ -692,7 +692,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ env.HAXE_VERSION }}
 
@@ -742,7 +742,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: 4.3.3 # minimum required version for HL/C is 4.3.3
 
@@ -794,7 +794,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ matrix.haxe-version }}
 
@@ -859,7 +859,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-      - uses: krdlab/setup-haxe@8f35d1215b93e940a76f9470e22e8a5ba6149598
+      - uses: krdlab/setup-haxe@v2
         with:
           haxe-version: ${{ matrix.haxe-version }}
 


### PR DESCRIPTION
The patches we need for haxe 4.2 to run properly have been released, so we should now be able to switch to the release version of setup-haxe.