### PR TITLE
Decode bundle images on demand

### DIFF
--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -273,6 +273,13 @@ class AssetLibrary
 		{
 			return cachedImages.get(id);
 		}
+		else if (cachedBytes.exists(id))
+		{
+			var image = Image.fromBytes(cachedBytes.get(id));
+			cachedBytes.remove(id);
+			cachedImages.set(id, image);
+			return image;
+		}
 		else if (classTypes.exists(id))
 		{
 			#if flash
@@ -341,7 +348,7 @@ class AssetLibrary
 					|| cachedAudioBuffers.exists(id) || cachedFonts.exists(id);
 
 			case IMAGE:
-				cachedImages.exists(id);
+				cachedImages.exists(id) || cachedBytes.exists(id);
 
 			case MUSIC, SOUND:
 				cachedAudioBuffers.exists(id);
@@ -692,7 +699,7 @@ class AssetLibrary
 					{
 						#if !web
 						case IMAGE:
-							cachedImages.set(id, Image.fromBytes(data));
+							cachedBytes.set(id, data);
 						case MUSIC, SOUND:
 							cachedAudioBuffers.set(id, AudioBuffer.fromBytes(data));
 						case FONT:

--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -32,6 +32,7 @@ class AssetLibrary
 	@:noCompletion private var cachedAudioBuffers = new Map<String, AudioBuffer>();
 	@:noCompletion private var cachedBytes = new Map<String, Bytes>();
 	@:noCompletion private var cachedFonts = new Map<String, Font>();
+	@:noCompletion private var cachedImageBytes = new Map<String, Bytes>();
 	@:noCompletion private var cachedImages = new Map<String, Image>();
 	@:noCompletion private var cachedText = new Map<String, String>();
 	@:noCompletion private var classTypes = new Map<String, Class<Dynamic>>();
@@ -273,10 +274,10 @@ class AssetLibrary
 		{
 			return cachedImages.get(id);
 		}
-		else if (cachedBytes.exists(id))
+		else if (cachedImageBytes.exists(id))
 		{
-			var image = Image.fromBytes(cachedBytes.get(id));
-			cachedBytes.remove(id);
+			var image = Image.fromBytes(cachedImageBytes.get(id));
+			cachedImageBytes.remove(id);
 			cachedImages.set(id, image);
 			return image;
 		}
@@ -344,11 +345,11 @@ class AssetLibrary
 		return switch (cast(type, AssetType))
 		{
 			case null:
-				cachedBytes.exists(id) || cachedText.exists(id) || cachedImages.exists(id)
+				cachedBytes.exists(id) || cachedText.exists(id) || cachedImageBytes.exists(id) || cachedImages.exists(id)
 					|| cachedAudioBuffers.exists(id) || cachedFonts.exists(id);
 
 			case IMAGE:
-				cachedImages.exists(id) || cachedBytes.exists(id);
+				cachedImages.exists(id) || cachedImageBytes.exists(id);
 
 			case MUSIC, SOUND:
 				cachedAudioBuffers.exists(id);
@@ -575,11 +576,11 @@ class AssetLibrary
 		{
 			return Future.withValue(Type.createInstance(classTypes.get(id), []));
 		}
-		else if (cachedBytes.exists(id))
+		else if (cachedImageBytes.exists(id))
 		{
-			return Image.loadFromBytes(cachedBytes.get(id)).then(function(image)
+			return Image.loadFromBytes(cachedImageBytes.get(id)).then(function(image)
 			{
-				cachedBytes.remove(id);
+				cachedImageBytes.remove(id);
 				cachedImages.set(id, image);
 				return Future.withValue(image);
 			});
@@ -623,12 +624,14 @@ class AssetLibrary
 		#if haxe4
 		cachedBytes.clear();
 		cachedFonts.clear();
+		cachedImageBytes.clear();
 		cachedImages.clear();
 		cachedAudioBuffers.clear();
 		cachedText.clear();
 		#else
 		cachedBytes = new Map<String, Bytes>();
 		cachedFonts = new Map<String, Font>();
+		cachedImageBytes = new Map<String, Bytes>();
 		cachedImages = new Map<String, Image>();
 		cachedText = new Map<String, String>();
 		classTypes = new Map<String, Class<Dynamic>>();
@@ -699,7 +702,7 @@ class AssetLibrary
 					{
 						#if !web
 						case IMAGE:
-							cachedBytes.set(id, data);
+							cachedImageBytes.set(id, data);
 						case MUSIC, SOUND:
 							cachedAudioBuffers.set(id, AudioBuffer.fromBytes(data));
 						case FONT:


### PR DESCRIPTION
## Summary

This changes `lime.utils.AssetLibrary` to decode bundle images lazily instead of decoding every `IMAGE` asset eagerly in `__fromBundle()`.

Bundle images are now stored in `cachedBytes` first, then decoded on first `getImage()` / `loadImage()` access. `isLocal(IMAGE)` is also updated so synchronous access continues to work for bundle-backed images that have not been decoded yet.

## Why

The previous behavior eagerly called `Image.fromBytes(...)` for every `IMAGE` asset in a bundle as soon as the library was created from the bundle.

For large bundles, this can create very large startup costs in both CPU and memory even when only a subset of the bundled images is actually used.

This change keeps bundle loading cheaper and shifts image decode cost to first real use, which is a better fit for large runtime-loaded libraries.

## Behavior change

Before:
- `fromBundle()` decoded all `IMAGE` assets immediately

After:
- `fromBundle()` keeps `IMAGE` assets as bytes
- `getImage()` / `loadImage()` decode on demand
- `isLocal(IMAGE)` remains true for bundle images backed by cached bytes

## Notes

This does change when decode cost is paid:
- lower upfront bundle load cost
- potential first-use cost when a specific image is accessed for the first time

Preloaded images still go through `loadImage()` during `load()`, so they are still decoded during preload as expected.