### PR TITLE
Security: Unchecked malloc return value

### DIFF
--- a/project/src/ui/DropEvent.cpp
+++ b/project/src/ui/DropEvent.cpp
@@ -46,9 +46,11 @@ namespace lime {
 
 				int length = strlen ((const char*)event->file);
 				char* file = (char*)malloc (length + 1);
-				strcpy (file, (const char*)event->file);
-				eventObject->file = (vbyte*)file;
-				eventObject->type = event->type;
+				if (file) {
+					strcpy (file, (const char*)event->file);
+					eventObject->file = (vbyte*)file;
+					eventObject->type = event->type;
+				}
 
 			}
 


### PR DESCRIPTION
## Summary

Security: Unchecked malloc return value

## Problem

**Severity**: `High` | **File**: `project/src/ui/DropEvent.cpp:L74`

In project/src/ui/DropEvent.cpp line 74-76, malloc is called without checking if it returns NULL. If malloc fails, subsequent strcpy will cause a crash.

## Solution

Add null check after malloc and handle the failure case appropriately.

## Changes

- `project/src/ui/DropEvent.cpp` (modified)