### PR TITLE
fix(html5): move mouse move handling outside switch statement

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -770,18 +770,18 @@ class HTML5Window
 					}
 					__stopMousePropagation = event.currentTarget == parent.element;
 
-					if (x != cacheMouseX || y != cacheMouseY)
-					{
-						parent.onMouseMove.dispatch(x, y);
-						parent.onMouseMoveRelative.dispatch(x - cacheMouseX, y - cacheMouseY);
-
-						if ((parent.onMouseMove.canceled || parent.onMouseMoveRelative.canceled) && event.cancelable)
-						{
-							event.preventDefault();
-						}
-					}
-
 				default:
+			}
+
+			if (x != cacheMouseX || y != cacheMouseY)
+			{
+				parent.onMouseMove.dispatch(x, y);
+				parent.onMouseMoveRelative.dispatch(x - cacheMouseX, y - cacheMouseY);
+
+				if ((parent.onMouseMove.canceled || parent.onMouseMoveRelative.canceled) && event.cancelable)
+				{
+					event.preventDefault();
+				}
 			}
 
 			cacheMouseX = x;


### PR DESCRIPTION
Prevents swallowing of MouseMove events in other Mouse Events, which presents itself in OpenFl with DOM rendered TextFields. Listening to MOUSE_MOVE on the stage would not fire when hovering over a TextField, and stage.mouseX / stage.mouseY would not update.