### PR TITLE
Fix gamepad connect/disconnect event listener on HTML5

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -229,8 +229,8 @@ class HTML5Window
 			element.addEventListener("touchend", handleTouchEvent, true);
 			element.addEventListener("touchcancel", handleTouchEvent, true);
 
-			element.addEventListener("gamepadconnected", handleGamepadEvent, true);
-			element.addEventListener("gamepaddisconnected", handleGamepadEvent, true);
+			Browser.window.addEventListener("gamepadconnected", handleGamepadEvent, true);
+			Browser.window.addEventListener("gamepaddisconnected", handleGamepadEvent, true);
 		}
 
 		createContext();
@@ -287,8 +287,8 @@ class HTML5Window
 			element.removeEventListener("touchend", handleTouchEvent, true);
 			element.removeEventListener("touchcancel", handleTouchEvent, true);
 
-			element.removeEventListener("gamepadconnected", handleGamepadEvent, true);
-			element.removeEventListener("gamepaddisconnected", handleGamepadEvent, true);
+			Browser.window.removeEventListener("gamepadconnected", handleGamepadEvent, true);
+			Browser.window.removeEventListener("gamepaddisconnected", handleGamepadEvent, true);
 		}
 
 		parent.application.__removeWindow(parent);


### PR DESCRIPTION
The **gamepadconnected** and **gamepaddisconnected** event listeners on HTML5 need to be added using `Browser.window.addEventListener` instead of `element.addEventListener` in order to work properly. 

Connected joysticks were still recognized, but it appears the event handler function in HTML5Window.hx (handleGamepadEvent) wasn't receiving any connect or disconnect events. As a consequence, the disconnect event for a connected gamepad would never fire.

Both the issue and the fix were tested in Firefox 150 and Microsoft Edge 148 on Windows 10 with a wireless Xbox 360 Controller connected via the official Wireless Receiver.