### PR TITLE
[tools] Add warning for haxelib rebuild with no file found

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -137,6 +137,10 @@ class CommandLineTools
 
 					if (haxelibPath != "" && haxelibPath != null)
 					{
+						if (Log.verbose)
+						{
+							Log.println('Rebuilding tools for haxelib: ${words[0]}');
+						}
 						words.push("tools");
 					}
 				}

--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -312,6 +312,17 @@ class CommandLineTools
 								Sys.putEnv("HAXELIB_PATH", cacheValue);
 							}
 						}
+						else
+						{
+							if (haxelib != null)
+							{
+								Log.warn('No rebuild script found for haxelib "${haxelib.name}"');
+							}
+							else
+							{
+								Log.warn('No rebuild script found at "${words[0]}"');
+							}
+						}
 					}
 					else
 					{


### PR DESCRIPTION
Closes #2027

Having it as a warning gives enough information to help with that issue along with the verbose message about it being interpreted as a haxelib. I guess it could also be an error, but not sure if some people rely on being able to just run `lime rebuild <haxelib>` for anything, regardless of whether it actually has anything to rebuild or not.