### PR TITLE
Bytes: Fix length from fromBytes on JS

### DIFF
--- a/src/lime/utils/Bytes.hx
+++ b/src/lime/utils/Bytes.hx
@@ -19,7 +19,7 @@ abstract Bytes(HaxeBytes) from HaxeBytes to HaxeBytes
 	public function new(length:Int, bytesData:BytesData)
 	{
 		#if js
-		// bytesData may have extra bytes
+		// bytesData may have extra bytes. See https://github.com/HaxeFoundation/haxe/issues/8974
 		this = new HaxeBytes(bytesData.slice(0, length));
 		#elseif hl
 		this = new HaxeBytes(bytesData, length);

--- a/src/lime/utils/Bytes.hx
+++ b/src/lime/utils/Bytes.hx
@@ -19,7 +19,8 @@ abstract Bytes(HaxeBytes) from HaxeBytes to HaxeBytes
 	public function new(length:Int, bytesData:BytesData)
 	{
 		#if js
-		this = new HaxeBytes(bytesData);
+		// bytesData may have extra bytes
+		this = new HaxeBytes(bytesData.slice(0, length));
 		#elseif hl
 		this = new HaxeBytes(bytesData, length);
 		#else

--- a/src/lime/utils/Bytes.hx
+++ b/src/lime/utils/Bytes.hx
@@ -20,7 +20,8 @@ abstract Bytes(HaxeBytes) from HaxeBytes to HaxeBytes
 	{
 		#if js
 		// bytesData may have extra bytes. See https://github.com/HaxeFoundation/haxe/issues/8974
-		this = new HaxeBytes(bytesData.slice(0, length));
+		this = new HaxeBytes(bytesData);
+		this.length = length;
 		#elseif hl
 		this = new HaxeBytes(bytesData, length);
 		#else

--- a/src/lime/utils/Bytes.hx
+++ b/src/lime/utils/Bytes.hx
@@ -19,8 +19,8 @@ abstract Bytes(HaxeBytes) from HaxeBytes to HaxeBytes
 	public function new(length:Int, bytesData:BytesData)
 	{
 		#if js
-		// bytesData may have extra bytes. See https://github.com/HaxeFoundation/haxe/issues/8974
 		this = new HaxeBytes(bytesData);
+		// bytesData may have extra bytes. See https://github.com/HaxeFoundation/haxe/issues/8974
 		this.length = length;
 		#elseif hl
 		this = new HaxeBytes(bytesData, length);


### PR DESCRIPTION
Potentially related to: https://github.com/openfl/openfl/issues/2360

In JS the underlying byte data may have extras, due to the underlying types used in js, explained here: https://github.com/HaxeFoundation/haxe/issues/8974. This pr will ignore those extras.

Example reproducing the inconsistent behavior:
```hx
final output = new haxe.io.BytesOutput();
output.writeString("test");
final byteArray = lime.utils.Bytes.fromBytes(output.getBytes());
trace('byteArray.length: ${byteArray.length}'); // 16 on JS, 4 otherwise
```

Tested on chrome for mac