### PR TITLE
Android Gradle 9 support

### DIFF
--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -13,6 +13,10 @@ System.setProperty('java.awt.headless','false')
 	options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 } */
 
+::if (ANDROID_GRADLE_PLUGIN>="9.0")::base {
+	archivesName = "::APP_FILE::"
+}::end::
+
 android {
 	namespace "::APP_PACKAGE::"
 	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
@@ -26,6 +30,7 @@ android {
 		targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
 		versionCode Integer.parseInt(project.VERSION_CODE)
 		versionName project.VERSION_NAME
+		::if (ANDROID_GRADLE_PLUGIN<"9.0")::setProperty("archivesBaseName", "::APP_FILE::")::end::
 		::if (languages != null)::resConfigs ::foreach languages::"::__current__::", ::end::""::end::
 	}
 
@@ -76,13 +81,6 @@ android {
 		}
 	}
 
-	android.applicationVariants.all { variant ->
-		variant.outputs.all { output ->
-			if (outputFileName != null && outputFileName.endsWith('.apk')) {
-				outputFileName =  "::APP_FILE::-" + variant.buildType.name + ".apk"
-			}
-		}
-	}
 }
 
 dependencies {

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
+		::if (ANDROID_GRADLE_PLUGIN>="9.0")::classpath 'org.apache.groovy:groovy-swing:+'::end::
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/templates/android/template/local.properties
+++ b/templates/android/template/local.properties
@@ -7,5 +7,3 @@ sdk.dir=::ANDROID_SDK_ESCAPED::
 ::if (ANDROID_GRADLE_PLUGIN<"4.0")::
 ndk.dir=::ANDROID_NDK_ROOT_ESCAPED::
 ::end::
-
-org.gradle.jvmargs=-Xmx2048m

--- a/templates/android/template/local.properties
+++ b/templates/android/template/local.properties
@@ -7,3 +7,5 @@ sdk.dir=::ANDROID_SDK_ESCAPED::
 ::if (ANDROID_GRADLE_PLUGIN<"4.0")::
 ndk.dir=::ANDROID_NDK_ROOT_ESCAPED::
 ::end::
+
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
This PR allows using Gradle version 9+ and changes the way the .apk and .aab files are renamed during the build.

**Details:**

- `classpath 'org.apache.groovy:groovy-swing:+'` added to top-level `build.gradle` because it's not included by default in Gradle 9+
- for the builds that use Gradle versions lower than 9 the renaming code is replaced with `setProperty("archivesBaseName", "::APP_FILE::")` that also enables renaming .aab in addition to .apk in the app-level `build.gradle`
- for the builds that use Gradle 9+ the renaming is done with the following code in the app-level `build.gradle`
```
base {
	archivesName = "::APP_FILE::"
}
```

**Warning!**
- When I switched to Gradle 9+, I had to increase Java heap size with `org.gradle.jvmargs=-Xmx2048m` in `gradle.properties`, otherwise the build started to crash with "Out of memory" exception. The reason can be in the Appodeal SDK though that includes dozens of packages.
- Additionally I had to rebuild Lime / Android, before that the apps crashed on startup, but most probably it's because I'm using the dev branch and didn't rebuild it for quite some time...