### PR TITLE
[ci] Set HXCPP_COMPILE_CACHE without "~"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 env:
   HAXE_VERSION: 4.2.5
+  HXCPP_COMPILE_CACHE: ${{ github.workspace }}/.hxcpp_cache
 
 jobs:
 
@@ -34,10 +35,6 @@ jobs:
           haxelib install ../hxcpp-4.3.45.zip --quiet
           haxelib install format --quiet
           haxelib install hxp --quiet
-
-      - name: Enable HXCPP compile cache
-        run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
 
       - name: Rebuild Lime tools
         run: |
@@ -206,10 +203,6 @@ jobs:
           haxelib install format --quiet
           haxelib install hxp --quiet
 
-      - name: Enable HXCPP compile cache
-        run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
-
       - name: Rebuild Lime tools
         run: |
           haxelib dev lime ${{ github.workspace }}
@@ -286,10 +279,6 @@ jobs:
           haxelib install ../hxcpp-4.3.45.zip --quiet
           haxelib install format --quiet
           haxelib install hxp --quiet
-
-      - name: Enable HXCPP compile cache
-        run: |
-          echo "HXCPP_COMPILE_CACHE=C:\.hxcpp" >> $Env:GITHUB_ENV
 
       - name: Rebuild Lime tools
         run: |
@@ -403,10 +392,6 @@ jobs:
           haxelib install format --quiet
           haxelib install hxp --quiet
 
-      - name: Enable HXCPP compile cache
-        run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
-
       - name: Prepare Lime
         run: |
           haxelib dev lime ${{ github.workspace }}
@@ -476,10 +461,6 @@ jobs:
           haxelib install format --quiet
           haxelib install hxp --quiet
 
-      - name: Enable HXCPP compile cache
-        run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
-
       - name: Prepare Lime
         run: |
           haxelib dev lime ${{ github.workspace }}
@@ -541,10 +522,6 @@ jobs:
           haxelib install hxp --quiet
           haxelib install svg --quiet
           haxelib install openfl --quiet
-
-      - name: Enable HXCPP compile cache
-        run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
 
       - name: Rebuild Lime tools
         run: |


### PR DESCRIPTION
The quotes used previously prevented ~ from being expanded by the shell, which broke the path on some platforms.

This allows the cache to function properly and should speed up build times.