### PR TITLE
Fix modular builds.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -95,12 +95,23 @@
 
 		<dependency name="extension-api" path="dependencies/extension-api" if="android" />
 
-		<dependency path="dependencies/howler.min.js" if="html5 howlerjs" embed="true" />
-		<dependency path="dependencies/pako.min.js" if="html5" embed="true" allow-web-workers="true" />
-		<dependency path="dependencies/lzma_worker-min.js" if="html5" embed="true" />
-		<dependency path="dependencies/FileSaver.min.js" if="html5" embed="true" />
-		<dependency path="dependencies/webgl-debug.js" if="html5 webgl-debug" embed="true" />
-		<dependency path="dependencies/stats.min.js" if="html5 stats" embed="true" />
+		<section if="lime-modular">
+			<dependency path="dependencies/howler.min.js" if="html5 howlerjs" embed="false" />
+			<dependency path="dependencies/pako.min.js" if="html5" embed="false" allow-web-workers="true" />
+			<dependency path="dependencies/lzma_worker-min.js" if="html5" embed="false" />
+			<dependency path="dependencies/FileSaver.min.js" if="html5" embed="false" />
+			<dependency path="dependencies/webgl-debug.js" if="html5 webgl-debug" embed="false" />
+			<dependency path="dependencies/stats.min.js" if="html5 stats" embed="false" />
+		</section>
+		
+		<section unless="lime-modular">
+			<dependency path="dependencies/howler.min.js" if="html5 howlerjs" embed="true" />
+			<dependency path="dependencies/pako.min.js" if="html5" embed="true" allow-web-workers="true" />
+			<dependency path="dependencies/lzma_worker-min.js" if="html5" embed="true" />
+			<dependency path="dependencies/FileSaver.min.js" if="html5" embed="true" />
+			<dependency path="dependencies/webgl-debug.js" if="html5 webgl-debug" embed="true" />
+			<dependency path="dependencies/stats.min.js" if="html5 stats" embed="true" />
+		</section>
 
 		<dependency path="dependencies/angle/d3dcompiler_47.dll" if="windows angle" unless="static_link" />
 		<dependency path="dependencies/angle/libegl.dll" if="windows angle" unless="static_link" />

--- a/include.xml
+++ b/include.xml
@@ -171,8 +171,8 @@
 
 			<module name="${lime-module-name}" if="html5" unless="exclude-lime-module">
 
-				<source path="" package="lime" exclude="lime._backend.*|lime.project.*|lime.tools.*|lime.net.*|lime.graphics.console.*|lime.text.harfbuzz.*" />
-				<source path="" package="lime" include="lime._backend.html5" />
+				<source path="src" package="lime" exclude="lime._backend.*|lime.project.*|lime.tools.*|lime.net.*|lime.graphics.console.*|lime.text.harfbuzz.*" />
+				<source path="src" package="lime" include="lime._backend.html5" />
 
 				<class name="lime.net.HTTPRequest" />
 

--- a/include.xml
+++ b/include.xml
@@ -171,8 +171,8 @@
 
 			<module name="${lime-module-name}" if="html5" unless="exclude-lime-module">
 
-				<source path="src" package="lime" exclude="lime._backend.*|lime.project.*|lime.tools.*|lime.net.*|lime.graphics.console.*|lime.text.harfbuzz.*" />
-				<source path="src" package="lime" include="lime._backend.html5" />
+				<source path="src" package="lime" exclude="lime._internal.backend.*|lime.project.*|lime.tools.*|lime.net.*|lime.graphics.console.*|lime.text.harfbuzz.*" />
+				<source path="src" package="lime" include="lime._internal.backend.html5" />
 
 				<class name="lime.net.HTTPRequest" />
 

--- a/include.xml
+++ b/include.xml
@@ -95,23 +95,15 @@
 
 		<dependency name="extension-api" path="dependencies/extension-api" if="android" />
 
-		<section if="lime-modular">
-			<dependency path="dependencies/howler.min.js" if="html5 howlerjs" embed="false" />
-			<dependency path="dependencies/pako.min.js" if="html5" embed="false" allow-web-workers="true" />
-			<dependency path="dependencies/lzma_worker-min.js" if="html5" embed="false" />
-			<dependency path="dependencies/FileSaver.min.js" if="html5" embed="false" />
-			<dependency path="dependencies/webgl-debug.js" if="html5 webgl-debug" embed="false" />
-			<dependency path="dependencies/stats.min.js" if="html5 stats" embed="false" />
-		</section>
-		
-		<section unless="lime-modular">
-			<dependency path="dependencies/howler.min.js" if="html5 howlerjs" embed="true" />
-			<dependency path="dependencies/pako.min.js" if="html5" embed="true" allow-web-workers="true" />
-			<dependency path="dependencies/lzma_worker-min.js" if="html5" embed="true" />
-			<dependency path="dependencies/FileSaver.min.js" if="html5" embed="true" />
-			<dependency path="dependencies/webgl-debug.js" if="html5 webgl-debug" embed="true" />
-			<dependency path="dependencies/stats.min.js" if="html5 stats" embed="true" />
-		</section>
+		<set name="embed-js" value="false" if="lime-modular" />
+		<set name="embed-js" value="true" unless="lime-modular" />
+		<dependency path="dependencies/howler.min.js" if="html5 howlerjs" embed="${embed-js}" />
+		<dependency path="dependencies/pako.min.js" if="html5" embed="${embed-js}" allow-web-workers="true" />
+		<dependency path="dependencies/lzma_worker-min.js" if="html5" embed="${embed-js}" />
+		<dependency path="dependencies/FileSaver.min.js" if="html5" embed="${embed-js}" />
+		<dependency path="dependencies/webgl-debug.js" if="html5 webgl-debug" embed="${embed-js}" />
+		<dependency path="dependencies/stats.min.js" if="html5 stats" embed="${embed-js}" />
+		<unset name="embed-js" />
 
 		<dependency path="dependencies/angle/d3dcompiler_47.dll" if="windows angle" unless="static_link" />
 		<dependency path="dependencies/angle/libegl.dll" if="windows angle" unless="static_link" />

--- a/include.xml
+++ b/include.xml
@@ -147,7 +147,7 @@
 				<class name="js.Promise" />
 				<class name="js.RegExp" />
 				<class name="js.Selection" />
-				<class name="js.XMLSocket" />
+				<class name="js.XMLSocket" if="${${haxe_ver} < 4}" />
 				<class name="EReg" />
 				<class name="HxOverrides" />
 				<class name="List" />

--- a/src/lime/math/RGBA.hx
+++ b/src/lime/math/RGBA.hx
@@ -49,9 +49,6 @@ abstract RGBA(#if (flash && !lime_doc_gen) Int #else UInt #end) from Int to Int 
 
 	private static function __init__():Void
 	{
-		#if (js && modular)
-		__initColors();
-		#else
 		__alpha16 = new UInt32Array(256);
 
 		for (i in 0...256)
@@ -70,32 +67,7 @@ abstract RGBA(#if (flash && !lime_doc_gen) Int #else UInt #end) from Int to Int 
 		{
 			__clamp[i] = 0xFF;
 		}
-		#end
 	}
-
-	#if (js && modular)
-	private static function __initColors()
-	{
-		__alpha16 = new UInt32Array(256);
-
-		for (i in 0...256)
-		{
-			__alpha16[i] = Math.ceil((i) * ((1 << 16) / 0xFF));
-		}
-
-		__clamp = new UInt8Array(0xFF + 0xFF);
-
-		for (i in 0...0xFF)
-		{
-			__clamp[i] = i;
-		}
-
-		for (i in 0xFF...(0xFF + 0xFF + 1))
-		{
-			__clamp[i] = 0xFF;
-		}
-	}
-	#end
 
 	/**
 		Creates a new RGBA instance

--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -125,7 +125,7 @@ class System
 	@:noCompletion private static var __userDirectory:String;
 
 	#if (js && html5)
-	@:keep @:expose("lime.embed")
+	@:keep @:expose
 	public static function embed(projectName:String, element:Dynamic, width:Null<Int> = null, height:Null<Int> = null, config:Dynamic = null):Void
 	{
 		if (__applicationEntryPoint == null) return;

--- a/src/lime/tools/ModuleHelper.hx
+++ b/src/lime/tools/ModuleHelper.hx
@@ -70,11 +70,18 @@ class ModuleHelper
 				for (haxelib in project.haxelibs)
 				{
 					var libPath:String = Haxelib.getPath(haxelib);
-					var classPath:String = Haxelib.getPathClassPath(libPath);
-					
+					var classPath:String = null;
+					var json:String = Path.combine(libPath, "haxelib.json");
+					if (FileSystem.exists(json))
+						try
+						{
+							classPath = haxe.Json.parse(File.getContent(json)).classPath;
+						}
+						catch (e:Dynamic) {}
+
 					if (classPath != null)
 						libPath = Path.combine(libPath, classPath);
-					
+
 					hxml += "\n-cp " + libPath;
 				}
 

--- a/src/lime/tools/ModuleHelper.hx
+++ b/src/lime/tools/ModuleHelper.hx
@@ -69,7 +69,13 @@ class ModuleHelper
 
 				for (haxelib in project.haxelibs)
 				{
-					hxml += "\n-cp " + Haxelib.getPath(haxelib);
+					var libPath:String = Haxelib.getPath(haxelib);
+					var classPath:String = Haxelib.getPathClassPath(libPath);
+					
+					if (classPath != null)
+						libPath = Path.combine(libPath, classPath);
+					
+					hxml += "\n-cp " + libPath;
 				}
 
 				for (key in project.haxedefs.keys())

--- a/src/lime/tools/ModuleHelper.hx
+++ b/src/lime/tools/ModuleHelper.hx
@@ -97,7 +97,11 @@ class ModuleHelper
 
 				hxml += "\n-D html5";
 				hxml += "\n-D html";
+				#if !haxe4
 				hxml += "\n--no-inline";
+				#else
+				hxml += "\n-D no-inline";
+				#end
 				hxml += "\n-dce no";
 				hxml += "\n-js " + outputPath;
 

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -510,6 +510,9 @@ class AssetLibrary
 		}
 		else if (classTypes.exists(id))
 		{
+			js.Browser.console.log(classTypes);
+			js.Browser.console.log(id);
+			js.Browser.console.log(classTypes.get(id));
 			var font:Font = Type.createInstance(classTypes.get(id), []);
 
 			#if (js && html5)
@@ -765,7 +768,7 @@ class AssetLibrary
 			{
 				classRef = Type.resolveClass(Reflect.field(asset, "className"));
 
-				#if (js && html5 && modular)
+				#if (js && html5 && lime_modular)
 				if (classRef == null)
 				{
 					classRef = untyped $hx_exports[asset.className];

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -510,9 +510,6 @@ class AssetLibrary
 		}
 		else if (classTypes.exists(id))
 		{
-			js.Browser.console.log(classTypes);
-			js.Browser.console.log(id);
-			js.Browser.console.log(classTypes.get(id));
 			var font:Font = Type.createInstance(classTypes.get(id), []);
 
 			#if (js && html5)

--- a/templates/html5/output.js
+++ b/templates/html5/output.js
@@ -55,4 +55,11 @@ if (typeof self !== "undefined" && !self.constructor.name.includes("Worker")) {
 		var meta = document.getElementById ("viewport");
 		meta.setAttribute ('content', 'width=device-width, initial-scale=' + (2 / window.devicePixelRatio) + ', user-scalable=no');
 	}
+
+	window.addEventListener ("load", function () {
+		const content = document.getElementById(::if LIB_OPENFL::"openfl-content"::else::"content"::end::);
+		if (content && content.childElementCount === 0) {
+			lime.embed ("::APP_FILE::", content, ::WIN_WIDTH::, ::WIN_HEIGHT::);
+		}
+	});
 }

--- a/templates/html5/output.js
+++ b/templates/html5/output.js
@@ -48,3 +48,11 @@ if (typeof define === "function" && define.__amd) {
 	define.amd = define.__amd;
 	delete define.__amd;
 }
+
+if (typeof self !== "undefined" && !self.constructor.name.includes("Worker")) {
+	window.addEventListener ("touchmove", function (event) { event.preventDefault (); }, { capture: false, passive: false });
+	if (typeof window.devicePixelRatio != 'undefined' && window.devicePixelRatio > 2) {
+		var meta = document.getElementById ("viewport");
+		meta.setAttribute ('content', 'width=device-width, initial-scale=' + (2 / window.devicePixelRatio) + ', user-scalable=no');
+	}
+}

--- a/templates/html5/output.js
+++ b/templates/html5/output.js
@@ -27,6 +27,19 @@ if (typeof self !== "undefined" && self.constructor.name.includes("Worker")) {
 		$hx_exports.lime.system?.System?.embed?.apply(lime, arguments);
 		return $hx_exports;
 	};
+
+	window.addEventListener ("touchmove", function (event) { event.preventDefault (); }, { capture: false, passive: false });
+	if (typeof window.devicePixelRatio != 'undefined' && window.devicePixelRatio > 2) {
+		var meta = document.getElementById ("viewport");
+		meta.setAttribute ('content', 'width=device-width, initial-scale=' + (2 / window.devicePixelRatio) + ', user-scalable=no');
+	}
+
+	window.addEventListener ("load", function () {
+		const content = document.getElementById(::if LIB_OPENFL::"openfl-content"::else::"content"::end::);
+		if (content && content.childElementCount === 0) {
+			$hx_exports.lime.embed ("::APP_FILE::", content, ::WIN_WIDTH::, ::WIN_HEIGHT::);
+		}
+	});
 }
 
 if (typeof define === "function" && define.amd) {
@@ -41,19 +54,4 @@ if (typeof define === "function" && define.amd) {
 if (typeof define === "function" && define.__amd) {
 	define.amd = define.__amd;
 	delete define.__amd;
-}
-
-if (typeof self !== "undefined" && !self.constructor.name.includes("Worker")) {
-	window.addEventListener ("touchmove", function (event) { event.preventDefault (); }, { capture: false, passive: false });
-	if (typeof window.devicePixelRatio != 'undefined' && window.devicePixelRatio > 2) {
-		var meta = document.getElementById ("viewport");
-		meta.setAttribute ('content', 'width=device-width, initial-scale=' + (2 / window.devicePixelRatio) + ', user-scalable=no');
-	}
-
-	window.addEventListener ("load", function () {
-		const content = document.getElementById(::if LIB_OPENFL::"openfl-content"::else::"content"::end::);
-		if (content && content.childElementCount === 0) {
-			lime.embed ("::APP_FILE::", content, ::WIN_WIDTH::, ::WIN_HEIGHT::);
-		}
-	});
 }

--- a/templates/html5/output.js
+++ b/templates/html5/output.js
@@ -1,4 +1,4 @@
-var $lime_init = (function ($hx_exports, $global) { "use strict"; var $hx_script = (function (exports, global) { ::SOURCE_FILE::
+"use strict"; var $hx_script = (function (exports) { ::SOURCE_FILE::
 });::if false::
 /*
 	Don't insert or remove any line breaks in the code above this line!
@@ -12,34 +12,31 @@ var $lime_init = (function ($hx_exports, $global) { "use strict"; var $hx_script
 	to avoid it getting ignored in a // comment at the end of ::SOURCE_FILE::.
 */
 ::end::
-	if (typeof self !== "undefined" && self.constructor.name.includes("Worker")) {
-		// No need for exports in a worker context, just initialize statics.
-		$hx_script({}, $global);
-	} else {
-		$hx_exports.lime = $hx_exports.lime || {};
-		$hx_exports.lime.$scripts = $hx_exports.lime.$scripts || {};
-		$hx_exports.lime.$scripts["::APP_FILE::"] = $hx_script;
-		$hx_exports.lime.embed = function (projectName) {
-			var exports = {};
-			var script = $hx_exports.lime.$scripts[projectName];
-			if (!script) throw Error("Cannot find project name \"" + projectName + "\"");
-			script(exports, $global);
-			for (var key in exports) $hx_exports[key] = $hx_exports[key] || exports[key];
-			var lime = exports.lime || window.lime;
-			if (lime && lime.embed && this !== lime.embed) lime.embed.apply(lime, arguments);
-			return exports;
-		};
-	}
+var $hx_exports = typeof exports !== "undefined" ? exports : typeof define === "function" && define.amd ? {} : typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : this;
+if (typeof self !== "undefined" && self.constructor.name.includes("Worker")) {
+	// No need for exports in a worker context, just initialize statics.
+	$hx_script({});
+} else {
+	$hx_exports.lime = $hx_exports.lime || {};
+	$hx_exports.lime.$scripts = $hx_exports.lime.$scripts || {};
+	$hx_exports.lime.$scripts["::APP_FILE::"] = $hx_script;
+	$hx_exports.lime.embed = function (projectName) {
+		var exports = {};
+		var script = $hx_exports.lime.$scripts[projectName];
+		if (!script) throw Error("Cannot find project name \"" + projectName + "\"");
+		script(exports);
+		for (var key in exports) $hx_exports[key] = $hx_exports[key] || exports[key];
+		var lime = exports.lime || window.lime;
+		if (lime && lime.embed && this !== lime.embed) lime.embed.apply(lime, arguments);
+		return exports;
+	};
+}
 
-	if (typeof define === "function" && define.amd) {
-		define([], function () { return $hx_exports.lime; });
-		define.__amd = define.amd;
-		define.amd = null;
-	}
-})
-
-$lime_init(typeof exports !== "undefined" ? exports : typeof define === "function" && define.amd ? {} : typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : this,
-typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : this);
+if (typeof define === "function" && define.amd) {
+	define([], function () { return $hx_exports.lime; });
+	define.__amd = define.amd;
+	define.amd = null;
+}
 
 ::if embeddedLibraries::::foreach embeddedLibraries::
 ::__current__::::end::::end::

--- a/templates/html5/output.js
+++ b/templates/html5/output.js
@@ -21,14 +21,11 @@ if (typeof self !== "undefined" && self.constructor.name.includes("Worker")) {
 	$hx_exports.lime.$scripts = $hx_exports.lime.$scripts || {};
 	$hx_exports.lime.$scripts["::APP_FILE::"] = $hx_script;
 	$hx_exports.lime.embed = function (projectName) {
-		var exports = {};
 		var script = $hx_exports.lime.$scripts[projectName];
 		if (!script) throw Error("Cannot find project name \"" + projectName + "\"");
-		script(exports);
-		for (var key in exports) $hx_exports[key] = $hx_exports[key] || exports[key];
-		var lime = exports.lime || window.lime;
-		if (lime && lime.embed && this !== lime.embed) lime.embed.apply(lime, arguments);
-		return exports;
+		script($hx_exports);
+		$hx_exports.lime.system?.System?.embed?.apply(lime, arguments);
+		return $hx_exports;
 	};
 }
 

--- a/templates/html5/template/index.html
+++ b/templates/html5/template/index.html
@@ -16,14 +16,6 @@
 	<script type="text/javascript" src="::__current__::"></script>::end::::end::
 	<script type="text/javascript" src="./::APP_FILE::.js"></script>
 
-	<script>
-		window.addEventListener ("touchmove", function (event) { event.preventDefault (); }, { capture: false, passive: false });
-		if (typeof window.devicePixelRatio != 'undefined' && window.devicePixelRatio > 2) {
-			var meta = document.getElementById ("viewport");
-			meta.setAttribute ('content', 'width=device-width, initial-scale=' + (2 / window.devicePixelRatio) + ', user-scalable=no');
-		}
-	</script>
-
 	<style>
 		html,body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
 		#content { ::if (WIN_BACKGROUND)::background: #000000; ::end::width: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_WIDTH::px::else::100%::end::; height: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_HEIGHT::px::else::100%::end::; }

--- a/templates/html5/template/index.html
+++ b/templates/html5/template/index.html
@@ -29,9 +29,5 @@
 
 	<div id="content"></div>
 
-	<script type="text/javascript">
-		lime.embed ("::APP_FILE::", "content", ::WIN_WIDTH::, ::WIN_HEIGHT::);
-	</script>
-
 </body>
 </html>


### PR DESCRIPTION
As discovered by @Digivorix, building with `-D lime-modular` is currently broken, and likely has been for 7+ years. This mode outputs separate .js files for Haxe, Lime, and OpenFL, among others, with the idea that most of them can be reused. Each file would add their classes to `$hx_exports`, then the final app could reference those exported classes.

The core of the problem is that, instead of passing `$hx_exports` to the app, we created an empty object and passed that instead. Without access to basic OpenFL, Lime, or Haxe classes, the app couldn't run.

As far as I can tell, the only reason not to pass `$hx_exports` is because `System` will overwrite `$hx_exports.lime.embed`. We want to expose _output.js_'s wrapper function in that spot, and the wrapper needs to call the function `System` exports. Solution: have `System` export to `$hx_exports.lime.system.System.embed` instead.

Downside: if the wrapper never runs, then the page can't call `lime.embed`, which it might expect to be able to do. But that would require running `haxe Export/html5/haxe/release.hxml` manually to remove the wrapper, which also strips away the embedded libraries, so I don't think that's ever been a supported use case.

Note: this PR is not enough to run OpenFL apps in modular mode. OpenFL will need [a patch](https://github.com/openfl/openfl/pull/2844) of its own.

Note 2: this includes #2013, because I considered a solution that would have required it.