### PR TITLE
Drop Haxe 3 support in Lime 9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -950,7 +950,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        haxe-version: [3.4.7, 4.0.5, 4.1.5, 4.2.5, 4.3.7]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.7]
     steps:
 
       - uses: actions/checkout@v6
@@ -984,7 +984,6 @@ jobs:
           lime build HelloWorld html5 -release -verbose -nocolor
 
       - name: Build HelloWorld variants
-        if: ${{ matrix.haxe-version != '3.4.7' }}
         run: |
           lime build HelloWorld html5 -clean -release -verbose -nocolor --haxelib=genes
           lime build HelloWorld html5 -clean -release -verbose -nocolor -minify -terser
@@ -995,7 +994,6 @@ jobs:
           lime build SimpleImage html5 -release -verbose -nocolor
 
       - name: Build SimpleImage variants
-        if: ${{ matrix.haxe-version != '3.4.7' }}
         run: |
           lime build SimpleImage html5 -clean -release -verbose -nocolor --haxelib=genes
           lime build SimpleImage html5 -clean -release -verbose -nocolor -minify -terser
@@ -1006,7 +1004,6 @@ jobs:
           lime build SimpleAudio html5 -release -verbose -nocolor
 
       - name: Build SimpleAudio variants
-        if: ${{ matrix.haxe-version != '3.4.7' }}
         run: |
           lime build SimpleAudio html5 -clean -release -verbose -nocolor --haxelib=genes
           lime build SimpleAudio html5 -clean -release -verbose -nocolor -minify -terser
@@ -1015,7 +1012,7 @@ jobs:
     needs: package-haxelib
     strategy:
       matrix:
-        haxe-version: [3.4.7, 4.2.5]
+        haxe-version: [4.2.5]
         os: [windows-latest, ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:

--- a/include.xml
+++ b/include.xml
@@ -82,16 +82,10 @@
 		<section unless="force-synchronous || force_synchronous">
 			<haxedef name="lime-threads" if="neko || cpp || html5" unless="emscripten" />
 			<!-- `target.threaded` isn't available, so enumerate the targets instead. -->
-			<haxedef name="lime-threads" if="cs || java || python || hl" unless="${${haxe_ver} < 4}" />
+			<haxedef name="lime-threads" if="cs || java || python || hl" />
 
 			<!-- For internal use; may be removed or renamed without warning. -->
 			<haxedef name="lime-threads-deque" if="neko || cpp || cs || java || python || hl" />
-		</section>
-
-		<section if="cpp ${${haxe_ver} < 3.3}" unless="static_link">
-			<ndll name="std" haxelib="hxcpp" />
-			<ndll name="regexp" haxelib="hxcpp" />
-			<ndll name="zlib" haxelib="hxcpp" unless="emscripten || ios || tvos" />
 		</section>
 
 		<ndll name="lime" if="native" unless="lime-console static_link || lime-switch static_link" />

--- a/src/haxe/Timer.hx
+++ b/src/haxe/Timer.hx
@@ -45,7 +45,7 @@ class Timer
 	#elseif java
 	private var timer:java.util.Timer;
 	private var task:java.util.TimerTask;
-	#elseif (haxe_ver >= "3.4.0")
+	#else
 	private var event:MainLoop.MainEvent;
 	#end
 
@@ -74,7 +74,7 @@ class Timer
 		#elseif java
 		timer = new java.util.Timer();
 		timer.scheduleAtFixedRate(task = new TimerTask(this), haxe.Int64.ofInt(time_ms), haxe.Int64.ofInt(time_ms));
-		#elseif (haxe_ver >= "3.4.0")
+		#else
 		var dt = time_ms / 1000;
 		event = MainLoop.add(function()
 		{
@@ -110,7 +110,7 @@ class Timer
 			timer = null;
 		}
 		task = null;
-		#elseif (haxe_ver >= "3.4.0")
+		#else
 		if (event != null)
 		{
 			event.stop();

--- a/src/lime/_internal/backend/html5/HTML5AudioInput.hx
+++ b/src/lime/_internal/backend/html5/HTML5AudioInput.hx
@@ -313,11 +313,11 @@ class HTML5AudioInput
 
 		try
 		{
-			return untyped #if haxe4 js.Syntax.code #else __js__ #end ("new audioContextClass({ sampleRate: {0} })", parent.sampleRate);
+			return js.Syntax.code("new audioContextClass({ sampleRate: {0} })", parent.sampleRate);
 		}
 		catch (e:Dynamic)
 		{
-			return untyped #if haxe4 js.Syntax.code #else __js__ #end ("new audioContextClass()");
+			return js.Syntax.code("new audioContextClass()");
 		}
 	}
 

--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -46,7 +46,7 @@ typedef CFFIPointer = Dynamic;
 @:noDebug
 #end
 #if (!macro && !lime_doc_gen)
-#if (disable_cffi || haxe_ver < "3.4.0")
+#if disable_cffi
 @:build(lime.system.CFFI.build())
 #end
 #end
@@ -54,7 +54,7 @@ class NativeCFFI
 {
 	#if (lime_cffi && !macro)
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_application_create():Dynamic;
 
 	@:cffi private static function lime_application_event_manager_register(callback:Dynamic, eventObject:Dynamic):Void;
@@ -2810,7 +2810,7 @@ class NativeCFFI
 	#end
 	#if (lime_cffi && !macro && android)
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_jni_call_member(jniMethod:Dynamic, jniObject:Dynamic, args:Dynamic):Dynamic;
 
 	@:cffi private static function lime_jni_call_static(jniMethod:Dynamic, args:Dynamic):Dynamic;
@@ -2875,7 +2875,7 @@ class NativeCFFI
 	#end
 	#if (lime_cffi && !macro && lime_openal)
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_al_buffer_data(buffer:CFFIPointer, format:Int, data:Dynamic, size:Int, freq:Int):Void;
 
 	@:cffi private static function lime_al_buffer3f(buffer:CFFIPointer, param:Int, value1:Float32, value2:Float32, value3:Float32):Void;
@@ -3805,7 +3805,7 @@ class NativeCFFI
 	#end
 	#if (lime_cffi && !macro && lime_cairo)
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_cairo_arc(handle:CFFIPointer, xc:Float, yc:Float, radius:Float, angle1:Float, angle2:Float):Void;
 
 	@:cffi private static function lime_cairo_arc_negative(handle:CFFIPointer, xc:Float, yc:Float, radius:Float, angle1:Float, angle2:Float):Void;
@@ -4757,7 +4757,7 @@ class NativeCFFI
 	#end
 	#if (lime_cffi && !macro && lime_curl)
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_curl_getdate(date:String, now:Float):Float;
 
 	@:cffi private static function lime_curl_global_cleanup():Void;
@@ -5014,7 +5014,7 @@ class NativeCFFI
 	#end
 	#if (lime_cffi && !macro && (lime_opengl || lime_opengles))
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_gl_active_texture(texture:Int):Void;
 
 	@:cffi private static function lime_gl_attach_shader(program:Int, shader:Int):Void;
@@ -7093,7 +7093,7 @@ class NativeCFFI
 	#end
 	#if (lime_cffi && !macro && lime_harfbuzz)
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_hb_blob_create(data:DataPointer, length:Int, memoryMode:Int):CFFIPointer;
 
 	@:cffi private static function lime_hb_blob_create_sub_blob(parent:CFFIPointer, offset:Int, length:Int):CFFIPointer;
@@ -8067,7 +8067,7 @@ class NativeCFFI
 	#end
 	#if (lime_cffi && !macro && lime_vorbis)
 	#if (cpp && !cppia)
-	#if (disable_cffi || haxe_ver < "3.4.0")
+	#if disable_cffi
 	@:cffi private static function lime_vorbis_file_bitrate(vorbisFile:Dynamic, bitstream:Int):Int;
 
 	@:cffi private static function lime_vorbis_file_bitrate_instant(vorbisFile:Dynamic):Int;

--- a/src/lime/app/BusyWaitMode.hx
+++ b/src/lime/app/BusyWaitMode.hx
@@ -3,7 +3,7 @@ package lime.app;
 /**
 	Controls whether Lime may busy-wait near frame deadlines.
 **/
-#if (haxe_ver >= 4.0) enum #else @:enum #end abstract BusyWaitMode(String) to String
+enum abstract BusyWaitMode(String) to String
 {
 	/** Use Lime's default busy-wait behavior for the active profile. **/
 	var Auto = "auto";

--- a/src/lime/app/FrameProfile.hx
+++ b/src/lime/app/FrameProfile.hx
@@ -3,7 +3,7 @@ package lime.app;
 /**
 	Built-in frame pacing profiles for Lime applications.
 **/
-#if (haxe_ver >= 4.0) enum #else @:enum #end abstract FrameProfile(String) to String
+enum abstract FrameProfile(String) to String
 {
 	/** A balanced default profile that preserves Lime's existing pacing behavior. **/
 	var Balanced = "balanced";

--- a/src/lime/app/TimePrecision.hx
+++ b/src/lime/app/TimePrecision.hx
@@ -3,7 +3,7 @@ package lime.app;
 /**
 	Selects the timer precision used for frame pacing.
 **/
-#if (haxe_ver >= 4.0) enum #else @:enum #end abstract TimePrecision(String) to String
+enum abstract TimePrecision(String) to String
 {
 	/** Use Lime's default precision for the active profile and platform. **/
 	var Auto = "auto";

--- a/src/lime/app/UncapMode.hx
+++ b/src/lime/app/UncapMode.hx
@@ -3,7 +3,7 @@ package lime.app;
 /**
 	Controls how aggressively Lime uncaps the frame loop.
 **/
-#if (haxe_ver >= 4.0) enum #else @:enum #end abstract UncapMode(String) to String
+enum abstract UncapMode(String) to String
 {
 	/** Keep normal frame-rate limiting behavior enabled. **/
 	var Off = "off";

--- a/src/lime/app/VSyncMode.hx
+++ b/src/lime/app/VSyncMode.hx
@@ -3,7 +3,7 @@ package lime.app;
 /**
 	Selects the requested vertical-sync behavior for rendering.
 **/
-#if (haxe_ver >= 4.0) enum #else @:enum #end abstract VSyncMode(String) from String to String
+enum abstract VSyncMode(String) from String to String
 {
 	/** Disable vertical sync. **/
 	var Off = "off";

--- a/src/lime/graphics/cairo/Cairo.hx
+++ b/src/lime/graphics/cairo/Cairo.hx
@@ -32,9 +32,6 @@ class Cairo
 	public var lineWidth(get, set):Float;
 	public var matrix(get, set):Matrix3;
 	public var miterLimit(get, set):Float;
-	#if (haxe_ver < "4.0.0")
-	public var operator(get, set):CairoOperator;
-	#end
 	public var source(get, set):CairoPattern;
 	public var target(get, null):CairoSurface;
 	public var tolerance(get, set):Float;
@@ -684,26 +681,6 @@ class Cairo
 
 		return value;
 	}
-
-	#if (haxe_ver < "4.0.0")
-	@:noCompletion private function get_operator():CairoOperator
-	{
-		#if (lime_cffi && lime_cairo && !macro)
-		return NativeCFFI.lime_cairo_get_operator(handle);
-		#end
-
-		return cast 0;
-	}
-
-	@:noCompletion private function set_operator(value:CairoOperator):CairoOperator
-	{
-		#if (lime_cffi && lime_cairo && !macro)
-		NativeCFFI.lime_cairo_set_operator(handle, value);
-		#end
-
-		return value;
-	}
-	#end
 
 	@:noCompletion private function get_source():CairoPattern
 	{

--- a/src/lime/system/CFFI.hx
+++ b/src/lime/system/CFFI.hx
@@ -247,12 +247,7 @@ class CFFI
 	private static function __loaderTrace(message:String)
 	{
 		#if (sys && !html5)
-		// #if (haxe_ver < 3.4)
-		// var get_env = cpp.Lib.load ("std", "get_env", 1);
-		// var debug = (get_env ("OPENFL_LOAD_DEBUG") != null);
-		// #else
 		var debug = (Sys.getEnv("OPENFL_LOAD_DEBUG") != null);
-		// #end
 
 		if (debug)
 		{

--- a/src/lime/system/ThreadPool.hx
+++ b/src/lime/system/ThreadPool.hx
@@ -70,7 +70,7 @@ import haxe.Exception;
 #end
 class ThreadPool extends WorkOutput
 {
-	#if (haxe4 && lime_threads && !html5)
+	#if (lime_threads && !html5)
 	/**
 		A reference to the app's main thread, for use in `isMainThread()`.
 	**/
@@ -104,7 +104,7 @@ class ThreadPool extends WorkOutput
 	{
 		#if (html5 && lime_threads)
 		return !Thread.current().isWorker();
-		#elseif (haxe4 && lime_threads)
+		#elseif lime_threads
 		return Thread.current() == __mainThread;
 		#else
 		return true;
@@ -1119,11 +1119,7 @@ private class JobArray
 
 	public inline function clear():Void
 	{
-		#if haxe4
 		jobs.resize(0);
-		#else
-		jobs.splice(0, jobs.length);
-		#end
 		startIndex = 0;
 	}
 

--- a/src/lime/system/WorkOutput.hx
+++ b/src/lime/system/WorkOutput.hx
@@ -336,7 +336,7 @@ class JobData
 	}
 }
 
-#if haxe4 enum #else @:enum #end abstract ThreadEventType(String)
+enum abstract ThreadEventType(String)
 {
 	// Events sent from a worker to the main thread, in any mode
 	var COMPLETE = "COMPLETE";

--- a/src/lime/tools/ConfigData.hx
+++ b/src/lime/tools/ConfigData.hx
@@ -1,11 +1,7 @@
 package lime.tools;
 
 import hxp.*;
-#if (haxe_ver >= 4)
 import haxe.xml.Access;
-#else
-import haxe.xml.Fast as Access;
-#end
 
 abstract ConfigData(Dynamic) to Dynamic from Dynamic
 {

--- a/src/lime/tools/HTML5Helper.hx
+++ b/src/lime/tools/HTML5Helper.hx
@@ -15,27 +15,6 @@ import cpp.vm.Thread;
 
 class HTML5Helper
 {
-	public static function encodeSourceMappingURL(sourceFile:String)
-	{
-		// This is only required for projects with url-unsafe characters built with a Haxe version prior to 4.0.0
-
-		var filename = Path.withoutDirectory(sourceFile);
-
-		if (filename != StringTools.urlEncode(filename))
-		{
-			var output = System.runProcess("", "haxe", ["-version"], true, true, true, false, true);
-			var haxeVer:Version = StringTools.trim(output);
-
-			if (haxeVer < ("4.0.0":Version))
-			{
-				var replaceString = "//# sourceMappingURL=" + filename + ".map";
-				var replacement = "//# sourceMappingURL=" + StringTools.urlEncode(filename) + ".map";
-
-				System.replaceText(sourceFile, replaceString, replacement);
-			}
-		}
-	}
-
 	// public static function generateFontData (project:HXProject, font:Asset):String {
 	// 	var sourcePath = font.sourcePath;
 	// 	if (!FileSystem.exists (FileSystem.fullPath (sourcePath) + ".hash")) {

--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -11,11 +11,7 @@ import lime.tools.Platform;
 import sys.FileSystem;
 import sys.io.File;
 import sys.io.Process;
-#if (haxe_ver >= 4)
 import haxe.xml.Access;
-#else
-import haxe.xml.Fast as Access;
-#end
 #if (lime && lime_cffi && !macro)
 import lime.text.Font;
 

--- a/src/lime/tools/ProjectXMLParser.hx
+++ b/src/lime/tools/ProjectXMLParser.hx
@@ -12,11 +12,7 @@ import lime.utils.AssetManifest;
 #end
 import sys.io.File;
 import sys.FileSystem;
-#if (haxe_ver >= 4)
 import haxe.xml.Access;
-#else
-import haxe.xml.Fast as Access;
-#end
 
 class ProjectXMLParser extends HXProject
 {

--- a/src/lime/utils/ArrayBufferView.hx
+++ b/src/lime/utils/ArrayBufferView.hx
@@ -1,7 +1,7 @@
 package lime.utils;
 
 #if (js && !doc_gen)
-typedef ArrayBufferView = #if haxe4 js.lib.ArrayBufferView #else js.html.ArrayBufferView #end;
+typedef ArrayBufferView = js.lib.ArrayBufferView;
 #else
 import lime.system.System;
 import lime.system.Endian;
@@ -482,8 +482,8 @@ class ArrayBufferView
 	RangeError;
 }
 
-@:noCompletion @:dox(hide) #if (haxe_ver >= 4.0) enum #else @:enum #end
-abstract TypedArrayType(Int) from Int to Int
+@:noCompletion @:dox(hide)
+enum abstract TypedArrayType(Int) from Int to Int
 {
 	var None = 0;
 	var Int8 = 1;

--- a/src/lime/utils/DataPointer.hx
+++ b/src/lime/utils/DataPointer.hx
@@ -41,18 +41,6 @@ abstract DataPointer(DataPointerType) to DataPointerType
 	#end
 
 	#if (cpp && !cppia && !doc_gen)
-	#if (haxe_ver < 4)
-	@:from @:noCompletion public static inline function fromCharPointer(pointer:Pointer<Char>):DataPointer
-	{
-		return untyped __cpp__('(uintptr_t){0}', pointer.ptr);
-	}
-
-	@:from @:noCompletion public static inline function fromUint8Pointer(pointer:Pointer<UInt8>):DataPointer
-	{
-		return untyped __cpp__('(uintptr_t){0}', pointer.ptr);
-	}
-	#end
-
 	@:generic @:from @:noCompletion public static inline function fromPointer<T>(pointer:Pointer<T>):DataPointer
 	{
 		return untyped __cpp__('(uintptr_t){0}', pointer.ptr);

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -173,7 +173,7 @@ import ::APP_MAIN::;
 			};
 
 		var loader = new neko.vm.Loader(untyped $loader);
-		loader.addPath(haxe.io.Path.directory(#if (haxe_ver >= 3.3) sys_program_path #else Sys.executablePath() #end));
+		loader.addPath(haxe.io.Path.directory(sys_program_path));
 		loader.addPath("./");
 		loader.addPath("@executable_path/");
 		#end

--- a/tests/unit/src/utils/UInt32ArrayTest.hx
+++ b/tests/unit/src/utils/UInt32ArrayTest.hx
@@ -36,10 +36,10 @@ class UInt32ArrayTest extends Test
 		array[2] = 0xffffffff;
 		array[3] = 0xdeadbeef;
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), array[0]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), array[1]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), array[2]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), array[3]);
+		Assert.equals(js.Syntax.code('0xcafebabe'), array[0]);
+		Assert.equals(js.Syntax.code('0xdecafbad'), array[1]);
+		Assert.equals(js.Syntax.code('0xffffffff'), array[2]);
+		Assert.equals(js.Syntax.code('0xdeadbeef'), array[3]);
 		#else
 		Assert.equals(0xcafebabe, array[0]);
 		Assert.equals(0xdecafbad, array[1]);
@@ -61,10 +61,10 @@ class UInt32ArrayTest extends Test
 		Assert.equals(4, four.length);
 		Assert.equals(16, four.byteLength);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), array[0]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), array[1]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), array[2]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), array[3]);
+		Assert.equals(js.Syntax.code'0xcafebabe'), array[0]);
+		Assert.equals(js.Syntax.code'0xdecafbad'), array[1]);
+		Assert.equals(js.Syntax.code'0xffffffff'), array[2]);
+		Assert.equals(js.Syntax.code'0xdeadbeef'), array[3]);
 		#else
 		Assert.equals(0xcafebabe, four[0]);
 		Assert.equals(0xdecafbad, four[1]);
@@ -76,8 +76,8 @@ class UInt32ArrayTest extends Test
 		Assert.equals(2, twoStart.length);
 		Assert.equals(8, twoStart.byteLength);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), twoStart[0]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), twoStart[1]);
+		Assert.equals(js.Syntax.code'0xcafebabe'), twoStart[0]);
+		Assert.equals(js.Syntax.code'0xdecafbad'), twoStart[1]);
 		#else
 		Assert.equals(0xcafebabe, twoStart[0]);
 		Assert.equals(0xdecafbad, twoStart[1]);
@@ -87,8 +87,8 @@ class UInt32ArrayTest extends Test
 		Assert.equals(2, twoEnd.length);
 		Assert.equals(8, twoEnd.byteLength);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), twoEnd[0]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), twoEnd[1]);
+		Assert.equals(js.Syntax.code'0xffffffff'), twoEnd[0]);
+		Assert.equals(js.Syntax.code'0xdeadbeef'), twoEnd[1]);
 		#else
 		Assert.equals(0xffffffff, twoEnd[0]);
 		Assert.equals(0xdeadbeef, twoEnd[1]);
@@ -106,10 +106,10 @@ class UInt32ArrayTest extends Test
 		Assert.equals(4, beyondLength.length);
 		Assert.equals(16, beyondLength.byteLength);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), array[0]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), array[1]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), array[2]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), array[3]);
+		Assert.equals(js.Syntax.code'0xcafebabe'), array[0]);
+		Assert.equals(js.Syntax.code'0xdecafbad'), array[1]);
+		Assert.equals(js.Syntax.code'0xffffffff'), array[2]);
+		Assert.equals(js.Syntax.code'0xdeadbeef'), array[3]);
 		#else
 		Assert.equals(0xcafebabe, beyondLength[0]);
 		Assert.equals(0xdecafbad, beyondLength[1]);
@@ -127,10 +127,10 @@ class UInt32ArrayTest extends Test
 
 		array2.set(array1);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), array2[0]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), array2[1]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), array2[2]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), array2[3]);
+		Assert.equals(js.Syntax.code'0xcafebabe'), array2[0]);
+		Assert.equals(js.Syntax.code'0xdecafbad'), array2[1]);
+		Assert.equals(js.Syntax.code'0xffffffff'), array2[2]);
+		Assert.equals(js.Syntax.code'0xdeadbeef'), array2[3]);
 		#else
 		Assert.equals(0xcafebabe, array2[0]);
 		Assert.equals(0xdecafbad, array2[1]);
@@ -150,10 +150,10 @@ class UInt32ArrayTest extends Test
 		array2.set(array1, 1);
 		Assert.equals(0x0, array2[0]);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), array2[1]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), array2[2]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), array2[3]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), array2[4]);
+		Assert.equals(js.Syntax.code'0xcafebabe'), array2[1]);
+		Assert.equals(js.Syntax.code'0xdecafbad'), array2[2]);
+		Assert.equals(js.Syntax.code'0xffffffff'), array2[3]);
+		Assert.equals(js.Syntax.code'0xdeadbeef'), array2[4]);
 		#else
 		Assert.equals(0xcafebabe, array2[1]);
 		Assert.equals(0xdecafbad, array2[2]);
@@ -334,10 +334,10 @@ class UInt32ArrayTest extends Test
 
 		array2.set(array1);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), array2[0]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), array2[1]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), array2[2]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), array2[3]);
+		Assert.equals(js.Syntax.code'0xcafebabe'), array2[0]);
+		Assert.equals(js.Syntax.code'0xdecafbad'), array2[1]);
+		Assert.equals(js.Syntax.code'0xffffffff'), array2[2]);
+		Assert.equals(js.Syntax.code'0xdeadbeef'), array2[3]);
 		#else
 		Assert.equals(0xcafebabe, array2[0]);
 		Assert.equals(0xdecafbad, array2[1]);
@@ -358,10 +358,10 @@ class UInt32ArrayTest extends Test
 		array2.set(array1, 1);
 		Assert.equals(0x0, array2[0]);
 		#if js
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xcafebabe'), array2[1]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdecafbad'), array2[2]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xffffffff'), array2[3]);
-		Assert.equals(untyped #if haxe4 js.Syntax.code #else __js__ #end ('0xdeadbeef'), array2[4]);
+		Assert.equals(js.Syntax.code'0xcafebabe'), array2[1]);
+		Assert.equals(js.Syntax.code'0xdecafbad'), array2[2]);
+		Assert.equals(js.Syntax.code'0xffffffff'), array2[3]);
+		Assert.equals(js.Syntax.code'0xdeadbeef'), array2[4]);
 		#else
 		Assert.equals(0xcafebabe, array2[1]);
 		Assert.equals(0xdecafbad, array2[2]);

--- a/tools/SVGExport.hx
+++ b/tools/SVGExport.hx
@@ -14,7 +14,7 @@ import sys.FileSystem;
 
 class SVGExport
 {
-	#if (neko && (haxe_210 || haxe3))
+	#if neko
 	public static function __init__()
 	{
 		var haxePath = Sys.getEnv("HAXEPATH");

--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -136,8 +136,6 @@ class HTML5Platform extends PlatformTarget
 
 			if (noOutput) return;
 
-			HTML5Helper.encodeSourceMappingURL(targetDirectory + "/bin/" + project.app.file + ".js");
-
 			if (project.targetFlags.exists("webgl"))
 			{
 				System.copyFile(targetDirectory + "/obj/ApplicationMain.js", outputFile);

--- a/tools/platforms/WebAssemblyPlatform.hx
+++ b/tools/platforms/WebAssemblyPlatform.hx
@@ -163,21 +163,7 @@ class WebAssemblyPlatform extends PlatformTarget
 			args.push(path);
 		}
 
-		var json = Json.parse(File.getContent(Haxelib.getPath(new Haxelib("hxcpp"), true) + "/haxelib.json"));
-		var prefix = "";
-
-		var version = Std.string(json.version);
-		var versionSplit = version.split(".");
-
-		while (versionSplit.length > 2)
-			versionSplit.pop();
-
-		if (Std.parseFloat(versionSplit.join(".")) > 3.1)
-		{
-			prefix = "lib";
-		}
-
-		args = args.concat([prefix + "ApplicationMain" + (project.debug ? "-debug" : "") + ".a"]);
+		args = args.concat(["libApplicationMain" + (project.debug ? "-debug" : "") + ".a"]);
 
 		if (!project.targetFlags.exists("asmjs"))
 		{


### PR DESCRIPTION
The last haxe 3 release was now over 8 years ago, and haxe is moving towards a haxe 5 release. Lime 9 will be a major release, and therefore a good opportunity to finally drop support for haxe 3.