### PR TITLE
Expose architecture defines during Project XML parsing

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -829,6 +829,7 @@ class HXProject extends Script
 		defines.set(Std.string(target).toLowerCase(), "1");
 		defines.set("target", Std.string(target).toLowerCase());
 		defines.set("platform", defines.get("target"));
+		initializeArchitectureDefines();
 
 		switch (System.hostPlatform)
 		{
@@ -847,6 +848,51 @@ class HXProject extends Script
 		#end
 
 		defines.set("hxp", "1"); // TODO: Version?
+	}
+
+	private function initializeArchitectureDefines():Void
+	{
+		var architecture:Architecture = null;
+
+		if (targetFlags.exists("arm64"))
+		{
+			architecture = ARM64;
+		}
+		else if (targetFlags.exists("64") || targetFlags.exists("x86_64"))
+		{
+			architecture = X64;
+		}
+		else if (targetFlags.exists("32") || targetFlags.exists("x86_32"))
+		{
+			architecture = X86;
+		}
+		else if (defines.exists("native"))
+		{
+			architecture = switch (System.hostArchitecture)
+			{
+				case ARM64: ARM64;
+				case X64: X64;
+				case X86: X86;
+				default: null;
+			}
+		}
+
+		switch (architecture)
+		{
+			case ARM64:
+				defines.set("64", "1");
+				defines.set("arm64", "1");
+				defines.set("HXCPP_ARM64", "1");
+			case X64:
+				defines.set("64", "1");
+				defines.set("x86_64", "1");
+				defines.set("HXCPP_M64", "1");
+			case X86:
+				defines.set("32", "1");
+				defines.set("x86_32", "1");
+				defines.set("HXCPP_M32", "1");
+			default:
+		}
 	}
 
 	private static function initializeStatics():Void

--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -877,6 +877,13 @@ class HXProject extends Script
 			}
 		}
 
+		// Non-native targets leave architecture unset.
+		// Switching on a null enum throws "Invalid field access : index".
+		if (architecture == null)
+		{
+			return;
+		}
+
 		switch (architecture)
 		{
 			case ARM64:

--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -866,6 +866,10 @@ class HXProject extends Script
 		{
 			architecture = X86;
 		}
+		else if (targetFlags.exists("armv7"))
+		{
+			architecture = ARMV7;
+		}
 		else if (defines.exists("native"))
 		{
 			architecture = switch (System.hostArchitecture)
@@ -873,6 +877,7 @@ class HXProject extends Script
 				case ARM64: ARM64;
 				case X64: X64;
 				case X86: X86;
+				case ARMV7: ARMV7;
 				default: null;
 			}
 		}
@@ -884,20 +889,17 @@ class HXProject extends Script
 			return;
 		}
 
+		// Target-agnostic architecture defines for include.xml conditions.
 		switch (architecture)
 		{
 			case ARM64:
-				defines.set("64", "1");
 				defines.set("arm64", "1");
-				defines.set("HXCPP_ARM64", "1");
 			case X64:
-				defines.set("64", "1");
 				defines.set("x86_64", "1");
-				defines.set("HXCPP_M64", "1");
 			case X86:
-				defines.set("32", "1");
 				defines.set("x86_32", "1");
-				defines.set("HXCPP_M32", "1");
+			case ARMV7:
+				defines.set("armv7", "1");
 			default:
 		}
 	}


### PR DESCRIPTION
## Summary

This updates Lime to expose resolved architecture defines earlier, during Project XML parsing.

`HXProject` now sets architecture-related defines such as:
- `HXCPP_M32`
- `HXCPP_M64`
- `HXCPP_ARM64`
- `32`
- `64`
- `x86_32`
- `x86_64`
- `arm64`

based on the requested target flags, or the default native architecture when applicable.

## Why

Some extensions need to select platform-specific runtime assets from `include.xml`, but architecture information was only becoming available later during the build phase.

This made conditions like `if="HXCPP_M32"` unusable in `include.xml`, even though the final build target was already known.

## Result

Extensions can now use normal XML conditions to choose the correct architecture-specific assets during project parsing, without requiring post-build scripts or other workarounds.