### PR TITLE
Fix Linux window icon handling

### DIFF
--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -89,6 +89,17 @@ import ::APP_MAIN::;
 		}
 
 		app.createWindow(attributes);
+		#if (linux && sys)
+		var iconPath = lime.system.System.applicationDirectory + "/icon.png";
+		if (sys.FileSystem.exists(iconPath))
+		{
+			var icon = lime.graphics.Image.fromFile(iconPath);
+			if (icon != null && app.window != null)
+			{
+				app.window.setIcon(icon);
+			}
+		}
+		#end
 		::end::
 		#elseif air
 		app.window.title = "::meta.title::";

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -13,6 +13,8 @@ import lime.tools.AssetType;
 import lime.tools.CPPHelper;
 import lime.tools.DeploymentHelper;
 import lime.tools.HXProject;
+import lime.tools.Icon;
+import lime.tools.IconHelper;
 import lime.tools.JavaHelper;
 import lime.tools.NekoHelper;
 import lime.tools.NodeJSHelper;
@@ -627,7 +629,15 @@ class LinuxPlatform extends PlatformTarget
 			ProjectHelper.recursiveSmartCopyTemplate(project, "cpp/static", targetDirectory + "/obj", context);
 		}
 
-		// context.HAS_ICON = IconHelper.createIcon (project.icons, 256, 256, Path.combine (applicationDirectory, "icon.png"));
+		var icons = project.icons;
+
+		if (icons.length == 0)
+		{
+			icons = [new Icon(System.findTemplate(project.templatePaths, "default/icon.svg"))];
+		}
+
+		context.HAS_ICON = IconHelper.createIcon(icons, 256, 256, Path.combine(applicationDirectory, "icon.png"));
+
 		for (asset in project.assets)
 		{
 			var path = Path.combine(applicationDirectory, asset.targetPath);


### PR DESCRIPTION
## Summary

This PR makes Linux builds honor `<icon path="...">` more like the other desktop targets.

Previously, Linux parsed project icons but did not generate an icon file in the application output, and the generated `ApplicationMain` did not apply an icon to the SDL window. As a result, Linux window managers could show the generic X11/default icon even when a project icon was configured.

This change:

- generates `bin/linux/bin/icon.png` from `project.icons`
- falls back to Lime’s default icon when no project icon is configured
- updates the generated Lime `ApplicationMain` to load `icon.png` from the application directory and call `window.setIcon(...)` on Linux

Windows and macOS already handle icons through their native packaging mechanisms, so this adds the missing Linux runtime path.

## Repro

[LimeLinuxIconRepro.zip](https://github.com/user-attachments/files/27539127/LimeLinuxIconRepro.zip)
