### PR TITLE
Add support for OpenGL VAOs on macOS

### DIFF
--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -531,6 +531,12 @@ namespace lime {
 	void lime_gl_bind_vertex_array (int vertexArray) {
 
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
+		#if defined (HX_MACOS)
+		if (glBindVertexArrayAPPLE) {
+			glBindVertexArrayAPPLE (vertexArray);
+		}
+		else
+		#endif
 		if (glBindVertexArray) {
 			glBindVertexArray (vertexArray);
 		}
@@ -542,6 +548,12 @@ namespace lime {
 	HL_PRIM void HL_NAME(hl_gl_bind_vertex_array) (int vertexArray) {
 
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
+		#if defined (HX_MACOS)
+		if (glBindVertexArrayAPPLE) {
+			glBindVertexArrayAPPLE (vertexArray);
+		}
+		else
+		#endif
 		if (glBindVertexArray) {
 			glBindVertexArray (vertexArray);
 		}
@@ -1200,6 +1212,12 @@ namespace lime {
 
 		GLuint id = 0;
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
+		#if defined (HX_MACOS)
+		if (glGenVertexArraysAPPLE) {
+			glGenVertexArraysAPPLE (1, &id);
+		}
+		else
+		#endif
 		if (glGenVertexArrays) {
 			glGenVertexArrays (1, &id);
 		}
@@ -1213,6 +1231,12 @@ namespace lime {
 
 		GLuint id = 0;
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
+		#if defined (HX_MACOS)
+		if (glGenVertexArraysAPPLE) {
+			glGenVertexArraysAPPLE (1, &id);
+		}
+		else
+		#endif
 		if (glGenVertexArrays) {
 			glGenVertexArrays (1, &id);
 		}
@@ -1401,6 +1425,12 @@ namespace lime {
 	void lime_gl_delete_vertex_array (int vertexArray) {
 
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
+		#if defined (HX_MACOS)
+		if (glDeleteVertexArraysAPPLE) {
+			glDeleteVertexArraysAPPLE (1, (GLuint*)&vertexArray);
+		}
+		else
+		#endif
 		if (glDeleteVertexArrays) {
 			glDeleteVertexArrays (1, (GLuint*)&vertexArray);
 		}
@@ -1412,6 +1442,12 @@ namespace lime {
 	HL_PRIM void HL_NAME(hl_gl_delete_vertex_array) (int vertexArray) {
 
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
+		#if defined (HX_MACOS)
+		if (glDeleteVertexArraysAPPLE) {
+			glDeleteVertexArraysAPPLE (1, (GLuint*)&vertexArray);
+		}
+		else
+		#endif
 		if (glDeleteVertexArrays) {
 			glDeleteVertexArrays (1, (GLuint*)&vertexArray);
 		}
@@ -3880,7 +3916,17 @@ namespace lime {
 	bool lime_gl_is_vertex_array (int handle) {
 
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
-		return glIsVertexArray ? glIsVertexArray (handle) : false;
+		#if defined (HX_MACOS)
+		if (glIsVertexArrayAPPLE) {
+			return glIsVertexArrayAPPLE (handle);
+		}
+		else
+		#endif
+		if (glIsVertexArray) {
+			return glIsVertexArray (handle);
+		}
+
+		return false;
 		#else
 		return false;
 		#endif
@@ -3891,7 +3937,17 @@ namespace lime {
 	HL_PRIM bool HL_NAME(hl_gl_is_vertex_array) (int handle) {
 
 		#if defined (LIME_GLES3_API) || !defined (LIME_GLES)
-		return glIsVertexArray ? glIsVertexArray (handle) : false;
+		#if defined (HX_MACOS)
+		if (glIsVertexArrayAPPLE) {
+			return glIsVertexArrayAPPLE (handle);
+		}
+		else
+		#endif
+		if (glIsVertexArray) {
+			return glIsVertexArray (handle);
+		}
+
+		return false;
 		#else
 		return false;
 		#endif

--- a/project/src/graphics/opengl/OpenGLBindings.cpp
+++ b/project/src/graphics/opengl/OpenGLBindings.cpp
@@ -228,10 +228,13 @@ namespace lime {
 						if (glIsRenderbuffer (id)) glDeleteRenderbuffers (1, &id);
 						break;
 
-					#ifdef LIME_GLES3_API
+					#if defined(LIME_GLES3_API) || !defined(LIME_GLES)
 					case TYPE_SAMPLER:
 
-						if (glIsSampler (id)) glDeleteSamplers (1, &id);
+						if (glIsSampler && glIsSampler (id)) {
+							if (glDeleteSamplers)
+								glDeleteSamplers (1, &id);
+						}
 						break;
 					#endif
 
@@ -245,10 +248,20 @@ namespace lime {
 						if (glIsTexture (id)) glDeleteTextures (1, &id);
 						break;
 
-					#ifdef LIME_GLES3_API
+					#if defined(LIME_GLES3_API) || !defined(LIME_GLES)
 					case TYPE_VERTEX_ARRAY_OBJECT:
-
-						if (glIsVertexArray (id)) glDeleteVertexArrays (1, &id);
+					
+						#if defined(HX_MACOS)
+						if (glIsVertexArrayAPPLE && glIsVertexArrayAPPLE (id)) {
+							if (glDeleteVertexArraysAPPLE)
+								glDeleteVertexArraysAPPLE (1, &id);
+						}
+						else
+						#endif
+						if (glIsVertexArray && glIsVertexArray (id)) {
+							if (glDeleteVertexArrays)
+								glDeleteVertexArrays (1, &id);
+						}
 						break;
 					#endif
 


### PR DESCRIPTION
Lime requests a OpenGL compatibility profile when creating a window, which on macOS results in an archaic version of OpenGL 2.1. This version does not support VAOs out of box, however, Apple provides the [`APPLE_vertex_array_object`](https://registry.khronos.org/OpenGL/extensions/APPLE/APPLE_vertex_array_object.txt) extension which provides the same set of methods, albeit with a suffix.

This PR adds calls to these methods on macOS only, if available, so that vertex array related methods aren't just a no-op.

```haxe
var vao = GL.createVertexArray();
trace(vao != null); 	      // true. false on 8.3.2

GL.bindVertexArray(vao);
trace(GL.isVertexArray(vao)); // true. false on 8.3.2
		
GL.deleteVertexArray(vao);
```