### PR TITLE
Fix sdl_sound missing definitions in macro context

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -348,7 +348,7 @@ class NativeAudioSource
 
 	private function clearSDLSoundStream():Void
 	{
-		#if lime_sdl_sound
+		#if (lime_sdl_sound && !macro)
 		if (sdlSoundStream != null)
 		{
 			NativeCFFI.lime_sdl_sound_stream_clear(sdlSoundStream);
@@ -383,7 +383,7 @@ class NativeAudioSource
 
 	private function openSDLSoundStream():Bool
 	{
-		#if lime_sdl_sound
+		#if (lime_sdl_sound && !macro)
 		clearSDLSoundStream();
 
 		if (parent.buffer.__srcSDLSoundBytes != null)
@@ -441,7 +441,7 @@ class NativeAudioSource
 
 	private function resetSDLSoundStream(time:Int):Bool
 	{
-		#if lime_sdl_sound
+		#if (lime_sdl_sound && !macro)
 		if (time < 0)
 		{
 			time = 0;
@@ -721,7 +721,7 @@ class NativeAudioSource
 
 	private function readSDLSoundBuffer(length:Int):Int
 	{
-		#if lime_sdl_sound
+		#if (lime_sdl_sound && !macro)
 		if (sdlSoundStream == null || length <= 0 || streamByteRate <= 0)
 		{
 			return 0;


### PR DESCRIPTION
Without these guards, there are errors about the NativeCFFI functions not being defined:

```
.../lime/src/lime/_internal/backend/native/NativeAudioSource.hx:354: characters 15-42 : Class<lime._internal.backend.native.NativeCFFI> has no field lime_sdl_sound_stream_clear
.../lime/src/lime/_internal/backend/native/NativeAudioSource.hx:391: characters 32-64 : Class<lime._internal.backend.native.NativeCFFI> has no field lime_sdl_sound_stream_from_bytes
.../lime/src/lime/_internal/backend/native/NativeAudioSource.hx:395: characters 32-63 : Class<lime._internal.backend.native.NativeCFFI> has no field lime_sdl_sound_stream_from_file
.../lime/src/lime/_internal/backend/native/NativeAudioSource.hx:457: characters 36-64 : Class<lime._internal.backend.native.NativeCFFI> has no field lime_sdl_sound_stream_rewind
.../lime/src/lime/_internal/backend/native/NativeAudioSource.hx:467: characters 35-61 : Class<lime._internal.backend.native.NativeCFFI> has no field lime_sdl_sound_stream_seek
.../lime/src/lime/_internal/backend/native/NativeAudioSource.hx:735: characters 25-51 : Class<lime._internal.backend.native.NativeCFFI> has no field lime_sdl_sound_stream_read
.../lime/src/lime/system/Clipboard.hx:27: characters 31-54 : Unknown<0> cannot be constructed
```