### PR TITLE
Prefer native WAV decoding before SDL_sound

### DIFF
--- a/project/src/ExternalInterface.cpp
+++ b/project/src/ExternalInterface.cpp
@@ -423,6 +423,12 @@ namespace lime {
 		bytes.Set (data);
 		resource = Resource (&bytes);
 
+		if (WAV::Decode (&resource, &audioBuffer)) {
+
+			return audioBuffer.Value (buffer);
+
+		}
+
 		#ifdef LIME_SDL_SOUND
 		if (SDLSound::Decode (&resource, &audioBuffer)) {
 
@@ -430,13 +436,6 @@ namespace lime {
 
 		}
 		#endif
-
-
-		if (WAV::Decode (&resource, &audioBuffer)) {
-
-			return audioBuffer.Value (buffer);
-
-		}
 
 		#ifdef LIME_OGG
 		if (OGG::Decode (&resource, &audioBuffer)) {
@@ -455,6 +454,12 @@ namespace lime {
 
 		Resource resource = Resource (data);
 
+		if (WAV::Decode (&resource, buffer)) {
+
+			return buffer;
+
+		}
+
 		#ifdef LIME_SDL_SOUND
 		if (SDLSound::Decode (&resource, buffer)) {
 
@@ -462,12 +467,6 @@ namespace lime {
 
 		}
 		#endif
-
-		if (WAV::Decode (&resource, buffer)) {
-
-			return buffer;
-
-		}
 
 		#ifdef LIME_OGG
 		if (OGG::Decode (&resource, buffer)) {
@@ -490,6 +489,12 @@ namespace lime {
 
 		resource = Resource (val_string (data));
 
+		if (WAV::Decode (&resource, &audioBuffer)) {
+
+			return audioBuffer.Value (buffer);
+
+		}
+
 		#ifdef LIME_SDL_SOUND
 		if (SDLSound::Decode (&resource, &audioBuffer)) {
 
@@ -497,12 +502,6 @@ namespace lime {
 
 		}
 		#endif
-
-		if (WAV::Decode (&resource, &audioBuffer)) {
-
-			return audioBuffer.Value (buffer);
-
-		}
 
 		#ifdef LIME_OGG
 		if (OGG::Decode (&resource, &audioBuffer)) {
@@ -521,6 +520,12 @@ namespace lime {
 
 		Resource resource = Resource (data ? hl_to_utf8 ((const uchar*)data->bytes) : NULL);
 
+		if (WAV::Decode (&resource, buffer)) {
+
+			return buffer;
+
+		}
+
 		#ifdef LIME_SDL_SOUND
 		if (SDLSound::Decode (&resource, buffer)) {
 
@@ -528,12 +533,6 @@ namespace lime {
 
 		}
 		#endif
-
-		if (WAV::Decode (&resource, buffer)) {
-
-			return buffer;
-
-		}
 
 		#ifdef LIME_OGG
 		if (OGG::Decode (&resource, buffer)) {


### PR DESCRIPTION
## Summary

Prefer Lime's native WAV decoder before SDL_sound when eagerly loading audio buffers from files or bytes.

## Rationale

Some PCM WAV sound effects decoded through SDL_sound first can produce audible startup artifacts when loaded via `AudioBuffer.fromBytes()`. The same assets decode and play correctly when Lime's native `WAV::Decode()` path is used first.

For plain PCM WAV files, the native decoder is the more direct path: it reads the RIFF/WAVE chunks and copies the sample data without routing through SDL_sound conversion. SDL_sound remains available as a fallback for formats or WAV variants that the native decoder does not support.

## Repro
[LimeWavSdlSoundArtifactRepro.zip](https://github.com/user-attachments/files/27942415/LimeWavSdlSoundArtifactRepro.zip)