### PR TITLE
Fix IOS build for hxcpp cert patch

### DIFF
--- a/templates/ios/template/{{app.file}}.xcodeproj/project.pbxproj
+++ b/templates/ios/template/{{app.file}}.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		792E75C91C6C876900D01DE0 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 792E75C81C6C876900D01DE0 /* GameController.framework */; };
 		792E75C91C6C876900D01DE1 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 792E75C81C6C876900D01DE1 /* CoreText.framework */; };
 		7C1D3D2F27403D7800CFEBE5 /* CoreHaptics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C1D3D2E27403D7800CFEBE5 /* CoreHaptics.framework */; };
+		426F5F953011039700F18766 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 126F5F943011039700F18766 /* Security.framework */; };
 		::if (IOS_LAUNCH_STORYBOARD != null)::D099CA9021A64C87003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D099CA8F21A64C86003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard */; };::end::
 		::ADDL_PBX_BUILD_FILE::
 
@@ -63,6 +64,7 @@
 		792E75C81C6C876900D01DE0 /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
 		792E75C81C6C876900D01DE1 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		7C1D3D2E27403D7800CFEBE5 /* CoreHaptics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreHaptics.framework; path = System/Library/Frameworks/CoreHaptics.framework; sourceTree = SDKROOT; };
+		126F5F943011039700F18766 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		::if (IOS_LAUNCH_STORYBOARD != null)::D099CA8F21A64C86003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "::APP_FILE::/::IOS_LAUNCH_STORYBOARD::.storyboard"; sourceTree = "<group>"; };::end::
 		::ADDL_PBX_FILE_REFERENCE::
 
@@ -80,6 +82,7 @@
 				792E75C91C6C876900D01DE0 /* GameController.framework in Frameworks */,
 				792E75C91C6C876900D01DE1 /* CoreText.framework in Frameworks */,
 				7C1D3D2F27403D7800CFEBE5 /* CoreHaptics.framework in Frameworks */,
+				426F5F953011039700F18766 /* Security.framework in Frameworks */,
 				6892FA0E263B5BC100EA2669 /* Metal.framework in Frameworks */,
 				1EEEBA9B121AF1C60048A9DF /* UIKit.framework in Frameworks */,
 				1EEEBAA3121AF2210048A9DF /* OpenAL.framework in Frameworks */,
@@ -122,6 +125,7 @@
 				792E75C81C6C876900D01DE0 /* GameController.framework */,
 				792E75C81C6C876900D01DE1 /* CoreText.framework */,
 				7C1D3D2E27403D7800CFEBE5 /* CoreHaptics.framework */,
+				126F5F943011039700F18766 /* Security.framework */,
 				1EEEBA9A121AF1C60048A9DF /* UIKit.framework */,
 				1EEEBAA2121AF2210048A9DF /* OpenAL.framework */,
 				1EEEBAA4121AF2210048A9DF /* OpenGLES.framework */,


### PR DESCRIPTION
A proposed hxcpp patch (https://github.com/HaxeFoundation/hxcpp/pull/1331) fixes certificate handling on ios, but it requires the Security framework to be linked. This adds that framework to the xcode project file to avoid linker errors with the patched hxcpp.