### PR TITLE
[tools] Support wine for running windows programs

### DIFF
--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -938,6 +938,11 @@ class WindowsPlatform extends PlatformTarget
 			arguments = arguments.concat(["-livereload"]);
 			System.runCommand(applicationDirectory, Path.withoutDirectory(executablePath), arguments);
 		}
+		else
+		{
+			arguments = [Path.withoutDirectory(executablePath)].concat(arguments.concat(["-livereload"]));
+			System.runCommand(applicationDirectory, "wine", arguments);
+		}
 	}
 
 	public override function update():Void


### PR DESCRIPTION
When a windows build is cross compiled from a different host platform, it can be run via the WINE compatibility tool