### PR TITLE
Add `<preupdate />` tag.

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -49,7 +49,9 @@ class HXProject extends Script
 	public var ndlls:Array<NDLL>;
 	public var platformType:PlatformType;
 	public var postBuildCallbacks:Array<CLICommand>;
+	public var postUpdateCallbacks:Array<CLICommand>;
 	public var preBuildCallbacks:Array<CLICommand>;
+	public var preUpdateCallbacks:Array<CLICommand>;
 	public var samplePaths:Array<String>;
 	public var sources:Array<String>;
 	public var splashScreens:Array<SplashScreen>;
@@ -206,7 +208,9 @@ class HXProject extends Script
 		modules = new Map<String, ModuleData>();
 		ndlls = new Array<NDLL>();
 		postBuildCallbacks = new Array<CLICommand>();
+		postUpdateCallbacks = new Array<CLICommand>();
 		preBuildCallbacks = new Array<CLICommand>();
+		preUpdateCallbacks = new Array<CLICommand>();
 		sources = new Array<String>();
 		samplePaths = new Array<String>();
 		splashScreens = new Array<SplashScreen>();
@@ -309,7 +313,9 @@ class HXProject extends Script
 
 		project.platformType = platformType;
 		project.postBuildCallbacks = postBuildCallbacks.copy();
+		project.postUpdateCallbacks = postUpdateCallbacks.copy();
 		project.preBuildCallbacks = preBuildCallbacks.copy();
+		project.preUpdateCallbacks = preUpdateCallbacks.copy();
 		project.samplePaths = samplePaths.copy();
 		project.sources = sources.copy();
 
@@ -954,7 +960,9 @@ class HXProject extends Script
 
 			ndlls = ArrayTools.concatUnique(ndlls, project.ndlls);
 			postBuildCallbacks = postBuildCallbacks.concat(project.postBuildCallbacks);
+			postUpdateCallbacks = postUpdateCallbacks.concat(project.postUpdateCallbacks);
 			preBuildCallbacks = preBuildCallbacks.concat(project.preBuildCallbacks);
+			preUpdateCallbacks = preUpdateCallbacks.concat(project.preUpdateCallbacks);
 			samplePaths = ArrayTools.concatUnique(samplePaths, project.samplePaths, true);
 			sources = ArrayTools.concatUnique(sources, project.sources, true);
 			splashScreens = ArrayTools.concatUnique(splashScreens, project.splashScreens);

--- a/src/lime/tools/PlatformTarget.hx
+++ b/src/lime/tools/PlatformTarget.hx
@@ -102,11 +102,15 @@ class PlatformTarget
 		{
 			logCommand("update");
 
+			CommandHelper.executeCommands(project.preUpdateCallbacks);
+
 			_touchedFiles = [];
 			update();
 
 			deleteStaleFiles(_touchedFiles);
 			_touchedFiles = null;
+
+			CommandHelper.executeCommands(project.postUpdateCallbacks);
 		}
 
 		if (command == "build" || command == "test")

--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -1895,6 +1895,12 @@ class ProjectXMLParser extends HXProject
 				case "postbuild":
 					parseCommandElement(element, postBuildCallbacks);
 
+				case "preupdate":
+					parseCommandElement(element, preUpdateCallbacks);
+
+				case "postupdate":
+					parseCommandElement(element, postUpdateCallbacks);
+
 				default:
 					if (StringTools.startsWith(element.name, "config:"))
 					{


### PR DESCRIPTION
This allows users to pre-process (or even programmatically generate) their assets before Lime copies them. I've included a `<postupdate />` tag for consistency (and so people don't ask why it's left out), but the main expected use case is pre-processing.

This is a more specific alternative to #1993, which offered full control at the expense of more potential to shoot yourself in the foot. This version should behave more like people expect.