### PR TITLE
Feature: Add native MP3 decoding support via minimp3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,5 +83,9 @@
 	url = https://github.com/HaxeFoundation/hashlink
 	shallow = true
 [submodule "project/lib/sdl_sound"]
-	path = project/lib/sdl_sound
-	url = https://github.com/icculus/SDL_sound.git
+    path = project/lib/sdl_sound
+    url = https://github.com/icculus/SDL_sound.git
+[submodule "project/lib/minimp3"]
+    path = project/lib/minimp3
+    url = https://github.com/lieff/minimp3
+    shallow = true

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -20,6 +20,7 @@
 	<set name="LIME_MBEDTLS" value="1" unless="emscripten || winrt" />
 	<!-- <set name="LIME_NEKO" value="1" if="linux" /> -->
 	<set name="LIME_OGG" value="1" />
+	<set name="LIME_MP3" value="1" />
 	<set name="LIME_OPENALSOFT" value="1" if="windows || linux || mac || android" unless="static_link" />
 	<set name="LIME_OPENAL" value="1" if="iphone || webassembly || tvos" />
 	<set name="LIME_MOJOAL" value="1" if="switch || static_link || winrt || mojoal" unless="LIME_OPENAL" />
@@ -181,6 +182,15 @@
 			<compilerflag value="-DLIME_OGG" />
 
 			<file name="src/media/containers/OGG.cpp" />
+
+		</section>
+
+		<section if="LIME_MP3">
+
+			<compilerflag value="-I${NATIVE_TOOLKIT_PATH}/minimp3/" />
+			<compilerflag value="-DLIME_MP3" />
+
+			<file name="src/media/containers/MP3.cpp" />
 
 		</section>
 
@@ -379,6 +389,7 @@
 	<include name="lib/mojoal-files.xml" />
 	<include name="lib/neko-files.xml" />
 	<include name="lib/ogg-files.xml" />
+	<include name="lib/mp3-files.xml" />
 	<include name="lib/openal-files.xml" />
 	<include name="lib/pixman-files.xml" />
 	<include name="lib/png-files.xml" />
@@ -413,6 +424,7 @@
 		<files id="native-toolkit-mojoal" if="LIME_MOJOAL" />
 		<files id="native-toolkit-neko" if="LIME_NEKO" />
 		<files id="native-toolkit-ogg" if="LIME_OGG" />
+		<files id="native-toolkit-mp3" if="LIME_MP3" />
 		<files id="native-toolkit-openal" if="LIME_OPENALSOFT" />
 		<files id="native-toolkit-pixman" if="LIME_PIXMAN" />
 		<files id="native-toolkit-png" if="LIME_PNG" />

--- a/project/include/media/containers/MP3.h
+++ b/project/include/media/containers/MP3.h
@@ -1,0 +1,19 @@
+#ifndef LIME_MEDIA_CONTAINERS_MP3_H
+#define LIME_MEDIA_CONTAINERS_MP3_H
+
+#include <media/AudioBuffer.h>
+#include <utils/Resource.h>
+
+namespace lime {
+
+    class MP3 {
+
+        public:
+
+            static bool Decode (Resource *resource, AudioBuffer *audioBuffer);
+
+    };
+
+}
+
+#endif

--- a/project/lib/mp3-files.xml
+++ b/project/lib/mp3-files.xml
@@ -1,0 +1,10 @@
+<xml>
+
+    <files id="native-toolkit-mp3">
+
+        <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/minimp3/" />
+        <cache value="1" />
+
+    </files>
+
+</xml>

--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -18,6 +18,7 @@
 #include <graphics/RenderEvent.h>
 #include <media/containers/OGG.h>
 #include <media/containers/WAV.h>
+#include <media/containers/MP3.h>
 #include <media/AudioBuffer.h>
 #include <system/CFFIPointer.h>
 #include <system/Clipboard.h>
@@ -414,6 +415,13 @@ namespace lime {
 		}
 		#endif
 
+		#ifdef LIME_MP3
+        if (MP3::Decode (&resource, &audioBuffer)) {
+
+            return audioBuffer.Value (buffer);
+        }
+        #endif
+
 		return alloc_null ();
 
 	}
@@ -444,6 +452,13 @@ namespace lime {
 
 		}
 		#endif
+
+		#ifdef LIME_MP3
+        if (MP3::Decode (&resource, buffer)) {
+
+            return buffer;
+        }
+        #endif
 
 		return 0;
 
@@ -480,6 +495,13 @@ namespace lime {
 		}
 		#endif
 
+		#ifdef LIME_MP3
+        if (MP3::Decode (&resource, &audioBuffer)) {
+
+            return audioBuffer.Value (buffer);
+        }
+        #endif
+
 		return alloc_null ();
 
 	}
@@ -510,6 +532,13 @@ namespace lime {
 
 		}
 		#endif
+
+		#ifdef LIME_MP3
+        if (MP3::Decode (&resource, buffer)) {
+
+            return buffer;
+        }
+        #endif
 
 		return 0;
 

--- a/project/src/media/containers/MP3.cpp
+++ b/project/src/media/containers/MP3.cpp
@@ -1,0 +1,90 @@
+#define MINIMP3_IMPLEMENTATION
+#include <minimp3.h>
+#include <minimp3_ex.h>
+#include <media/containers/MP3.h>
+#include <utils/Bytes.h>
+#include <utils/ArrayBufferView.h>
+
+namespace lime {
+
+    bool MP3::Decode (Resource *resource, AudioBuffer *audioBuffer) {
+
+        if (!resource || !audioBuffer) {
+            return false;
+        }
+
+        const uint8_t *inputData = NULL;
+        int inputLength = 0;
+        Bytes fileBytes;
+
+        if (resource->data) {
+
+            inputData = resource->data->b;
+            inputLength = resource->data->length;
+
+        } else if (resource->path) {
+
+            fileBytes.ReadFile (resource->path);
+
+            if (!fileBytes.b || fileBytes.length == 0) {
+                return false;
+            }
+
+            inputData = fileBytes.b;
+            inputLength = fileBytes.length;
+
+        } else {
+
+            return false;
+
+        }
+
+        if (!inputData || inputLength <= 0) {
+            return false;
+        }
+
+        mp3dec_t decoder;
+        mp3dec_init (&decoder);
+
+        mp3dec_file_info_t info = { 0 };
+        int result = mp3dec_load_buf (&decoder, inputData, inputLength, &info, NULL, NULL);
+
+        if (result != 0 || !info.buffer || info.samples == 0 || info.channels <= 0 || info.hz <= 0) {
+
+            if (info.buffer) {
+                free (info.buffer);
+            }
+
+            return false;
+
+        }
+
+        int byteLength = info.samples * static_cast<int>(sizeof (mp3d_sample_t));
+
+        Bytes *decodedBytes = new Bytes ();
+        decodedBytes->Resize (byteLength);
+        memcpy (decodedBytes->b, info.buffer, byteLength);
+
+        if (audioBuffer->data) {
+            delete audioBuffer->data;
+        }
+
+        audioBuffer->data = new ArrayBufferView (alloc_null ());
+        audioBuffer->data->type = 1;
+        audioBuffer->data->byteOffset = 0;
+        audioBuffer->data->buffer = decodedBytes;
+        audioBuffer->data->byteLength = byteLength;
+        audioBuffer->data->length = byteLength;
+        audioBuffer->data->bytesPerElement = 1;
+
+        audioBuffer->sampleRate = info.hz;
+        audioBuffer->channels = info.channels;
+        audioBuffer->bitsPerSample = 16;
+
+        free (info.buffer);
+
+        return true;
+
+    }
+
+}


### PR DESCRIPTION
### Description
This PR adds native support for decoding and playing MP3 files in the C++ backend, matching the existing architecture used for WAV and OGG formats.

To keep the implementation lightweight and avoid heavy external dependencies, this uses the `minimp3` header-only library (which is already included in the ecosystem for the HashLink target).

### Changes made
* **Submodule:** Added `minimp3` as a Git submodule in `lib/minimp3`.
* **Build System:** Updated `Build.xml` to include the `LIME_MP3` flag and created `lib/mp3-files.xml` for the build toolkit configuration.
* **C++ Decoder:** Implemented `include/media/containers/MP3.h` and `src/media/containers/MP3.cpp` with the `Decode` method. It handles both memory buffers and file paths. Memory is safely mapped to Haxe's `ArrayBufferView` using `alloc_null()` with explicit byte assignment.
* **CFFI Integration:** Updated all four loading functions in `src/ExternalInterface.cpp` (`lime_audio_load_bytes`, `hl_audio_load_bytes`, `lime_audio_load_file`, `hl_audio_load_file`) to properly route MP3 checks to the new decoder.

### Testing
* Successfully compiled on Linux (CachyOS).
* Tested playback using a sample application calling `AudioBuffer.loadFromFile()` and successfully played the decoded MP3 data through `AudioSource`.
* [LimeMP3Testing.zip](https://github.com/user-attachments/files/27369944/LimeMP3Testing.zip)