### PR TITLE
Enable stereo spatialization when using OpenAL Soft

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -28,6 +28,7 @@ class NativeAudioSource
 
 	#if lime_openalsoft
 	private static var hasDirectChannelsExt:Null<Bool>;
+	private static var hasSourceSpatializeExt:Null<Bool>;
 	#end
 
 	private var buffers:Array<ALBuffer>;
@@ -149,6 +150,16 @@ class NativeAudioSource
 		if (hasDirectChannelsExt)
 		{
 			AL.sourcei(handle, AL.DIRECT_CHANNELS_SOFT, AL.REMIX_UNMATCHED_SOFT);
+		}
+		
+		if (hasSourceSpatializeExt == null)
+		{
+			hasSourceSpatializeExt = AL.isExtensionPresent("AL_SOFT_source_spatialize");
+		}
+
+		if (hasSourceSpatializeExt)
+		{
+			AL.sourcei(handle, AL.SOURCE_SPATIALIZE_SOFT, AL.TRUE);
 		}
 		#end
 

--- a/src/lime/media/openal/AL.hx
+++ b/src/lime/media/openal/AL.hx
@@ -239,6 +239,9 @@ class AL
 	/* AL_SOFT_direct_channels_remix extension */
 	public static inline var DROP_UNMATCHED_SOFT:Int = 0x0001;
 	public static inline var REMIX_UNMATCHED_SOFT:Int = 0x0002;
+	/* AL_SOFT_source_spatialize extension */
+	public static inline var SOURCE_SPATIALIZE_SOFT:Int = 0x1214;
+	public static inline var AUTO_SOFT:Int = 0x0002;
 	#end
 
 	public static function removeDirectFilter(source:ALSource)


### PR DESCRIPTION
By default, OpenAL Soft will only allow spatialization on mono sounds. This means that the position property of Lime AudioSource instances has no effect if the audio is stereo. This change makes use of the **AL_SOFT_source_spatialize** extension to enable the spatialization of stereo audio sources along with mono ones when using OpenAL Soft.

According to the [extension documentation,](https://openal-soft.org/openal-extensions/SOFT_source_spatialize.txt) the stereo audio will be down-mixed to mono, but only if the audio has a non-0 distance from the listener, so stereo audio that is left at the default position should not be affected by this change.

> When a spatialized source plays a non-mono buffer and has a non-0 distance from the listener, the channels are down-mixed to mono and panned as appropriate (that is, all channels occupy the same spot in 3D space). An exception is the LFE channel of buffer formats that include one. The LFE input is sent separately to LFE output as normal, rather than being down-mixed and panned. It is still influenced by distance and cone attenuation however.

I feel like most people will be using stereo audio sources, so enabling spatialization of these samples where possible makes sense.

Credit to @ACrazyTown for helping me out with this on the Haxe Discord and directing me to their PR (#2001) as an example of how to work with OpenAL extensions.
