### PR TITLE
Fix default openal backend without include.xml

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -20,9 +20,11 @@
 	<set name="LIME_MBEDTLS" value="1" unless="emscripten || winrt" />
 	<!-- <set name="LIME_NEKO" value="1" if="linux" /> -->
 	<set name="LIME_OGG" value="1" />
-	<set name="LIME_OPENALSOFT" value="1" if="lime-openalsoft" />
-	<set name="LIME_OPENAL" value="1" if="lime-openal" />
-	<set name="LIME_MOJOAL" value="1" if="lime-mojoal" />
+	<set name="LIME_OPENALSOFT" value="1" if="windows || linux || mac || android" unless="static_link" />
+	<set name="LIME_OPENAL" value="1" if="iphone || webassembly || tvos" />
+	<set name="LIME_MOJOAL" value="1" if="switch || static_link || winrt || mojoal" unless="LIME_OPENAL" />
+	<unset name="LIME_OPENALSOFT" if="LIME_MOJOAL" />
+	<set name="LIME_OPENAL" value="1" if="LIME_OPENALSOFT || LIME_MOJOAL" />
 	<set name="LIME_OPENGL" value="1" />
 	<set name="LIME_PIXMAN" value="1" />
 	<set name="LIME_PNG" value="1" />


### PR DESCRIPTION
Fixes regression in #1912. See: https://github.com/openfl/lime/pull/1912#issuecomment-4214409886

Running `lime rebuild linux` outside the lime directory or `lime rebuild path/to/lime linux` produced broken ndlls due to no default openal implementation set.