### PR TITLE
Backport sdl fix for backspace bug on android

### DIFF
--- a/templates/android/template/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/templates/android/template/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2005,16 +2005,14 @@ class SDLInputConnection extends BaseInputConnection {
 
     @Override
     public boolean deleteSurroundingText(int beforeLength, int afterLength) {
-        if (Build.VERSION.SDK_INT <= 29 /* Android 10.0 (Q) */) {
-            // Workaround to capture backspace key. Ref: http://stackoverflow.com/questions>/14560344/android-backspace-in-webview-baseinputconnection
-            // and https://bugzilla.libsdl.org/show_bug.cgi?id=2265
-            if (beforeLength > 0 && afterLength == 0) {
-                // backspace(s)
-                while (beforeLength-- > 0) {
-                    nativeGenerateScancodeForUnichar('\b');
-                }
-                return true;
-           }
+        // Workaround to capture backspace key. Ref: http://stackoverflow.com/questions>/14560344/android-backspace-in-webview-baseinputconnection
+        // and https://bugzilla.libsdl.org/show_bug.cgi?id=2265
+        if (beforeLength > 0 && afterLength == 0) {
+            // backspace(s)
+            while (beforeLength-- > 0) {
+                nativeGenerateScancodeForUnichar('\b');
+            }
+            return true;
         }
 
         if (!super.deleteSurroundingText(beforeLength, afterLength)) {


### PR DESCRIPTION
This patch has already been accepted upstream: https://github.com/libsdl-org/SDL/commit/22a6d76f2295ccc22353b6372b27181615c71e08.

We'd get it if we update to future releases of sdl 2.32 or sdl 3, however, it is quite a bad bug so it's nice to have the patch applied manually in the meantime.

See here for more details: https://github.com/libsdl-org/SDL/issues/15067.

This bug affects lime 8.3.0+ which includes the sdl 2.30 version bump:
- a926989d44f131761f84df3cb6bebffa9fb3cfd0
- 09040f443de22a8ccb244a22fa11925c432bdea7