### PR TITLE
[hxp] Fix compatbility with haxe 3

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -452,7 +452,7 @@ class HXProject extends Script
 		{
 			#if (lime && !eval)
 			var nekoOutput = Path.combine(tempDirectory, name + ".n");
-			System.runCommand("", "haxe", args.concat(["--main", "lime.tools.HXProject", "-neko", nekoOutput]));
+			System.runCommand("", "haxe", args.concat(["-main", "lime.tools.HXProject", "-neko", nekoOutput]));
 			System.runCommand("", "neko", [nekoOutput, inputFile, outputFile]);
 			#else
 			System.runCommand("", "haxe", args.concat(["--run", "lime.tools.HXProject", inputFile, outputFile]));


### PR DESCRIPTION
haxe 3 compatibility with hxp projects was broken in:: 22032ef6b51ed9e3e0f4c865cf65fd9d515abaa3

This is because haxe 3 doesn't support --main, only -main.

This gave [errors](https://github.com/openfl/hxp/actions/runs/18919536447/job/54011696998#step:7:10) like:
```
$ haxelib run lime build neko
Error: : unknown option '--main'.
```