### PR TITLE
Fix template asset copy failures for nested output paths

### DIFF
--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -37,6 +37,8 @@ class AssetHelper
 
 	public static function copyAsset(asset:Asset, destination:String, context:Dynamic = null)
 	{
+		System.mkdir(Path.directory(destination));
+
 		if (asset.sourcePath != "")
 		{
 			System.copyFile(asset.sourcePath, destination, context, asset.type == TEMPLATE);


### PR DESCRIPTION
`AssetHelper.copyAsset` can write generated/template asset data directly to a destination path, but it did not ensure the destination directory existed first.

This caused writes to nested generated paths to fail when no platform-specific caller created the parent directory beforehand.

The fix creates the destination directory before copying or writing the asset. A standalone repro is included to demonstrate the failure on Windows without the fix and the success case with it.
[lime-generated-template-asset-repro.zip](https://github.com/user-attachments/files/27502143/lime-generated-template-asset-repro.zip)
