### PR TITLE
Fix deprecated syntax.

### DIFF
--- a/dependencies/extension-api/build.gradle
+++ b/dependencies/extension-api/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-	namespace 'org.haxe.extension'
+	namespace = 'org.haxe.extension'
 	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
 	buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -14,11 +14,11 @@ System.setProperty('java.awt.headless','false')
 } */
 
 android {
-	namespace "::APP_PACKAGE::"
+	namespace = "::APP_PACKAGE::"
 	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
 	buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
-	::if (ANDROID_GRADLE_PLUGIN>="4.0")::ndkPath '::ANDROID_NDK_ROOT_ESCAPED::'::end::
-	::if (ANDROID_NDK_VERSION)::ndkVersion '::ANDROID_NDK_VERSION::'::end::
+	::if (ANDROID_GRADLE_PLUGIN>="4.0")::ndkPath = '::ANDROID_NDK_ROOT_ESCAPED::'::end::
+	::if (ANDROID_NDK_VERSION)::ndkVersion = '::ANDROID_NDK_VERSION::'::end::
 
 	defaultConfig {
 		applicationId "::META_PACKAGE_NAME::"
@@ -72,7 +72,7 @@ android {
 	buildTypes {
 		release {
 			minifyEnabled false
-			signingConfig signingConfigs.release
+			signingConfig = signingConfigs.release
 		}
 	}
 


### PR DESCRIPTION
Gradle warns that these specific lines will require an equal sign starting in Gradle 10. Why these and not others, I'm not sure. Maybe these are assignments and the others are function calls?