### PR TITLE
Add fromInt method on doc_gen

### DIFF
--- a/src/lime/graphics/opengl/GLShader.hx
+++ b/src/lime/graphics/opengl/GLShader.hx
@@ -21,7 +21,7 @@ import lime.utils.Log;
 }
 #end
 
-public static function fromSource(gl:Dynamic, source:String, type:Int):GLShader
+public static function fromSource(gl:WebGLRenderContext, source:String, type:Int):GLShader
 {
 	var shader = gl.createShader(type);
 	gl.shaderSource(shader, source);
@@ -55,13 +55,13 @@ public static function fromSource(gl:Dynamic, source:String, type:Int):GLShader
 @:forward abstract GLShader(Dynamic) from Dynamic to Dynamic
 {
 	#if !lime_webgl
-	@:from private static function fromInt(id:Int):GLShader
+	@:noDoc @:from private static function fromInt(id:Int):GLShader
 	{
 		return 0;
 	}
 	#end
 	
-	public static function fromSource(gl:WebGLRenderContext, source:String, type:Int):GLShader
+	public static function fromSource(gl:Dynamic, source:String, type:Int):GLShader
 	{
 		return null;
 	}

--- a/src/lime/graphics/opengl/GLShader.hx
+++ b/src/lime/graphics/opengl/GLShader.hx
@@ -21,7 +21,7 @@ import lime.utils.Log;
 }
 #end
 
-public static function fromSource(gl:WebGLRenderContext, source:String, type:Int):GLShader
+public static function fromSource(gl:Dynamic, source:String, type:Int):GLShader
 {
 	var shader = gl.createShader(type);
 	gl.shaderSource(shader, source);

--- a/src/lime/graphics/opengl/GLShader.hx
+++ b/src/lime/graphics/opengl/GLShader.hx
@@ -54,6 +54,11 @@ public static function fromSource(gl:WebGLRenderContext, source:String, type:Int
 #else
 @:forward abstract GLShader(Dynamic) from Dynamic to Dynamic
 {
+	@:from private static function fromInt(id:Int):GLShader
+	{
+		return 0;
+	}
+	
 	public static function fromSources(gl:Dynamic, source:String, type:Int):GLShader
 	{
 		return null;

--- a/src/lime/graphics/opengl/GLShader.hx
+++ b/src/lime/graphics/opengl/GLShader.hx
@@ -54,12 +54,14 @@ public static function fromSource(gl:WebGLRenderContext, source:String, type:Int
 #else
 @:forward abstract GLShader(Dynamic) from Dynamic to Dynamic
 {
+	#if !lime_webgl
 	@:from private static function fromInt(id:Int):GLShader
 	{
 		return 0;
 	}
+	#end
 	
-	public static function fromSources(gl:Dynamic, source:String, type:Int):GLShader
+	public static function fromSource(gl:WebGLRenderContext, source:String, type:Int):GLShader
 	{
 		return null;
 	}


### PR DESCRIPTION
Flixel-doc was getting the following error on [this line](https://github.com/openfl/lime/blob/develop/src/lime/_internal/backend/native/NativeOpenGLRenderContext.hx#L1500):
> 8,3,2/src/lime/_internal/backend/native/NativeOpenGLRenderContext.hx:1500: characters 26-33 : Abstract<lime.graphics.opengl.GLShader> has no field fromInt

I was gonna make an issue and fix later but I saw your new 12 part questionnaire to make a bug and decided I'll probably never ever want to go through that, especially for something like this that takes 2 sentences to properly convey.